### PR TITLE
feat(orchestrator): clean-session-per-iteration optimization loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@ __pycache__/
 # rocprof-trace-decoder is cloned by install.sh at runtime
 tools/rocprof-trace-decoder/
 
+# Optimization workspaces created by orchestrator/optimize.py
+kernel_opt_*/
+
 # Git submodules are tracked via .gitmodules
 # reference-projects/ content is managed as submodules

--- a/SKILL.md
+++ b/SKILL.md
@@ -173,21 +173,29 @@ Exit criteria:
 - `baseline_report.md` exists.
 - Git commit is complete.
 
-Then the main agent takes over and must enter Stage 2 immediately. It is forbidden to stop, summarize final deliverables, or exit the workflow after Stage 1 unless Stage 2 has also completed or the user explicitly asks to stop.
+Stage 2 (profile-driven optimization) is driven by the **orchestrator** as a series of clean, one-iteration-per-session runs — see `orchestrator/optimize.py` and `orchestrator/prompts/`. When this router is run as the setup session (`orchestrator/prompts/setup.md`), stop after Stage 1: exit once `memory/v0.json` is committed, and let the orchestrator spawn the optimization iterations.
 
-### Stage 2: Profile-Driven Iterative Optimization
+### Stage 2: Profile-Driven Iterative Optimization (orchestrator-driven)
 
 **Sub-skill**: [gpu-kernel-profile-optimizer](skills/gpu-kernel-profile-optimizer/SKILL.md)
 
-Goal: use Step 0 Roofline conclusions and multiple profile -> code change -> validation loops to approach the performance limit.
+**Helper skill**: [gpu-kernel-bottleneck-analysis](skills/gpu-kernel-bottleneck-analysis/SKILL.md)
 
-Stage 2 researches, plans, searches gpu-wiki/reference projects, writes an optimization plan, profiles, modifies code, validates correctness, applies quality gates, commits, and writes `memory/v<N>.json`. It must continually compare against ISA optimization targets recorded in `README.md`.
+Goal: approach the performance limit through repeated profile -> code change -> validation cycles.
+
+The iteration loop is owned by the **orchestrator** (`orchestrator/optimize.py`), not by a single long session. Each iteration is a fresh `claude` session that runs `gpu-kernel-profile-optimizer` for **exactly one** profile -> edit -> validate -> bench cycle and then exits (see `orchestrator/prompts/iteration.md`). State crosses sessions only on disk (`memory/v<N>.json`, `plans/`, `profiles/`, git): each session reads the prior `open_directions` + recorded dead-ends and starts from HEAD (the best kernel so far). A regressing iteration reverts and is never committed, so HEAD stays best.
+
+**Termination is mechanical and owned by the orchestrator, not the model**: it stops on a hard budget (max iterations or token budget), or when a committed, correctness-PASS iteration reaches the target utilization in `README.md` under `Stop Conditions` (default: peak utilization >= 90%). A single session never decides to keep looping.
 
 Entry criteria: Stage 1 passed and `README.md` contains Step 0 Roofline analysis and `Stop Conditions`.
 
-Exit condition: performance reaches the absolute target in `README.md` under `Stop Conditions`.
+Run:
 
-When the exit condition is met, stop optimization and summarize deliverables.
+```bash
+python orchestrator/optimize.py \
+  --name <name> --kernel-demo <path> --platform <P> --framework <F> \
+  [--max-iters 20] [--token-budget 0] [--target-util 90]
+```
 
 ## Recommended Flows
 

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,6 @@
 #   ./install.sh --prefix /my/path     # specify custom install directory
 #   ./install.sh --hooks-only          # only install/update hooks for detected targets
 #   ./install.sh --without-github      # install/update, but skip GitHub reference repos from gpu-wiki
-#   ./install.sh --max-iterations N    # allow Stop hooks after memory/vN.json exceeds N iterations
 #   ./install.sh --uninstall           # remove hooks installed by this script from detected targets
 #
 # Idempotent. Safe to re-run.
@@ -36,7 +35,6 @@ ROCPROF_TRACE_DECODER_REPO="https://github.com/ROCm/rocprof-trace-decoder.git"
 
 MODE="install"
 WITHOUT_GITHUB="0"
-MAX_ITERATIONS="${GPU_KERNEL_MAX_ITERATIONS:-0}"
 CLI_PREFIX=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -59,22 +57,6 @@ while [[ $# -gt 0 ]]; do
     --hooks-only)     MODE="hooks-only"; shift ;;
     --without-github) WITHOUT_GITHUB="1"; shift ;;
     --uninstall)      MODE="uninstall"; shift ;;
-    --max-iterations)
-      if [[ $# -lt 2 || ! "$2" =~ ^[0-9]+$ ]]; then
-        echo "ERROR: --max-iterations requires a non-negative integer."
-        exit 2
-      fi
-      MAX_ITERATIONS="$2"
-      shift 2
-      ;;
-    --max-iterations=*)
-      MAX_ITERATIONS="${1#*=}"
-      if [[ ! "$MAX_ITERATIONS" =~ ^[0-9]+$ ]]; then
-        echo "ERROR: --max-iterations requires a non-negative integer."
-        exit 2
-      fi
-      shift
-      ;;
     *) echo "Unknown arg: $1"; exit 2 ;;
   esac
 done
@@ -104,11 +86,6 @@ CLAUDE_HOOK_TAG="gpu-kernel-optimizer-claude-hook-v1"
 
 GPU_WIKI_DIR="$INSTALL_BASE/gpu-wiki"
 REFERENCE_PROJECTS_DIR="$INSTALL_BASE/reference-projects"
-
-if [[ ! "$MAX_ITERATIONS" =~ ^[0-9]+$ ]]; then
-  echo "ERROR: GPU_KERNEL_MAX_ITERATIONS must be a non-negative integer."
-  exit 2
-fi
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required. Install it with your system package manager."
@@ -1079,12 +1056,6 @@ def memory_write_continuation_prompt(workspace: Path, version: str) -> str:
     )
 
 
-def iteration_limit_reached(workspace: Path, max_iterations: int) -> bool:
-    if max_iterations <= 0:
-        return False
-    return latest_memory_version(workspace) > max_iterations
-
-
 def output_path_for_workspace(workspace: Path) -> Path:
     return workspace.parent / "generated_kernel.py"
 
@@ -1224,13 +1195,11 @@ def goal_check_prompt_for_level(workspace: Path, level: int) -> str:
         return goal_check_prompt_level_3(workspace)
 
 
-def handle_goal_check(payload: dict, target: str, max_iterations: int) -> int:
+def handle_goal_check(payload: dict, target: str) -> int:
     stop_hook_active = payload.get("stop_hook_active", False)
 
     for workspace in iter_workspaces(payload):
         if not recently_active(workspace):
-            continue
-        if iteration_limit_reached(workspace, max_iterations):
             continue
 
         newest_mtime = newest_iteration_artifact_mtime(workspace)
@@ -1266,18 +1235,13 @@ def handle_goal_check(payload: dict, target: str, max_iterations: int) -> int:
 
     return 0
 
-def handle_stop(payload: dict, target: str, max_iterations: int) -> int:
+def handle_stop(payload: dict, target: str) -> int:
     for workspace in iter_workspaces(payload):
         if not recently_active(workspace):
             continue
 
         newest_mtime = newest_iteration_artifact_mtime(workspace)
         if newest_mtime <= 0:
-            continue
-
-        iteration_limit_hit = iteration_limit_reached(workspace, max_iterations)
-
-        if iteration_limit_hit:
             continue
 
         output_path = first_existing_output_path(payload, workspace)
@@ -1314,10 +1278,9 @@ def handle_stop(payload: dict, target: str, max_iterations: int) -> int:
     return 0
 
 
-def parse_args() -> tuple[str, str, int]:
+def parse_args() -> tuple[str, str]:
     mode = "stop"
     target = "generic"
-    max_iterations = 0
     args = sys.argv[1:]
     index = 0
     while index < len(args):
@@ -1329,30 +1292,21 @@ def parse_args() -> tuple[str, str, int]:
             index += 1
         elif arg.startswith("--target="):
             target = arg.split("=", 1)[1]
-        elif arg == "--max-iterations" and index + 1 < len(args):
-            value = args[index + 1]
-            if value.isdigit():
-                max_iterations = int(value)
-            index += 1
-        elif arg.startswith("--max-iterations="):
-            value = arg.split("=", 1)[1]
-            if value.isdigit():
-                max_iterations = int(value)
         index += 1
-    return mode, target, max_iterations
+    return mode, target
 
 
 def main() -> int:
-    mode, target, max_iterations = parse_args()
+    mode, target = parse_args()
     payload = load_payload()
     if mode == "pre":
         return handle_pre_tool_use(payload, target)
     if mode == "post":
         return handle_post_tool_use(payload, target)
     if mode == "stop":
-        return handle_stop(payload, target, max_iterations)
+        return handle_stop(payload, target)
     if mode == "goal":
-        return handle_goal_check(payload, target, max_iterations)
+        return handle_goal_check(payload, target)
     return 0
 
 
@@ -1377,19 +1331,15 @@ merge_hooks() {
   cp "$HOOKS_FILE" "$backup"
   echo "[$TARGET_NAME][hooks] Backup: $backup"
 
-  local pre_cmd post_cmd stop_cmd goal_cmd tmp
+  local pre_cmd post_cmd tmp
   pre_cmd="python3 \"$HOOK_SCRIPT\" pre --target $TARGET_NAME --tag $HOOK_TAG"
   post_cmd="python3 \"$HOOK_SCRIPT\" post --target $TARGET_NAME --tag $HOOK_TAG"
-  stop_cmd="python3 \"$HOOK_SCRIPT\" stop --target $TARGET_NAME --max-iterations $MAX_ITERATIONS --tag $HOOK_TAG"
-  goal_cmd="python3 \"$HOOK_SCRIPT\" goal --target $TARGET_NAME --max-iterations $MAX_ITERATIONS --tag $HOOK_TAG"
   tmp=$(mktemp)
 
   jq \
     --arg tag "$HOOK_TAG" \
     --arg pre "$pre_cmd" \
-    --arg post "$post_cmd" \
-    --arg stop "$stop_cmd" \
-    --arg goal "$goal_cmd" '
+    --arg post "$post_cmd" '
     def strip_tagged:
       (. // [])
       | map(.hooks |= (map(select((.command // "") | contains($tag) | not))))
@@ -1404,21 +1354,8 @@ merge_hooks() {
         matcher:"Read|read_file|Write|Edit|MultiEdit|apply_patch|file_replace|shell|Bash",
         hooks:[{type:"command", command:$post, statusMessage:"gpu-kernel-optimizer memory/kernel edit gate", timeout:10}]
       }])
-    | .hooks.Stop = ((.hooks.Stop | strip_tagged) + [{
-        hooks:[{
-          type:"command",
-          command:$stop,
-          statusMessage:"gpu-kernel-optimizer workflow gate",
-          timeout:30
-        }]
-      }, {
-        hooks:[{
-          type:"command",
-          command:$goal,
-          statusMessage:"gpu-kernel-optimizer goal check",
-          timeout:30
-        }]
-      }])
+    | .hooks.Stop = ((.hooks.Stop // []) | strip_tagged)
+    | if (.hooks.Stop | length) == 0 then del(.hooks.Stop) else . end
   ' "$HOOKS_FILE" > "$tmp"
 
   jq empty "$tmp" >/dev/null

--- a/orchestrator/optimize.py
+++ b/orchestrator/optimize.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Clean-session orchestrator for atrex-kernel-agent.
+
+Owns the OUTER optimization loop so termination no longer depends on the model's
+in-session judgment (the old Stage-6 "is README's Stop Conditions met?" self-call).
+
+Each iteration is a **fresh `claude` session** (`--print`, new `--session-id`) over the
+*same* git workspace. State crosses the session boundary only through disk — exactly the
+artifacts atrex already maintains: `memory/v<N>.json`, `plans/`, `profiles/`, and git.
+HEAD is always the best kernel (a regressing iteration reverts and is never committed).
+
+Termination policy
+------------------
+- Outer loop (this file):  HARD budget break = max iterations OR token budget,
+  plus a mechanical target short-circuit (peak utilization >= --target-util on a
+  committed, correctness-PASS iteration). No plateau ladder, no convergence judge.
+- Inner loop (one session): exactly one profile->edit->validate->bench cycle, bounded
+  by a hang-backstop timeout (SIGKILL of the process group). See prompts/iteration.md.
+
+Per-iteration reasoning stays in markdown (the gpu-kernel-* skills + prompts/*.md);
+this file only does mechanism: spawn, time-bound, token-account, read state, decide stop.
+
+Usage
+-----
+    python orchestrator/optimize.py \
+        --name mla_decode --kernel-demo /path/to/demo.py \
+        --platform H20 --framework CuteDSL \
+        --max-iters 20 --token-budget 8000000 --target-util 90
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+WORKSPACE_INIT = REPO_ROOT / "reference" / "workspace_init.sh"
+
+
+# ── thin IO ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SessionResult:
+    exit_status: int
+    timed_out: bool
+    tokens: int
+    stdout_tail: str
+    stderr_tail: str
+
+
+def _render(template_path: Path, **kw: str) -> str:
+    text = template_path.read_text(encoding="utf-8")
+    for key, val in kw.items():
+        text = text.replace("{{" + key + "}}", str(val))
+    return text
+
+
+def _tokens_from_stream(stdout: str) -> int:
+    """Sum core token usage from a `--output-format stream-json` stdout.
+
+    Prefer the terminal `{"type":"result", ...,"usage":{...}}` event (cumulative);
+    fall back to summing per-message usage. Counts input+output (+cache) tokens.
+    Never raises — budget accounting degrades to max-iters if the stream is unparseable.
+    """
+    def _usage_tokens(u: dict) -> int:
+        if not isinstance(u, dict):
+            return 0
+        return int(
+            (u.get("input_tokens") or 0)
+            + (u.get("output_tokens") or 0)
+            + (u.get("cache_creation_input_tokens") or 0)
+            + (u.get("cache_read_input_tokens") or 0)
+        )
+
+    result_total = None
+    summed = 0
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line or line[0] != "{":
+            continue
+        try:
+            evt = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(evt, dict):
+            continue
+        if evt.get("type") == "result" and isinstance(evt.get("usage"), dict):
+            result_total = _usage_tokens(evt["usage"])
+        usage = evt.get("usage")
+        if usage is None and isinstance(evt.get("message"), dict):
+            usage = evt["message"].get("usage")
+        if isinstance(usage, dict):
+            summed += _usage_tokens(usage)
+    return result_total if result_total is not None else summed
+
+
+def _run_bounded(cmd: list[str], cwd: Path, timeout: int) -> tuple[str, str, int, bool]:
+    """Run cmd in its own process group; SIGKILL the whole tree on timeout."""
+    proc = subprocess.Popen(
+        cmd,
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,  # own process group -> killpg reaps grandchildren
+    )
+    timed_out = False
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        stdout, stderr = proc.communicate()
+    return stdout or "", stderr or "", proc.returncode, timed_out
+
+
+def run_session(workspace: Path, prompt: str, timeout: int) -> SessionResult:
+    """One clean `claude` session. Fresh session-id = no memory of prior sessions."""
+    session_id = str(uuid.uuid4())
+    cmd = [
+        "claude", "--print", "--verbose",
+        "--output-format", "stream-json",
+        "--session-id", session_id,
+        prompt,
+    ]
+    stdout, stderr, exit_status, timed_out = _run_bounded(cmd, cwd=workspace, timeout=timeout)
+    return SessionResult(
+        exit_status=exit_status,
+        timed_out=timed_out,
+        tokens=_tokens_from_stream(stdout),
+        stdout_tail=stdout[-2000:],
+        stderr_tail=stderr[-2000:],
+    )
+
+
+# ── workspace / memory readers ────────────────────────────────────────────────
+
+
+def latest_version(workspace: Path) -> int:
+    mem = workspace / "memory"
+    if not mem.exists():
+        return -1
+    vs = []
+    for p in mem.glob("v*.json"):
+        try:
+            vs.append(int(p.stem[1:]))
+        except ValueError:
+            continue
+    return max(vs) if vs else -1
+
+
+def read_memory(workspace: Path, n: int) -> Optional[dict]:
+    path = workspace / "memory" / f"v{n}.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def committed(mem: Optional[dict]) -> bool:
+    return bool(mem and mem.get("git_commit_hash"))
+
+
+def peak_util(mem: Optional[dict]) -> float:
+    """Max of tflops / bandwidth peak utilization (%), 0 if unknown."""
+    if not mem:
+        return 0.0
+    perf = mem.get("performance") or {}
+    vals = [perf.get("tflops_peak_utilization_pct"), perf.get("bandwidth_peak_utilization_pct")]
+    return max([float(v) for v in vals if isinstance(v, (int, float))] or [0.0])
+
+
+def target_met(mem: Optional[dict], target_util: float) -> bool:
+    """Mechanical success: a committed, correctness-PASS iteration at/above target util."""
+    if not committed(mem):
+        return False
+    if (mem.get("quality_gate") or {}).get("result") != "PASS":
+        return False
+    return peak_util(mem) >= target_util
+
+
+def detect_arch() -> str:
+    """Return the real runtime GPU architecture token (vendor-neutral), or '' if undetectable.
+
+    NVIDIA/CUDA -> 'sm_<cap>' (e.g. 'sm_103'); AMD/ROCm -> the gfx arch (e.g. 'gfx942').
+    Uses torch (get_device_capability / gcnArchName) — the AUTHORITATIVE source, which stays
+    correct even when the GPU name / vendor SMI is DESENSITIZED (e.g. a B300 reporting as 'L20D').
+    """
+    code = (
+        "import torch\n"
+        "p=torch.cuda.get_device_properties(0)\n"
+        "if getattr(torch.version,'hip',None):\n"
+        "    print(getattr(p,'gcnArchName','').split(':')[0])\n"
+        "else:\n"
+        "    c=torch.cuda.get_device_capability(0); print('sm_%d%d'%(c[0],c[1]))\n"
+    )
+    for py in ("python", "python3", sys.executable):
+        try:
+            out = subprocess.run([py, "-c", code], capture_output=True, text=True, timeout=120)
+            s = out.stdout.strip()
+            if s:
+                return s
+        except (OSError, subprocess.SubprocessError):
+            continue
+    return ""
+
+
+def hardware_directive(platform: str, arch: str) -> str:
+    """Authoritative, vendor-neutral hardware-identity block injected into every session.
+
+    Guards against desensitized boxes: the agent must target the real architecture from the
+    runtime API, not the (possibly faked) device name. Deliberately does NOT prescribe any
+    vendor's feature set — the agent maps the detected arch to its own codegen choices, so this
+    works on NVIDIA (Hopper/Blackwell/...) and AMD (CDNA/...) alike.
+    """
+    real = f"**{arch}**" if arch else "whatever the runtime GPU API reports"
+    return (
+        "## Hardware ground truth (authoritative — read before choosing an algorithm)\n\n"
+        f"- Intended target hardware: **{platform}**. Real runtime GPU architecture: {real} — from the "
+        "runtime API (`torch.cuda.get_device_capability()` on CUDA; the device gfx arch on ROCm). This is "
+        "the ONLY source to trust for the architecture.\n"
+        "- **The GPU *name* and vendor SMI (`nvidia-smi` / `rocm-smi`) on this box may be DESENSITIZED / "
+        "FAKED** — they can report an older or entirely different GPU than the real silicon. Do NOT infer "
+        "the architecture, vendor, or feature set from the device name; if it disagrees with the runtime "
+        "API, the runtime API wins.\n"
+        "- Design *and* build for the real architecture above: select the code paths, instructions, and "
+        "build/target flags your DSL/compiler exposes for THAT architecture and generation. Do NOT fall "
+        "back to an older-arch portable path because of the device name, and do NOT assume a different "
+        "vendor or generation than the detected one.\n"
+    )
+
+
+# ── campaign ──────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Campaign:
+    name: str
+    kernel_demo: str
+    platform: str
+    framework: str
+    notes: str = "none"
+    arch: str = ""                 # real runtime GPU arch e.g. "sm_103" / "gfx942"; auto-detected
+    gpu_wiki: str = ""             # abs path to gpu-wiki (default: <repo>/gpu-wiki)
+    max_iters: int = 20
+    token_budget: int = 0          # 0 = no token cap (max-iters still bounds the run)
+    target_util: float = 90.0
+    iter_timeout: int = 5400       # 90 min hang-backstop per optimization session
+    setup_timeout: int = 7200      # 120 min for the baseline session
+    max_stall: int = 0             # 0 = disabled (budget-only); >0 = stop after N no-commit iters
+    tokens_spent: int = field(default=0, init=False)
+
+    @property
+    def workspace(self) -> Path:
+        return Path.cwd() / f"kernel_opt_{self.name}"
+
+    def _account(self, res: SessionResult, label: str) -> None:
+        self.tokens_spent += res.tokens
+        print(f"[orchestrator] {label}: exit={res.exit_status} timed_out={res.timed_out} "
+              f"tokens={res.tokens} cum_tokens={self.tokens_spent}", flush=True)
+        if res.exit_status != 0 or res.timed_out:
+            print(f"[orchestrator] stderr tail:\n{res.stderr_tail}", file=sys.stderr, flush=True)
+
+    def _link_runtime(self) -> None:
+        """Make the skill's `tools/` and `reference/` resolvable from cwd=workspace.
+
+        The gpu-kernel-* skills reference `tools/...` and `reference/...` by relative
+        path; sessions run with cwd=workspace, so symlink them in (absolute targets, so
+        the workspace can live anywhere). gpu-wiki is passed by absolute path instead.
+        Idempotent.
+        """
+        for sub in ("tools", "reference", "skills"):
+            src, dst = REPO_ROOT / sub, self.workspace / sub
+            if src.exists() and not dst.exists():
+                os.symlink(src, dst)
+        gi = self.workspace / ".gitignore"
+        existing = gi.read_text(encoding="utf-8") if gi.exists() else ""
+        if "/tools" not in existing:
+            with gi.open("a", encoding="utf-8") as fh:
+                fh.write("\n# orchestrator runtime symlinks (not part of the workspace)\n/tools\n/reference\n/skills\n")
+
+    def setup_baseline(self) -> None:
+        if not WORKSPACE_INIT.exists():
+            raise FileNotFoundError(f"missing {WORKSPACE_INIT}")
+        subprocess.run(["bash", str(WORKSPACE_INIT), self.name, self.kernel_demo], check=True)
+        self._link_runtime()
+        prompt = _render(
+            PROMPTS_DIR / "setup.md",
+            WORKSPACE=str(self.workspace), PLATFORM=self.platform,
+            FRAMEWORK=self.framework, KERNEL_DEMO=self.kernel_demo,
+            NOTES=self.notes, GPU_WIKI=self.gpu_wiki,
+            HARDWARE=hardware_directive(self.platform, self.arch),
+        )
+        res = run_session(self.workspace, prompt, timeout=self.setup_timeout)
+        self._account(res, "setup")
+        if read_memory(self.workspace, 0) is None:
+            raise RuntimeError("setup did not produce memory/v0.json (baseline failed)")
+
+    def budget_exhausted(self) -> bool:
+        return self.token_budget > 0 and self.tokens_spent >= self.token_budget
+
+    def run(self) -> str:
+        if latest_version(self.workspace) < 0:
+            self.setup_baseline()
+        else:
+            print(f"[orchestrator] resuming: latest = v{latest_version(self.workspace)}", flush=True)
+            self._link_runtime()  # ensure runtime symlinks exist for iteration sessions
+
+        stall = 0
+        n = latest_version(self.workspace)  # 0 after baseline
+        while True:
+            if n >= self.max_iters:
+                return self._finish("budget: max-iters")
+            if self.budget_exhausted():
+                return self._finish("budget: token-budget")
+
+            n += 1
+            prompt = _render(PROMPTS_DIR / "iteration.md",
+                             WORKSPACE=str(self.workspace), N=n, PREV=n - 1,
+                             PLATFORM=self.platform, NOTES=self.notes,
+                             HARDWARE=hardware_directive(self.platform, self.arch))
+            res = run_session(self.workspace, prompt, timeout=self.iter_timeout)
+            self._account(res, f"iter v{n}")
+
+            mem = read_memory(self.workspace, n)
+            if target_met(mem, self.target_util):
+                return self._finish(f"success: peak_util {peak_util(mem):.1f}% >= {self.target_util:.0f}%")
+
+            if committed(mem):
+                stall = 0
+            else:
+                stall += 1
+                if self.max_stall > 0 and stall >= self.max_stall:
+                    return self._finish(f"stall: {stall} iterations with no commit")
+
+    def _finish(self, reason: str) -> str:
+        print(f"\n[orchestrator] STOP — {reason}", flush=True)
+        try:
+            subprocess.run(
+                [sys.executable, str(REPO_ROOT / "tools" / "memory_manager.py"),
+                 "summary", "--workspace", str(self.workspace)],
+                check=False,
+            )
+        except OSError:
+            pass
+        return reason
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Clean-session orchestrator for atrex-kernel-agent.")
+    ap.add_argument("--name", required=True, help="Workspace name -> ./kernel_opt_<name>/")
+    ap.add_argument("--kernel-demo", required=True, help="Path to the initial kernel to optimize.")
+    ap.add_argument("--platform", required=True, help="Target hardware, e.g. H20 / MI308X.")
+    ap.add_argument("--framework", required=True, help="e.g. CuteDSL / FlyDSL.")
+    ap.add_argument("--notes", default="none", help="Extra constraints / known bottlenecks.")
+    ap.add_argument("--gpu-wiki", default=str(REPO_ROOT / "gpu-wiki"),
+                    help="Absolute path to the gpu-wiki knowledge base (default: <repo>/gpu-wiki).")
+    ap.add_argument("--max-iters", type=int, default=20, help="Hard cap on optimization iterations.")
+    ap.add_argument("--token-budget", type=int, default=0,
+                    help="Hard token cap across all sessions (0 = no cap; max-iters still bounds it).")
+    ap.add_argument("--target-util", type=float, default=90.0,
+                    help="Peak-utilization %% short-circuit (default stop condition).")
+    ap.add_argument("--iter-timeout", type=int, default=5400, help="Per-iteration hang backstop (s).")
+    ap.add_argument("--setup-timeout", type=int, default=7200, help="Baseline session timeout (s).")
+    ap.add_argument("--max-stall", type=int, default=0,
+                    help="Optional: stop after N consecutive no-commit iterations (0 = disabled).")
+    ap.add_argument("--arch", default="",
+                    help="Override the real runtime GPU arch, e.g. sm_103 or gfx942. Default: auto-detect "
+                         "via torch (get_device_capability / gcnArchName) — use this if auto-detect fails.")
+    args = ap.parse_args(argv)
+
+    arch = args.arch or detect_arch()
+    print(f"[orchestrator] platform={args.platform} runtime_arch="
+          f"{arch or 'UNKNOWN (detect failed)'} "
+          f"(device name / vendor-smi may be desensitized; trusting the runtime API)", flush=True)
+
+    campaign = Campaign(
+        name=args.name, kernel_demo=args.kernel_demo, platform=args.platform,
+        framework=args.framework, notes=args.notes, arch=arch, gpu_wiki=args.gpu_wiki,
+        max_iters=args.max_iters, token_budget=args.token_budget, target_util=args.target_util,
+        iter_timeout=args.iter_timeout, setup_timeout=args.setup_timeout, max_stall=args.max_stall,
+    )
+    campaign.run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/orchestrator/prompts/iteration.md
+++ b/orchestrator/prompts/iteration.md
@@ -1,0 +1,91 @@
+# One optimization iteration (clean session)
+
+You are one **clean session** in a profile-driven GPU-kernel optimization campaign.
+Run **exactly one cycle** — profile → pick ONE lever → edit → validate → bench → record — then **exit**.
+
+Hard rules for this session:
+
+- **Do NOT loop.** One cycle, then stop. There is no Stage 6 here — the orchestrator owns the outer loop and decides whether another session runs.
+- **Do NOT try to reach the final target** in this session. Just make this one cycle count and hand off cleanly.
+- The whole point of a clean session is a fresh context: you inherit state from disk, not from a prior conversation.
+
+## Context
+
+- Workspace: `{{WORKSPACE}}` — this is your cwd, and a git repo. **git HEAD is the best kernel so far.**
+- You are producing version **v{{N}}**. Previous version: **v{{PREV}}**.
+- `tools/`, `reference/`, and `skills/` are symlinked into the workspace — read/use them by relative path
+  (`tools/profile_nvidia.sh`, `python tools/memory_manager.py --workspace .`,
+  `reference/v_iteration.schema.json`, `skills/gpu-kernel-profile-optimizer/SKILL.md`).
+  The gpu-wiki path is recorded as `gpu_wiki_path` in `README.md`.
+
+{{HARDWARE}}
+
+Read and follow **`skills/gpu-kernel-profile-optimizer/SKILL.md`** for the *mechanics* — profiling commands,
+evidence format (`evidence -> inference -> action`), the localization rule, plan format, the Stage 4 quality
+gate, and the Stage 5 commit format. This prompt **overrides its loop/stop behavior**: do Stages 1–5 once,
+skip Stage 6, then exit. Honor that skill's subagent requirements for Stage 2 (planning) and Stage 4 (validation).
+
+## Step A — Learn from prior sessions (read; do not redo their work)
+
+1. Read `README.md` — config, `Hardware Spec`, and `Stop Conditions`.
+2. Cross-version digest — `python tools/memory_manager.py summary --workspace .` (where we are; the trajectory).
+3. The latest entry, in full — `python tools/memory_manager.py read --workspace . --version v{{PREV}}`. Pay attention to:
+   - **`open_directions`** — candidate leads the previous session left for you.
+   - **`search_log` + `pitfalls_and_fixes`** across the digest — **recorded dead-ends. Do NOT repeat them.**
+4. Profile reuse — if `profiles/v{{PREV}}/` holds a profile of the *current* HEAD kernel (carried forward),
+   you may reuse it instead of re-profiling. Otherwise profile fresh in Step B.
+
+**`open_directions` are priors, not orders.** Pick the most promising lead — **or**, if a fresh look at the
+profile reveals a better lever, pursue that instead. The only hard constraint is: don't re-run a recorded dead-end.
+
+## Step B — One cycle
+
+1. **Profile** the current `kernel.py` into `profiles/v{{N}}/` (skill Stage 1). Extract ≥1 concrete bottleneck.
+2. **Pick exactly ONE optimization lever** (skill Stage 2 → `plans/v{{N}}_plan.md`). One category only, so the result is attributable.
+3. **Edit** `kernel.py` — apply that single change, nothing else (skill Stage 3).
+4. **Validate + bench** (skill Stage 4): correctness first (with the timeout guard), then measure
+   latency / TFLOPS / bandwidth / peak-utilization. Bench must be **variance-aware** — a delta only counts as
+   real if it clears measurement noise (best-of-N or delta > noise band; flat-within-noise is *not* an improvement).
+
+## Step C — Commit or revert (mechanical, no discretion)
+
+- **Real win** (correctness PASS **and** speedup clears noise vs v{{PREV}}) → **commit** (skill Stage 5 format).
+  This kernel becomes the new HEAD/best.
+- **Otherwise** (regression, flat-within-noise, or correctness FAIL) → `git reset --hard HEAD` to restore the
+  best-known `kernel.py`. **Never commit a regression.**
+
+## Step D — Record + hand off (ALWAYS — win *or* dead-end)
+
+Fill `memory/v{{N}}.json` regardless of outcome (`memory_manager.py create` then `update`, per the skill). It is
+untracked until you commit it, so it survives `git reset --hard`.
+
+- `performance`, `correctness`, `profile_evidence`, `optimization` (what you tried) — per `reference/v_iteration.schema.json`.
+- `quality_gate` + `git_commit_hash` — set the hash if you committed; leave `null` if you reverted.
+- **If this cycle was a dead-end**, record *why* in `search_log` / `pitfalls_and_fixes` so the next session doesn't repeat it.
+- **`open_directions`** — up to **3** candidate leads for the *next* session, most-promising first (fewer is fine
+  if you only found 1–2). Include any **unfinished-but-promising thread** you didn't get to. These are the "word
+  for the next session":
+
+  ```bash
+  python tools/memory_manager.py update --workspace . --version v{{N}} \
+    --set 'open_directions=[{"direction":"<lever>","rationale":"<evidence/why promising>"}]'
+  ```
+
+- **Profile-carry-forward** — if you committed, leave the post-edit profile in `profiles/v{{N}}/` so the next
+  session can reuse it instead of re-profiling.
+- **Commit the record** even on a revert, so the next session sees the dead-end:
+
+  ```bash
+  # win:  kernel.py already committed in Step C; amend the hash in per Stage 5.
+  # revert: commit just the record —
+  git add memory/v{{N}}.json plans/v{{N}}_plan.md && \
+    git commit -m "v{{N}}: reverted (<reason>) — dead-end recorded"
+  ```
+
+## Finish
+
+Print one line and stop — do **not** start another cycle:
+
+```
+v{{N}}: committed (+X.X%)   |   v{{N}}: reverted (<reason>)
+```

--- a/orchestrator/prompts/setup.md
+++ b/orchestrator/prompts/setup.md
@@ -1,0 +1,36 @@
+# Campaign setup (clean session, run once)
+
+You are the **setup session** for a profile-driven GPU-kernel optimization campaign.
+The orchestrator drives the optimization loop after you; your job is to produce the **V0 baseline** and stop.
+
+The workspace already exists at your cwd (`{{WORKSPACE}}`) — it was created by the orchestrator
+(`workspace_init.sh` already ran: directory structure, git, and `kernel.py` are in place).
+**Do NOT re-run `workspace_init.sh`.**
+
+Environment (resolve all paths against your cwd = the workspace):
+- `tools/`, `reference/`, and `skills/` are symlinked into the workspace — read/use them by relative path
+  (e.g. `tools/profile_nvidia.sh`, `python tools/memory_manager.py --workspace .`,
+  `reference/v_iteration.schema.json`, `skills/gpu-kernel-baseline/SKILL.md`).
+- The gpu-wiki knowledge base is at `{{GPU_WIKI}}` — record this as `gpu_wiki_path` in `README.md` and resolve every `<gpu-wiki>/...` reference to it.
+
+{{HARDWARE}}
+Read the bundled skill docs by path and follow them, but only through baseline:
+
+1. **Step 0 — Hardware specs + Roofline.** Per `skills/gpu-kernel-bottleneck-analysis/SKILL.md`, source
+   every hardware spec from `{{GPU_WIKI}}/` (**no fabrication** — every spec value must cite a gpu-wiki path),
+   do the Roofline analysis, compute absolute targets (`hardware peak * 90%`), and write `Hardware Spec`,
+   the Roofline analysis, and `Stop Conditions` into the workspace `README.md`.
+2. **Write `README.md`** — static config from the parameters below + Step 0 outputs (use `reference/README.md` as the template).
+3. **Stage 1 — Baseline.** Follow `skills/gpu-kernel-baseline/SKILL.md`: implement `kernel.py` + `test_kernel.py`,
+   validate correctness and baseline performance, write `baseline_report.md`, write `memory/v0.json` (via
+   `tools/memory_manager.py`), and `git commit` ("V0: baseline kernel").
+
+Then **STOP**. Do **NOT** enter Stage 2 / any optimization iteration — the orchestrator spawns those as
+separate clean sessions. Exit once `memory/v0.json` exists and the baseline is committed.
+
+## Parameters
+
+- platform: `{{PLATFORM}}`
+- framework: `{{FRAMEWORK}}`
+- kernel_demo: `{{KERNEL_DEMO}}` (already copied to `kernel.py`)
+- additional_notes: `{{NOTES}}`

--- a/reference/CLAUDE.md
+++ b/reference/CLAUDE.md
@@ -42,6 +42,12 @@ When executing `skills/gpu-kernel-profile-optimizer/SKILL.md`:
 - Referencing third-party code for learning is permitted, but the final implementation MUST NOT depend on or copy from external libraries.
 - If a kernel requires utility functions (e.g., memory management helpers, math primitives), they MUST be implemented inline or as project-local utilities — NEVER imported from external packages.
 
+## Benchmark Harness Integrity
+
+- **test_kernel.py is immutable for performance measurement**: DO NOT modify `test_kernel.py` to change the benchmark harness (e.g., warmup count, repetition count, `return_mode`, timing method, input shapes, or any other benchmark parameter) in order to obtain better performance numbers.
+- `test_kernel.py` defines the ground-truth benchmark methodology. Any change to it invalidates cross-version comparisons.
+- If a measurement methodology issue is discovered (e.g., outlier inflation, incorrect return mode), report it in `memory/v<N>.json` under `pitfalls_and_fixes` and propose the fix — but DO NOT apply the fix to `test_kernel.py` within an optimization iteration.
+
 ## Hardware Architecture Constraints
 
 - **blackwell-geforce is NOT blackwell**: `blackwell-geforce` (sm120) and `blackwell` (sm100) are completely different architectures. Do NOT conflate them or assume they share the same optimization strategies.

--- a/reference/v_iteration.schema.json
+++ b/reference/v_iteration.schema.json
@@ -66,5 +66,11 @@
     "result": "<PASS / FAIL / TIMEOUT_FAIL>",
     "failure_reason": null
   },
+  "open_directions": [
+    {
+      "direction": "<candidate optimization lever for the NEXT session to try, most-promising first; max 3>",
+      "rationale": "<evidence/intuition for why this is promising, incl. unfinished-but-promising threads>"
+    }
+  ],
   "git_commit_hash": null
 }

--- a/skills/gpu-kernel-profile-optimizer/SKILL.md
+++ b/skills/gpu-kernel-profile-optimizer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gpu-kernel-profile-optimizer
 description: |
-  Profile-driven GPU kernel iterative optimization skill. Use this skill to run a closed loop in a temporary git workspace: profile evidence extraction, evidence-driven search and planning, single-category optimization, validation, memory update, and git commit.
+  Profile-driven GPU kernel optimization skill. Use this skill to run ONE optimization iteration in a temporary git workspace: profile evidence extraction, evidence-driven search and planning, single-category optimization, validation, memory update, git commit, and handoff. The outer iteration loop is owned by the orchestrator (orchestrator/optimize.py), not by this skill — run one cycle, then exit.
 ---
 
 # GPU Kernel Profile Optimizer
@@ -16,24 +16,24 @@ Use this skill when the user asks to:
 
 ## Overall Principles
 
-This skill must follow the stage order below. Commands, wiki searches, profiling, validation, records, and commits must be completed inside their corresponding stage.
+This skill runs **exactly ONE iteration** end-to-end, then exits. It does not loop: the orchestrator (`orchestrator/optimize.py`) spawns the next iteration as a separate clean session. Follow the stage order below. Commands, wiki searches, profiling, validation, records, and commits must be completed inside their corresponding stage.
 
 ```text
 Stage 1 Profile and evidence extraction
 Stage 2 Evidence-driven search and planning
 Stage 3 Single-category optimization implementation
 Stage 4 Performance, correctness, and quality gate
-Stage 5 Memory update and git commit
-Stage 6 Stop-condition check or next iteration
+Stage 5 Memory update, git commit, and handoff
 ```
 
 Constraints:
 
 - Do not skip stages.
 - Do not edit code without profile evidence.
+- Implement only one optimization category per iteration so the result can be attributed.
 - Each optimization action must have clear profile evidence attribution.
-- If the quality gate fails, revert to the previous commit, record the failure, and stop the current iteration.
-- If stop conditions are not met, do not exit unless the user explicitly stops the workflow.
+- If the quality gate fails, revert to the previous commit, record the failure, and stop the iteration.
+- Run exactly one iteration, then exit. Do not start another cycle — the orchestrator decides whether the next iteration runs.
 
 ## Workspace Layout
 
@@ -272,6 +272,15 @@ Pass conditions:
 - No unacceptable performance regression, or the regression is clearly explained and supports later optimization.
 - No severe ISA regression, such as new spills or a large occupancy drop.
 
+### Measurement Reliability Guard
+
+Before accepting a large performance delta (especially regressions > 30%), verify the measurement is trustworthy:
+
+1. Compare `kernel.py` and `test_kernel.py` against the previous committed version (`git diff HEAD -- kernel.py test_kernel.py`). If both are unchanged, the kernel binary and benchmark harness are identical — any large latency change is an environment artifact, not a real regression.
+2. Check GPU occupancy: `nvidia-smi --query-gpu=index,memory.used,utilization.gpu --format=csv,noheader`. If the current GPU shows significant memory usage (> 1GB from other processes) or high utilization from other workloads, the measurement is unreliable.
+3. If the GPU is occupied, switch to a free GPU by setting `CUDA_VISIBLE_DEVICES=<free_gpu_id>` and re-run the benchmark.
+4. If both files are unchanged but latency differs by more than 30%, do not treat it as a real regression. Re-measure on a confirmed-free GPU before recording.
+
 ### Failure Handling
 
 If the subagent returns FAIL or TIMEOUT_FAIL, the main agent must:
@@ -282,9 +291,9 @@ git reset --hard HEAD
 
 Record the failure reason, skip further planning for this iteration, and do not enter the next iteration. Write the failure into `memory/v<N>.json` under `pitfalls_and_fixes` and `quality_gate`, then commit a revert marker such as `V5: revert V4 (occupancy 25% -> 12%)` when appropriate.
 
-## Stage 5: Memory Update and Git Commit
+## Stage 5: Memory Update, Git Commit, and Handoff
 
-Goal: finalize `memory/v<N>.json` with quality gate result and git commit hash, then commit.
+Goal: finalize `memory/v<N>.json` with quality gate result and git commit hash, commit, then hand off to the next session.
 
 ### Procedure
 
@@ -330,34 +339,37 @@ Examples:
 - `V3: 150 TFLOPS / 1.5 GB/s | XOR16 swizzle layout (bottleneck: ds_read bank conflict stall 12 cycles)`
 - `V5: revert V4 (occupancy 25% -> 12%)`
 
-## Stage 6: Stop-Condition Check or Next Iteration
+### Handoff to the next session
 
-Goal: decide whether to stop or return to Stage 1 for another iteration.
+Before exiting, record the "word for the next session" in `memory/v<N>.json` — this is how a fresh
+clean session (which has none of your conversation context) picks up where you left off:
 
-Default stop condition:
-
-```text
-utilization reaches >= 90% relative to the same-size baseline
-```
-
-If `README.md` or the user specifies a more concrete condition, use the more concrete condition.
-
-When stop conditions are met:
-
-- Output the final performance summary using the memory manager:
+- **`open_directions`** — up to **3** most-promising untried levers for the next session (fewer if you
+  found fewer), including any unfinished-but-promising thread you did not get to. These are *priors, not
+  orders*: the next session may pick one or choose a better lever it sees from a fresh profile.
 
   ```bash
-  python tools/memory_manager.py summary --workspace kernel_opt_<name>
+  python tools/memory_manager.py update --workspace kernel_opt_<name> --version v<N> \
+      --set 'open_directions=[{"direction":"<lever>","rationale":"<evidence/why promising>"}]'
   ```
 
-- Summarize key actions and gains for all versions.
-- Preserve `profiles/` so the evidence chain remains auditable.
+- **Dead-ends** — if this iteration regressed or led nowhere, record *why* in `search_log` /
+  `pitfalls_and_fixes` so the next session does not retry it.
+- **Profile-carry-forward** — if you committed, leave the post-edit profile in `profiles/v<N>/` so the
+  next session can reuse it instead of re-profiling.
 
-When stop conditions are not met:
+## End of Iteration
 
-- Return to Stage 1.
-- Read the latest unmasked `memory/v<N>.json` and `README.md`.
-- Profile the current version, extract the latest bottleneck, then search and plan the next iteration.
+This skill runs one iteration. After Stage 5, **exit** — do not return to Stage 1 and do not start another
+cycle. The orchestrator (`orchestrator/optimize.py`) reads `memory/v<N>.json`, decides whether the budget or
+stop conditions are met (default: peak utilization >= 90% on a committed, correctness-PASS iteration), and
+spawns the next clean session if needed.
+
+Print a one-line status and stop:
+
+```text
+v<N>: committed (+X.X%)   |   v<N>: reverted (<reason>)
+```
 
 ## Appendix: Tool-to-Evidence Mapping
 
@@ -372,7 +384,8 @@ Different tools provide different layers of evidence and must not be mixed:
 ## Appendix: Prohibited Actions
 
 - Do not skip `<gpu-wiki>/README.md`.
-- Do not start the next iteration without reading `README.md` and the latest unmasked `memory/v*.json` files.
+- Do not begin the iteration without reading `README.md` and the latest unmasked `memory/v*.json` files (including the previous `open_directions` and recorded dead-ends).
+- Do not loop: run exactly one iteration, then exit. The orchestrator spawns the next session.
 - Do not read `memory/v*.json` files where `masked: true` as active iteration data.
 - Do not reuse profile artifacts across versions.
 - Do not commit performance conclusions without correctness validation.

--- a/tools/memory_manager.py
+++ b/tools/memory_manager.py
@@ -99,6 +99,7 @@ SCHEMA_TEMPLATE = {
         "result": None,
         "failure_reason": None,
     },
+    "open_directions": [],
     "git_commit_hash": None,
 }
 
@@ -173,6 +174,13 @@ def parse_typed_value(raw_value: str) -> Any:
         return True
     if raw_value.lower() == "false":
         return False
+    # JSON arrays/objects (e.g. open_directions): --set 'open_directions=[{"direction":"...","rationale":"..."}]'
+    stripped = raw_value.strip()
+    if stripped[:1] in ("[", "{"):
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError:
+            pass
     try:
         return int(raw_value)
     except ValueError:


### PR DESCRIPTION
Move the outer optimization loop out of the markdown skills (where the model itself decided when to stop) into an external orchestrator that spawns a fresh `claude --print` session per iteration. State crosses sessions only on disk (memory/v<N>.json, plans/, profiles/, git); a regressing iteration reverts, so git HEAD is always the best kernel.

Termination is now mechanical and orchestrator-owned: a hard budget (max-iters OR token-budget) plus a target-utilization short-circuit. Each session runs exactly one profile -> edit -> validate -> bench cycle, then exits.

- orchestrator/optimize.py: loop owner; bounded subprocess sessions w/ process- group SIGKILL backstop; token accounting from stream-json; mechanical stop
- orchestrator/prompts/{iteration,setup}.md: one-cycle contract + run-once baseline
- reference/v_iteration.schema.json + tools/memory_manager.py: add forward-looking open_directions handoff field (<=3 leads); --set now parses JSON arrays
- skills/gpu-kernel-profile-optimizer/SKILL.md: drop Stage 6 self-loop; one iteration then exit; Stage 5 records open_directions + carries profile forward
- SKILL.md: Stage 2 reframed as orchestrator-driven; no in-session looping
- install.sh: retire Stop continuation/escalation hooks (fought clean-session); keep Pre/PostToolUse edit guards; --max-iterations now a deprecated no-op