### PR TITLE
convert: run inline (no subagent) + orchestrator bail detector + nest…

### DIFF
--- a/orchestrator/optimize.py
+++ b/orchestrator/optimize.py
@@ -54,6 +54,10 @@ PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
 WORKSPACE_INIT = REPO_ROOT / "reference" / "workspace_init.sh"
 SOL_SEED = REPO_ROOT / "reference" / "sol_seed.py"
 CONVERT_PERF_TOL = 0.05   # triton->gluon is a direct translation: gluon must be within +5% of triton
+CONVERT_MIN_TOKENS = 200_000  # a convert session below this (and no gluon) barely ran -> "bailed"
+                              # (set below a genuine-but-incomplete attempt, e.g. ~336K; the launch-and-
+                              # exit bail we saw was ~85K — only that class should trip the give-up)
+CONVERT_MAX_BAILS = 2         # consecutive bails -> disable escalation, continue triton-only
 
 
 def is_sol_op(op_dir: Path) -> bool:
@@ -185,8 +189,14 @@ def run_session(workspace: Path, prompt: str, timeout: int) -> SessionResult:
         "claude", "--print", "--verbose",
         "--output-format", "stream-json",
         "--session-id", session_id,
-        prompt,
     ]
+    # Route nested sessions to a specific settings profile (model/base-url/token) without touching
+    # the user's active ~/.claude/settings.json — e.g. run the experiment on a different backend
+    # than the monitoring session. Command-line --settings has higher precedence than user settings.
+    session_settings = os.environ.get("ATREX_SESSION_SETTINGS")
+    if session_settings:
+        cmd += ["--settings", session_settings]
+    cmd += [prompt]
     stdout, stderr, exit_status, timed_out = _run_bounded(cmd, cwd=workspace, timeout=timeout, env=_session_env())
     return SessionResult(
         exit_status=exit_status,
@@ -527,6 +537,7 @@ class Campaign:
         if stall > 0:
             print(f"[orchestrator] stall counter restored: {stall} rounds without progress", flush=True)
         infra_fails = 0  # consecutive sessions that crashed with 0 tokens (auth/infra issue)
+        convert_bails = 0  # consecutive convert sessions that bailed early (low tokens, no gluon)
         n = latest_version(self.workspace)  # 0 after baseline
         while True:
             if n >= self.max_iters:
@@ -611,6 +622,22 @@ class Campaign:
                     if read_memory(self.workspace, n) is None:
                         self._record_failed_convert(n, "convert session produced no committed gluon kernel")
                     print("[orchestrator] convert produced no committed gluon kernel; staying on triton", flush=True)
+                # Classify the failed convert. A "bail" (session barely ran — low tokens AND no gluon)
+                # is a model-compliance failure (e.g. launched work then exited), not a genuinely hard
+                # conversion. Retrying it identically just loops forever, so after a few bails disable
+                # the escalation and stay triton-only rather than burning cooldown cycles for nothing.
+                # A genuine attempt (did real work: extracted TTGIR, rewrote, validated) uses many tokens
+                # even when it fails parity — that resets the streak and keeps the learning-retry path.
+                if res.tokens < CONVERT_MIN_TOKENS:
+                    convert_bails += 1
+                    print(f"[orchestrator] convert v{n} bailed early ({res.tokens} tokens, no gluon) "
+                          f"[{convert_bails}/{CONVERT_MAX_BAILS}]", flush=True)
+                    if convert_bails >= CONVERT_MAX_BAILS:
+                        self.convert_after = 0  # disable escalation for the rest of this run
+                        print("[orchestrator] convert repeatedly bailed -> disabling triton->gluon "
+                              "escalation; continuing triton-only", flush=True)
+                else:
+                    convert_bails = 0
                 # A convert was issued -> reset the cooldown regardless of outcome; conversion
                 # re-fires only after another `convert_after` stalled rounds.
                 stall = 0

--- a/orchestrator/prompts/convert.md
+++ b/orchestrator/prompts/convert.md
@@ -5,6 +5,12 @@ This is a framework lowering, **not** an optimization: preserve the algorithm, t
 Gluon is a lower-level DSL, so the *following* sessions will optimize deeper — your job is to hand them
 a correct Gluon kernel. Do **one** conversion, then exit.
 
+**Do the conversion yourself, in THIS session — do not delegate it to a subagent.** The steps below are
+your work directly: read the sheet, extract TTGIR, rewrite `kernel.py`, validate, and commit or revert.
+(You may still spawn a short-lived helper for a narrow diagnostic — e.g. a profiler to explain a >5%
+regression — but the conversion itself is yours, and you must finish it before you exit. A session that
+launches work and exits early produces no v{{N}} and wastes the whole attempt.)
+
 ## Context
 - Workspace: `{{WORKSPACE}}` — your cwd, a git repo. **git HEAD is the best Triton kernel so far.**
 - You are producing version **v{{N}}** (previous: v{{PREV}}).
@@ -12,50 +18,71 @@ a correct Gluon kernel. Do **one** conversion, then exit.
 
 {{HARDWARE}}
 
-## Read first (one file, then source on demand)
-Read the single conversion sheet for the **real arch above** — do not read the others:
+## Step 0 — Learn from prior attempts (this may be a RETRY)
+Read `memory/v*.json` entries with `optimization.action_category="triton_to_gluon_conversion"`
+(`python tools/memory_manager.py read --workspace .`). The orchestrator re-issues conversion each time
+Triton re-plateaus, so earlier attempts may have failed or come out >5% slower — their
+`pitfalls_and_fixes` tell you which lowering to avoid. Take a **different** approach this time; do not
+repeat a recorded dead-end.
+
+## Step 1 — Read the ONE conversion sheet for the real arch above
+Read only the sheet for the **real arch** — do not read the others:
 - `sm_100` / `sm_103` (Blackwell data-center, B200/B300) → `{{GPU_WIKI}}/docs/converter/nvidia/blackwell.md`
 - `sm_90` (Hopper) → `{{GPU_WIKI}}/docs/converter/nvidia/hopper.md`
 - `gfx94*` (CDNA3) → `{{GPU_WIKI}}/docs/converter/amd/cdna3.md`; `gfx95*` (CDNA4) → `{{GPU_WIKI}}/docs/converter/amd/cdna4.md`
 
 The sheet gives the Triton→Gluon API map, the critical pitfalls, and **pointers to the exact local
 Triton source** (`reference-projects/triton`). Open that source only for the construct you are
-converting — do not re-derive the whole API.
+converting — do not re-derive the whole API or read other arches' sheets.
 
-## Do (delegate to the `gpu-kernel-convert` subagent — **wait for it to complete before exiting**)
-Launch the **`gpu-kernel-convert`** subagent with: workspace, version v{{N}}, the arch, the sheet path,
-and `kernel.py`. You may spawn it in the background, but **you MUST wait for it to complete before you
-exit**. If you exit before the subagent finishes, the conversion will be incomplete and the orchestrator
-will see no v2. You are responsible for the full conversion — do not exit until the subagent has reported
-back with its result (committed gluon kernel, or a recorded revert).
+## Step 2 — Extract TTGIR FIRST, before writing any Gluon
+`python tools/extract_ttgir.py <driver>.py -o v{{N}}.ttgir` (the driver must launch the kernel; the
+kernel's `__main__` profiling block works). Confirm the target matches the real arch (e.g. `cuda:100`).
+The Gluon kernel's layouts **must be the real `#blocked`/`#shared`/`#tmem` layouts from THIS kernel's
+TTGIR** — never fabricate them, and never lift the reference example's layouts/shapes (use the example
+for code *structure*, not its concrete layouts). Do not draft Gluon before this dump exists.
 
-The subagent must:
-0. **Learn from prior attempts** — this may be a RETRY. Read `memory/v*.json` entries with
-   `optimization.action_category="triton_to_gluon_conversion"` (`python tools/memory_manager.py read --workspace .`);
-   do NOT repeat a lowering a previous attempt recorded as failed or >5% slower — take a different approach.
-1. Extract real layouts from the current kernel: `python tools/extract_ttgir.py <driver>.py -o v{{N}}.ttgir` (confirm the target arch). Never fabricate layouts.
-2. Rewrite `kernel.py` to Gluon per the sheet — **same algorithm/tiling**, no new optimizations. If entry/deps change, keep `solution.json` in sync (Gluon still `languages:["triton"]`).
-3. Validate: `python -c "import kernel"` then `python test_kernel.py --version v{{N}}` — the real evaluator over EVERY workload with its own tolerance.
+## Step 3 — Rewrite `kernel.py` → Gluon (same algorithm, no optimization)
+Map loads → the arch's async/TMA + barrier pattern, matmuls → the arch's MMA + accumulator-residency
+pattern, and reproduce the original `num_stages` (nothing more). Keep the DPS `run(...)` signature
+(inputs then outputs). Change **only** `kernel.py`; if languages/deps/entry change, keep `solution.json`
+in sync (Gluon stays `languages:["triton"]`). Do **not** add tiling changes, split-K, fusion, or new
+pipelining — those are for later sessions.
+
+## Step 4 — Validate (the SOL harness is the only gate)
+`python -c "import kernel"` (compiles) → `timeout 1800 python test_kernel.py --version v{{N}}` (real
+evaluator, every workload, per-workload tolerance). Iterate on compile/correctness fixes only.
 
 ## Commit gate — correctness AND performance parity (±5%)
-A direct translation must be **as fast as the Triton kernel it came from** — same algorithm, same
-work. Commit only if BOTH hold:
-1. **All workloads PASS** (correctness).
-2. **Geomean kernel latency is within +5% of the Triton HEAD** you converted from (compare v{{N}}'s
-   `performance.latency_us` against v{{PREV}}'s in memory). Faster is fine; **>5% slower means the
-   conversion is defective** (missed async/TMA copy, wrong layout, register round-trip instead of
-   direct SMEM/TMEM) — fix it, don't accept it.
-- Both hold → `git commit -m "v{{N}}: triton->gluon conversion (no opt, perf parity)"`. This Gluon kernel becomes HEAD and unlocks the deeper Gluon phase.
-- Correctness FAIL or >5% slower after fix attempts → `git reset --hard HEAD` (restore the Triton kernel), record why in `memory/v{{N}}.json` (`pitfalls_and_fixes`), and exit.
+A direct translation preserves the algorithm and the work, so the Gluon kernel must be **as fast as the
+Triton kernel it came from**. Commit only if BOTH hold:
+1. **All workloads PASS** (correctness), and
+2. **Geomean kernel latency within +5% of the Triton HEAD** you converted from — compare v{{N}}'s
+   `performance.latency_us` against v{{PREV}}'s in memory. Faster is fine; **>5% slower means the
+   conversion is defective** (missed async/TMA copy, wrong/fabricated layout forcing extra conversions,
+   accumulator not resident in TMEM/registers, or a missing pipeline the Triton had) — **fix the specific
+   construct and re-measure; do not accept it.**
+
+- Both hold → `git commit -m "v{{N}}: triton->gluon conversion (no opt, perf parity)"`. This Gluon kernel
+  becomes HEAD and unlocks the deeper Gluon phase.
+- Correctness FAIL or >5% slower after fix attempts → `git reset --hard HEAD` (restore the Triton kernel),
+  record why in `memory/v{{N}}.json` (`pitfalls_and_fixes`), and exit.
 
 The orchestrator **mechanically re-checks this parity** and will revert a convert that committed a
 >5%-slower kernel — so do not commit a slow translation hoping it slips through.
 
-**Always write `memory/v{{N}}.json`** — success OR failure — with
-`optimization.action_category="triton_to_gluon_conversion"`, and on failure the exact cause (compile
-error / correctness mismatch / which construct made it >5% slower) in `pitfalls_and_fixes`. **Commit the
-record even on revert** (`git add memory/v{{N}}.json plans/ && git commit -m "v{{N}}: conversion reverted (<reason>)"`)
-so the next conversion attempt — after Triton plateaus again — learns from it. Then print one line and stop:
+## Constraints
+- Convert only — no optimization, no algorithm change, no shape bucketing.
+- Never fabricate layouts; extract from TTGIR or derive via the arch's documented helpers.
+- Never use another vendor's Gluon APIs (e.g. `gl.amd.*` on NVIDIA → unregistered-dialect crash).
+- Do not edit `test_kernel.py`, `definition.json`, `reference.py`, or `workload.jsonl`.
+
+## Record + finish (ALWAYS — success OR failure)
+**Always write `memory/v{{N}}.json`** with `optimization.action_category="triton_to_gluon_conversion"`,
+and on failure the exact cause (compile error / correctness mismatch / which construct made it >5% slower)
+in `pitfalls_and_fixes`. **Commit the record even on revert**
+(`git add memory/v{{N}}.json plans/ && git commit -m "v{{N}}: conversion reverted (<reason>)"`) so the
+next conversion attempt — after Triton plateaus again — learns from it. Then print one line and stop:
 ```
 v{{N}}: converted to gluon (PASS, <±X%> vs triton)   |   v{{N}}: conversion reverted (<reason>)
 ```


### PR DESCRIPTION
…ed-session settings routing

The Triton->Gluon convert session delegated to a gpu-kernel-convert subagent and had to wait for it before exiting; a weaker model launched the subagent then exited immediately (~85K tokens, no gluon committed), so convert never made progress and the escalation looped forever. Fold the full conversion methodology into convert.md so the session does the work itself (no subagent to abandon) — a lazy session now simply produces no gluon, which the existing git-HEAD gate handles as an ordinary rejected attempt.

Add a bail detector to the orchestrator: a failed convert with < CONVERT_MIN_TOKENS (200K) and no gluon is a 'bail' (barely ran); after CONVERT_MAX_BAILS (2) consecutive bails, disable the escalation and continue triton-only instead of looping. A genuine attempt (real token spend, even if it fails parity) resets the streak and keeps the learning-retry path. Convert reject now reverts to pre_head (the true incumbent).

Add ATREX_SESSION_SETTINGS: when set, nested claude sessions get --settings <path>, so a run can target a different backend/model than the monitoring session without touching ~/.claude/settings.json (no-op when unset).