### PR TITLE
docs(cutedsl/sm100): add SM100 CuTeDSL usage guide for Blackwell

### DIFF
--- a/gpu-wiki/docs/kernel-opt/nvidia/common/blackwell/hardware/2sm-cooperative.md
+++ b/gpu-wiki/docs/kernel-opt/nvidia/common/blackwell/hardware/2sm-cooperative.md
@@ -30,16 +30,29 @@ tcgen05.mma.cta_group::2.kind::f16
 3. Both CTAs in the same cluster
 4. Each CTA contributes half the M-dimension
 
-## Performance Impact
+## Advantages
 
-From tcgen05 tutorial progression:
-- 1-SM MMA (m128×n256): 80% of cuBLAS → adding 2-SM: **86%** of cuBLAS
-- ~7.5% improvement from doubling the MMA tile size
+- **Doubles the effective MMA tile** — M up to 256 (`m256×n256×k16`) per instruction; a single-SM MMA caps at M=128 and reaches only ~50% of tensor-core peak, so 2-SM is the way to approach 100%.
+- **Splits the accumulator across two SMs' TMEM** — each CTA holds half (e.g. 128×N), so a tile whose accumulator would not fit one SM's 512 TMEM columns can still run. This is the main reason to go 2-SM for large head-dim / large-N tiles.
+- **Halves per-CTA operand SMEM traffic** — with cluster TMA multicast each CTA loads only its half of A/B, cutting redundant DRAM→SMEM movement.
 
-## When to Use
-- Large GEMM problems where M ≥ 256
-- Compute-bound kernels where peak FLOPS matters
-- Combined with persistent scheduling for maximum throughput
+## Overheads / Costs
+
+2-SM is **not free**; weigh these against the advantages:
+
+- **Cross-CTA synchronization tax** — a `shared::cluster` mbarrier / cluster membar plus the leader↔peer handshake is on the critical path every tile. For kernels that are *not* capacity- or throughput-bound, this sync can cost more than the 2-SM speedup (it has been measured at tens of percent of runtime in sync-heavy attention kernels).
+- **Mapping constraint** — the pair must be one cluster of 2 mapped to the same TPC (`cluster=(2,1)`); reduces scheduler freedom and can worsen wave quantization for small grids.
+- **Leader/peer coordination** — only the even (leader) CTA issues the MMA; TMEM alloc/**dealloc must be symmetric across the pair** (asymmetric ordering can deadlock), and peer-mbarrier addressing must be correct (handled by CUTLASS/CuTeDSL helpers — don't hand-roll).
+- **All-or-nothing per kernel** — every tcgen05 op in the kernel must use the same `cta_group`; you cannot mix 1-SM and 2-SM.
+
+## When to Use — decide by *net* cost
+
+Use 2-SM when the **capacity or throughput need outweighs the sync tax**:
+
+- Large compute-bound GEMM (M ≥ 256) where peak FLOPS matters, combined with persistent scheduling.
+- Tiles whose accumulator genuinely needs both SMs' TMEM to fit.
+
+Prefer **1-SM** when the tile already fits one SM's TMEM and the kernel is sync- or latency-bound (e.g. an attention tile whose S+O accumulators fit 512 columns at single-stage — see [tmem.md](tmem.md) budget): there the cluster sync tax can dominate and 1-SM is faster. Profile both; choose by measured net cost, not by "tile is large ⇒ 2-SM".
 
 ## Related
 - [tcgen05-mma](tcgen05-mma.md) -- Base MMA instruction

--- a/gpu-wiki/docs/kernel-opt/nvidia/common/blackwell/hardware/tmem.md
+++ b/gpu-wiki/docs/kernel-opt/nvidia/common/blackwell/hardware/tmem.md
@@ -256,6 +256,29 @@ With 512 total columns per SM:
 
 For double-buffered 128x256 tiles, the full 512 columns are consumed. If additional scratch TMEM is needed (e.g., for softmax in attention kernels), reduce the tile size or use a single accumulator buffer.
 
+### When can you pipeline-overlap? (columns / bytes / head-dim threshold)
+
+Pipeline overlap of MMA with the epilogue (or of consecutive MMAs) relies on having a **second accumulator buffer** so one can be filled while the other is drained. That requires both buffers to coexist in the 512-column TMEM:
+
+> **Double-buffer fits ⇔ 2 × (accumulator columns) ≤ 512 ⇔ accumulator ≤ 256 columns.**
+
+Column ↔ byte conversion (per SM): each TMEM column spans 128 lanes × 4 B = **512 B/column**, so 512 columns = 256 KB.
+
+| Per-accumulator footprint | Columns | Bytes | Can double-buffer (overlap)? |
+|---|---|---|---|
+| ≤ 128 cols | ≤ 128 | ≤ 64 KB | Yes — up to 4 buffers, room for scratch |
+| ≤ 256 cols | ≤ 256 | ≤ 128 KB | Yes — exactly 2 buffers, no scratch left |
+| > 256 cols | > 256 | > 128 KB | **No** — only one fits; overlap must come from 2-SM (split the accumulator across the pair) or a smaller tile |
+
+For a GEMM tile M×N the accumulator occupies **N columns** (M maps to the 128 lanes), so overlap is feasible when **N ≤ 256**.
+
+For attention, the accumulators are sized by **head-dim and KV-tile**: the O accumulator is **head-dim columns** and the S accumulator is **kv-tile columns**. Practical consequences:
+
+- **head-dim ≤ 128:** O (≤128 cols) leaves ample room to double-buffer O and still hold S + softmax scratch.
+- **head-dim = 256:** a single O accumulator already uses 256 cols (= half of TMEM). With an S accumulator alongside it (e.g. 128 cols → S+O = 384 ≤ 512 fits **single-buffered**), there is **no room to also double-buffer O on one SM** — so large head-dim trades away overlap headroom. Options: keep single-stage (`q_stage=1`) on 1 SM, or go 2-SM to split O across the pair's TMEM (then weigh the cluster sync tax — see [2sm-cooperative.md](2sm-cooperative.md)).
+
+Rule of thumb: **overlap is "free" on TMEM up to ~256 accumulator columns (~128 KB); beyond that you must either shrink the tile or use 2-SM.**
+
 ## Microbenchmark Data
 
 From published Blackwell microbenchmarks:

--- a/gpu-wiki/docs/kernel-opt/nvidia/common/blackwell/techniques/software-exp.md
+++ b/gpu-wiki/docs/kernel-opt/nvidia/common/blackwell/techniques/software-exp.md
@@ -196,8 +196,18 @@ For applications requiring higher accuracy, a degree-6 polynomial (6 FMAs) achie
 - **Any kernel limited by transcendental function throughput**: If profiling shows SFU utilization near 100% while FMA utilization is low, software emulation can rebalance the workload.
 - **Not recommended on Hopper**: The SFU-to-MMA throughput ratio is better balanced on SM90. The overhead of 4 FMAs vs 1 SFU instruction is not justified unless the SFU is proven to be the bottleneck.
 
+## B200 vs B300 (Blackwell Ultra) — the key practical difference
+
+Software exp2 is a **B200-targeted mitigation, not a universal Blackwell win**. The bottleneck it addresses is arch-specific:
+
+- **B200 (sm_100):** tensor-core throughput roughly doubled vs Hopper while the SFU/`ex2` path did not, so for softmax-heavy attention the SFU is the bottleneck — software exp2 (exp on FMA units) is a clear win.
+- **B300 / Blackwell Ultra (sm_103):** NVIDIA advertises **~2× attention-layer acceleration** vs B200 — the special-function / softmax path is strengthened, so hardware `MUFU.EX2` is much closer to keeping up with the tensor cores. On B300 the SFU exp bottleneck that motivates software exp2 is largely relieved: hardware `ex2.approx` is often adequate, and the extra FMA work of the software path can be **net-negative**. In practice, on B300 it is frequently faster to *disable* the software-exp emulation and use hardware `MUFU.EX2`.
+
+**Rule of thumb:** treat software exp2 as conditional on "is the SFU the proven softmax bottleneck on *this* arch?" — usually yes on B200, often no on B300. Profile `MUFU`/SFU utilization vs FMA utilization on the target part before enabling it, and keep it behind a flag so it can be turned off per architecture.
+
 ## Caveats
 
 - The 4-FMA chain has a latency of ~16 cycles (4 dependent FMAs at ~4 cycles each), vs ~20 cycles for SFU `ex2.approx`. Latency is comparable; the win comes from throughput (128 FMA units vs 16 SFU units).
+- **Arch-conditional (see above):** on B300/sm_103 the hardware exp path is faster relative to the tensor cores than on B200, so the software path is often unnecessary or slower. Do not enable it unconditionally for "Blackwell".
 - Polynomial coefficients are for 2^x on [-0.5, 0.5]. For e^x, multiply the input by log2(e) first.
 - The `ldexpf` or exponent bit-manipulation step for 2^n must handle overflow/underflow (very large/small x). In attention, `x <= 0` always holds, so only underflow toward zero is possible.

--- a/gpu-wiki/docs/ref-docs/nvidia/cutedsl/sm100/README.md
+++ b/gpu-wiki/docs/ref-docs/nvidia/cutedsl/sm100/README.md
@@ -19,3 +19,4 @@ Reference articles on CuTeDSL-specific features on the Blackwell architecture (i
 | [colfax-blackwell-gemm-part3-85-percent-sota.md](colfax-blackwell-gemm-part3-85-percent-sota.md) | Blackwell Matrix Multiplication Part 3: Achieving 85% SOTA |
 | [colfax-blackwell-gemm-part4-beyond-sota.md](colfax-blackwell-gemm-part4-beyond-sota.md) | Blackwell Matrix Multiplication Part 4: Beyond SOTA |
 | [mxfp8-b200-high-performance-memory-bound-kernel.md](mxfp8-b200-high-performance-memory-bound-kernel.md) | High-Performance Memory-Bound Kernels on B200: An MXFP8 Quantization Case Study |
+| [cutedsl-sm100-helper-api.md](cutedsl-sm100-helper-api.md) | Usage guide for the SM100 CuTeDSL surface: capability→helper map, how to use each feature well (MMA / TMEM / CTA-pair / TMA / block scaling / pipelines), autotuning, debugging knobs, pitfalls |

--- a/gpu-wiki/docs/ref-docs/nvidia/cutedsl/sm100/cutedsl-sm100-helper-api.md
+++ b/gpu-wiki/docs/ref-docs/nvidia/cutedsl/sm100/cutedsl-sm100-helper-api.md
@@ -1,0 +1,136 @@
+# Using the SM100 Blackwell CuTeDSL Helper Layer
+
+An index + usage guide for the **high-level `cutlass.utils.sm100` / `blackwell_helpers` helper layer** on Blackwell (SM100/SM103): which helper exposes each hardware capability, the call signature, and the rules for using it correctly. Applies to GEMM, attention, MoE, and other tensor-core kernels.
+
+This doc deliberately stays at the helper-API level and defers mechanism/worked examples to the docs it links:
+
+- Generic CuTeDSL model (`@cute.jit`/`@cute.kernel`, constexpr-vs-dynamic, JIT cache, control flow): [../cutedsl-programming-model.md](../cutedsl-programming-model.md)
+- CUTLASS internals on SM100 (descriptor iterators, `calculate_umma_peer_mask`, CLC, warp roles, dispatch policies): [blackwell-cutedsl-sm100.md](blackwell-cutedsl-sm100.md)
+- Pipeline classes/patterns (state machine, `.create()` signatures, role table): [../cutedsl-pipeline-patterns.md](../cutedsl-pipeline-patterns.md)
+- Worked GEMM tutorials: [blackwell-tcgen05-gemm-from-scratch.md](blackwell-tcgen05-gemm-from-scratch.md), [blackwell-gemm-tensor-memory.md](blackwell-gemm-tensor-memory.md), [blackwell-gemm-thread-block-cluster.md](blackwell-gemm-thread-block-cluster.md), [blackwell-gemm-low-precision.md](blackwell-gemm-low-precision.md), [cutedsl-nvfp4-gemm-tutorial.md](cutedsl-nvfp4-gemm-tutorial.md)
+
+> API names/signatures are functional facts paraphrased from NVIDIA's official CuTe DSL documentation
+> (<https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/cute_dsl_api.html>). Code is illustrative, not copied source.
+
+```python
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import tcgen05, cpasync
+import cutlass.utils as utils
+import cutlass.utils.sm100 as sm100              # high-level Blackwell helpers
+from cutlass.pipeline import PipelineTmaUmma, PipelineUmmaAsync, CooperativeGroup, PipelineOp
+```
+
+---
+
+## 1. SM100 capability → helper map
+
+The single thing this doc adds over the rest of the corpus: a map from each Blackwell capability to the **high-level helper** you call (not the raw atom / PTX / CUTLASS-C++ form the other docs use).
+
+| SM100 capability | CuTeDSL helper entry point |
+|---|---|
+| 5th-gen MMA (UMMA / tcgen05) | `sm100.make_trivial_tiled_mma(...)` (wraps `tcgen05.MmaF16BF16Op` / `MmaFP8Op` / `MmaTF32Op` / `MmaI8Op`) |
+| Block-scaled MMA (MXFP/NVFP4) | `sm100.make_blockscaled_trivial_tiled_mma(...)`; **B300/sm_103 NVFP4-Ultra: `blackwell_helpers.sm103_make_blockscaled_trivial_tiled_mma(...)`** |
+| CTA-pair / 2-SM cooperation | `cta_group=tcgen05.CtaGroup.TWO` + `use_2cta_instrs=True` on the helpers; `cluster=(2,1)` |
+| Tensor Memory (TMEM) | `utils.TmemAllocator(...)` (`allocate`/`retrieve_ptr`/`free`); columns via `sm100.get_num_tmem_alloc_cols(...)` |
+| TMEM ↔ register movement | `sm100.get_tmem_load_op(...)` → `tcgen05.make_tmem_copy(...)`; store-out via `sm100.get_smem_store_op(...)` |
+| SMEM operand layouts (TMA+UMMA-legal) | `sm100.make_smem_layout_a/b/epi(...)` or `tcgen05.make_smem_layout_atom(kind, dtype)` |
+| TMA + cluster multicast | `sm100.cluster_shape_to_tma_atom_A/B/SFB(...)` or `cpasync.make_tiled_tma_atom(...)`; mask via `cpasync.create_tma_multicast_mask(...)` |
+| Software pipeline | `PipelineTmaUmma` (TMA→UMMA) / `PipelineUmmaAsync` (UMMA→AsyncThread) / `PipelineAsyncUmma` / `PipelineTmaAsync` |
+| Cluster / persistent grid | `utils.HardwareInfo().get_max_active_clusters(cluster_size)`; `cute.arch` cluster primitives |
+| Epilogue tile sizing | `sm100.compute_epilogue_tile_shape(...)` |
+
+Low-level primitives (`elect_one`, `mbarrier_*`, cluster indexing): [../nvidia-cutedsl-arch-primitives.md](../nvidia-cutedsl-arch-primitives.md).
+
+---
+
+## 2. Per-helper usage rules
+
+Signatures plus the *correctness rules* specific to each helper. For the hardware mechanism behind each, follow the linked doc.
+
+### 2.1 `make_trivial_tiled_mma` / `make_blockscaled_trivial_tiled_mma`
+
+```python
+tiled_mma = sm100.make_trivial_tiled_mma(
+    ab_dtype=cutlass.BFloat16, acc_dtype=cutlass.Float32,
+    a_leading_mode=tcgen05.OperandMajorMode.K, b_leading_mode=tcgen05.OperandMajorMode.K,
+    cta_group=tcgen05.CtaGroup.ONE, mma_tiler_mn=(128, 256),
+    a_source=tcgen05.OperandSource.SMEM)      # A from SMEM (default) or TMEM
+```
+- Issue with `cute.gemm(tiled_mma, acc, A, B, acc)` — **accumulator-first** (D = A·B + C). Issued by one elected thread; calling from many threads deadlocks.
+- Accumulator lives in TMEM (2.2). Use `tcgen05.Field.ACCUMULATE = False` on the first K-tile, then `True`. `Field.NEGATE_A/B`, `Field.SFA/SFB` are runtime-settable.
+- All tcgen05 ops in a kernel must share one `cta_group`.
+- Block-scaled: `make_blockscaled_trivial_tiled_mma(..., sf_dtype=cutlass.Float8E4M3, sf_vec_size=16)` (NVFP4 = 16, MXFP = 32). Mechanism: [blackwell-cutedsl-sm100.md §1](blackwell-cutedsl-sm100.md), [../../../kernel-opt/nvidia/common/blackwell/hardware/tcgen05-mma.md](../../../../kernel-opt/nvidia/common/blackwell/hardware/tcgen05-mma.md).
+
+### 2.2 `TmemAllocator` + TMEM movement helpers
+
+```python
+num_cols = sm100.get_num_tmem_alloc_cols(acc_tmem_tensors)
+tmem_alloc = utils.TmemAllocator(alloc_result_dst_smem_ptr=..., barrier_for_retrieve=...,
+    is_two_cta=use_2cta_instrs, num_allocated_columns=num_cols,
+    two_cta_tmem_dealloc_mbar_ptr=dealloc_mbar)        # last arg 2-SM only
+tmem_alloc.allocate(...); acc_ptr = tmem_alloc.retrieve_ptr(cutlass.Float32); ...; tmem_alloc.free(...)
+```
+Rules (violating these hangs/corrupts): always `free` before exit (`allocate` can block → back-off retry); read-back needs a **full warpgroup** (one warp reaches only 1/4 of TMEM lanes) — build it via `sm100.get_tmem_load_op(...)` → `tcgen05.make_tmem_copy(...)`; column count is power-of-two in [32, 512] (use `get_num_tmem_alloc_cols`). Full TMEM model: [../../../kernel-opt/nvidia/common/blackwell/hardware/tmem.md](../../../../kernel-opt/nvidia/common/blackwell/hardware/tmem.md), [blackwell-cutedsl-sm100.md §2](blackwell-cutedsl-sm100.md).
+
+### 2.3 CTA-pair (2-SM)
+
+Enable `cta_group=tcgen05.CtaGroup.TWO` consistently across the MMA helper, the TMA atoms, the pipeline, and `TmemAllocator(is_two_cta=True, ...)`; use `cluster=(2,1)`. The even CTA is leader; peer-mbarrier / `calculate_umma_peer_mask` are handled for you — don't hand-roll. When/why and internals: [../../../kernel-opt/nvidia/common/blackwell/hardware/2sm-cooperative.md](../../../../kernel-opt/nvidia/common/blackwell/hardware/2sm-cooperative.md), [blackwell-cutedsl-sm100.md §3](blackwell-cutedsl-sm100.md), [blackwell-gemm-thread-block-cluster.md](blackwell-gemm-thread-block-cluster.md).
+
+### 2.4 TMA atoms + multicast
+
+```python
+atom_A = sm100.cluster_shape_to_tma_atom_A(cluster_shape_mnk, atom_thr_id)   # auto-multicast iff cluster dim > 1
+op = cpasync.CopyBulkTensorTileG2SOp(cta_group=tcgen05.CtaGroup.TWO)
+tma_atom, gA = cpasync.make_tiled_tma_atom(op, gmem_A, smem_layout_A, cta_tiler, num_multicast=cluster_m)
+mask = cpasync.create_tma_multicast_mask(cta_layout_vmnk, cta_coord_vmnk, mcast_mode=...)
+```
+Also `cluster_shape_to_tma_atom_B/SFB`. Sync model and 16-byte alignment: [../../../kernel-opt/nvidia/common/blackwell/hardware/tma.md](../../../../kernel-opt/nvidia/common/blackwell/hardware/tma.md) — let the pipeline class drive the mbarriers.
+
+### 2.5 Pipelines
+
+Pick by producer→consumer role: **`PipelineTmaUmma`** (TMA→UMMA, mainloop), `PipelineUmmaAsync` (UMMA→AsyncThread, accumulator drain), `PipelineAsyncUmma` (input fusion), `PipelineTmaAsync` (Hopper-style). Full role table, `.create()` signatures, and state machine: [../cutedsl-pipeline-patterns.md](../cutedsl-pipeline-patterns.md).
+
+---
+
+## 3. Performance & autotuning
+
+B200/B300 default starting point (from NVIDIA's autotuning guidance):
+
+```python
+use_2cta_instrs, mma_tiler_mn, cluster_shape_mn = True, (256, 256), (2, 1)
+max_active_clusters = utils.HardwareInfo().get_max_active_clusters(cluster_shape_mn[0]*cluster_shape_mn[1])
+# sizes the persistent grid; the CLC tile scheduler then distributes tiles dynamically
+```
+Sweep `use_2cta_instrs`, `mma_tiler_m/n`, `cluster_shape_m/n`, `use_tma_store`, `num_stages`. The JIT cache is keyed on function + arg types/layouts + CuTeDSL env vars, so each config compiles once and is reused. **Mark dynamic dims with `cute.mark_layout_dynamic`** or autotuning recompiles per shape (see [../cutedsl-programming-model.md](../cutedsl-programming-model.md)).
+
+---
+
+## 4. Debugging knobs
+
+The full `CUTE_DSL_*` env-var list is in [cutedsl-api-reference-guide.md](../cutedsl-api-reference-guide.md) §10. SM100-relevant additions:
+- Inspect generated code programmatically: compiled-kernel attrs `__ptx__`, `__cubin__`, `__mlir__`.
+- `cute.printf("...", x)` prints a value at runtime; Python `print(tensor.layout)` prints a layout at compile time.
+- When dropping to CUDA/PTX, the `--g-tensor-memory-access-check` build flag catches uninitialized / out-of-bounds TMEM access (silent otherwise). In DSL, keep TMEM copies built from `make_tmem_copy` so the warpgroup/lane mapping is correct by construction.
+
+---
+
+## 5. Common pitfalls (SM100 DSL-level)
+
+- `cute.gemm` / tcgen05 ops issued from more than one thread → deadlock.
+- Wrong `cute.gemm` operand order — it is **accumulator-first**: `cute.gemm(mma, acc, A, B, acc)`.
+- Mixing `cta_group=ONE` and `TWO` in one kernel → undefined.
+- TMEM epilogue from a single warp (needs a full warpgroup) → wrong / partial results.
+- Forgetting `tmem_alloc.free` → later blocks' `allocate` blocks forever.
+- Block scaling without scale factors in TMEM / `Field.SFA/SFB` unset → wrong results.
+- Not marking layouts dynamic → per-shape recompilation during autotuning.
+
+---
+
+## Related
+
+- [blackwell-cutedsl-sm100.md](blackwell-cutedsl-sm100.md) — CUTLASS-internals panorama
+- [../cutedsl-pipeline-patterns.md](../cutedsl-pipeline-patterns.md) · [../cutedsl-programming-model.md](../cutedsl-programming-model.md) · [../nvidia-cutedsl-arch-primitives.md](../nvidia-cutedsl-arch-primitives.md) · [../cutedsl-api-reference-guide.md](../cutedsl-api-reference-guide.md)
+- Worked tutorials: [blackwell-tcgen05-gemm-from-scratch.md](blackwell-tcgen05-gemm-from-scratch.md), [cutedsl-nvfp4-gemm-tutorial.md](cutedsl-nvfp4-gemm-tutorial.md)
+- [blackwell hardware mechanism docs](../../../../kernel-opt/nvidia/common/blackwell/hardware/README.md) — TMEM / tcgen05 / TMA / 2sm / CLC
+- Official API: <https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/cute_dsl_api.html>


### PR DESCRIPTION
Adds a usage guide for the SM100/SM103 CuTeDSL surface — how to use the Blackwell features well, not a single-kernel recipe. Complements the existing internals panorama (blackwell-cutedsl-sm100.md) and generic DSL model docs.

Contents:
- SM100 capability -> helper map (utils.sm100 / TmemAllocator / pipelines)
- How to use each capability well: 5th-gen MMA, TMEM, CTA-pair (2-SM), TMA+multicast, block scaling (incl. sm103 NVFP4-Ultra), pipeline-by-role
- Performance & autotuning (standard config, sweep axes, JIT cache reuse)
- Debugging/profiling knobs (CUTE_DSL_* env, cute.printf vs print, __ptx__/__mlir__, static-vs-dynamic layout recompiles, TMEM access check)
- Common SM100 DSL pitfalls; one minimal end-to-end example
