### PR TITLE
feat: add sandbox-backed optimization and local gateway scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,25 @@ The installer detects supported runtime home directories and prepares local hook
 
 ![route2 optimization loop](assets/optimize_workflow.png)
 
-This route runs the optimization loop from the source repo without installing anything into your coding runtime. `orchestrator/optimize.py` owns the **outer loop** and spawns a fresh, clean session for each iteration over the same git workspace. State crosses the session boundary only through disk (`memory/v<N>.json`, `plans/`, `profiles/`, and git), and HEAD is always the best kernel.
+This route runs the optimization loop from the source repo without installing anything into your coding runtime. `orchestrator/optimize.py` owns the **outer loop** and spawns a fresh, clean Claude or Qoder CLI session for each iteration over the same git workspace. Select the backend with `--agent-cli claude|qodercli` (default: `claude`). State crosses the session boundary only through disk (`memory/v<N>.json`, `plans/`, `profiles/`, and git), and HEAD is always the best kernel.
+
+Correctness/performance validation and profiling run on an atrex-gpu-gateway sandbox selected by
+`--sandbox-hardware`. The gateway worker receives code and test/profile inputs only: optimizer `memory/`, plans,
+edits, and Git state remain local. Structured test results and profile analysis artifacts are returned to the
+local session. The same transport can be used directly:
+
+```bash
+python tools/sandbox.py --hardware REMOTE_GPU --no-sync -- python test_kernel.py --no-memory
+python tools/sandbox.py --hardware REMOTE_GPU --sync profiles/v1 -- \
+  bash tools/profile_nvidia.sh kernel.py --output-dir profiles/v1 --source
+
+# Same interface on a localhost GPU gateway (`atrex-gateway serve --local`)
+python tools/sandbox.py --hardware local --url http://127.0.0.1:8000 \
+  --no-sync -- python test_kernel.py --no-memory
+```
+
+Local gateway mode preserves the request/packaging/result interface but is not a security sandbox:
+submitted commands run directly as the server user. Use `atrex-gateway serve --local` only with trusted code.
 
 Termination is **mechanical**, not left to in-session judgment: the loop stops on a hard budget (max iterations or token budget) or a target-utilization short-circuit on a committed, correctness-passing iteration.
 
@@ -75,12 +93,24 @@ Key options:
 ```bash
 --max-iters N        # Hard cap on optimization iterations
 --token-budget N     # Hard token cap across all sessions (0 = no cap)
+--agent-cli CLI      # Optimization session backend: claude (default) or qodercli
 --target-util PCT    # Peak-utilization %% short-circuit (default 90)
+--sandbox-hardware GPU # agate scheduler token for tests/profiles, e.g. REMOTE_GPU
+--sandbox-profile P  # Optional pre/prod endpoint; default uses agate config
+--sandbox-url URL    # Explicit endpoint; use http://127.0.0.1:8000 with hardware=local
+--sandbox-timeout S  # Remote command timeout, max 600 seconds
 --workspace DIR      # Working directory for the campaign (default: current directory)
 --max-stall N        # Stop after N consecutive no-commit iterations (0 = disabled)
 --convert-after N    # Triton only: after N stalled iters, run one Triton->Gluon convert session
 --arch ARCH          # Override auto-detected runtime arch, e.g. sm_103 or gfx942
 ```
+
+Both backends run non-interactively with a fresh session ID and the same workspace-local skills,
+agents, prompts, sandbox constraints, and quality gates. Authenticate the selected CLI first with
+`claude auth status` or `qodercli status`. Provider-specific settings can be supplied through
+`ATREX_CLAUDE_SESSION_SETTINGS` or `ATREX_QODER_SESSION_SETTINGS`; `ATREX_SESSION_SETTINGS` remains
+the generic fallback. Some Qoder models report zero token usage in stream JSON; in that case
+`--token-budget` cannot be enforced and `--max-iters` remains the hard campaign bound.
 
 ## Main Files
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,16 @@ python tools/sandbox.py --hardware REMOTE_GPU --no-sync -- python test_kernel.py
 python tools/sandbox.py --hardware REMOTE_GPU --sync profiles/v1 -- \
   bash tools/profile_nvidia.sh kernel.py --output-dir profiles/v1 --source
 
-# Same interface on a localhost GPU gateway (`atrex-gateway serve --local`)
+# Same interface on the bundled localhost FIFO scheduler
+# Start it first with: python tools/local_gateway.py serve
 python tools/sandbox.py --hardware local --url http://127.0.0.1:8000 \
   --no-sync -- python test_kernel.py --no-memory
 ```
 
 Local gateway mode preserves the request/packaging/result interface but is not a security sandbox:
-submitted commands run directly as the server user. Use `atrex-gateway serve --local` only with trusted code.
+submitted commands run directly as the server user. The bundled scheduler serializes jobs by default,
+persists their status in SQLite, and speaks the same public `agate dev`/jobs API. See
+[docs/local_gateway.md](docs/local_gateway.md) for startup, queue, cancellation, and compatibility details.
 
 Termination is **mechanical**, not left to in-session judgment: the loop stops on a hard budget (max iterations or token budget) or a target-utilization short-circuit on a committed, correctness-passing iteration.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -229,8 +229,11 @@ structured `RESULT_JSON` output.
 
 The execution endpoint is independent of the workflow. Remote gateways can be selected through agate
 configuration or `--sandbox-profile`; `--sandbox-url http://127.0.0.1:8000` together with
-`--sandbox-hardware local` targets `atrex-gateway serve --local`. Both modes use the same packaging,
-result parsing, artifact synchronization, and execution-boundary rules.
+`--sandbox-hardware local` targets either atrex-gateway's localhost backend or the bundled
+`tools/local_gateway.py` community scheduler. Both modes use the same packaging, result parsing, artifact
+synchronization, and execution-boundary rules. The community scheduler persists the public job model in
+SQLite and consumes `dev` commands FIFO with one worker by default, preventing concurrent local campaigns
+from contending for the same GPU.
 Local mode is transport-compatible but not an isolation boundary: the server executes submitted commands
 as its current user and therefore must only accept trusted code.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -222,6 +222,18 @@ The subagent must:
 
 Each optimization iteration follows the profile optimizer Skill.
 
+For the orchestrated route, all GPU execution crosses `tools/sandbox.py`: `--sandbox-hardware` selects the
+agate worker, tests run with `--no-memory`, and profiler analysis artifacts are synchronized from the worker.
+`memory/`, plans, source edits, and Git remain local; the local session records metrics from the test's
+structured `RESULT_JSON` output.
+
+The execution endpoint is independent of the workflow. Remote gateways can be selected through agate
+configuration or `--sandbox-profile`; `--sandbox-url http://127.0.0.1:8000` together with
+`--sandbox-hardware local` targets `atrex-gateway serve --local`. Both modes use the same packaging,
+result parsing, artifact synchronization, and execution-boundary rules.
+Local mode is transport-compatible but not an isolation boundary: the server executes submitted commands
+as its current user and therefore must only accept trusted code.
+
 Important rules:
 
 - Official profile evidence is required before code changes.

--- a/docs/local_gateway.md
+++ b/docs/local_gateway.md
@@ -1,0 +1,79 @@
+# Community Local Gateway
+
+`tools/local_gateway.py` is a small, standard-library-only scheduler for maintaining and testing the
+localhost optimization path without a deployed atrex-gateway server. It implements the public HTTP shapes
+used by `agate dev` and `tools/sandbox.py`, and queues local GPU commands FIFO.
+
+## Start the Server
+
+Run it from the repository root in the Python environment that contains the workload's GPU stack:
+
+```bash
+python tools/local_gateway.py serve \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --state-dir .atrex-local-gateway
+```
+
+The default `--workers 1` serializes commands for one local GPU. A larger value enables parallel command
+execution and should only be used when the machine and workloads can safely share the device.
+
+The state directory contains `jobs.db`, per-job uploaded files, stdout, and stderr. Queued jobs survive a
+restart. A job that was running when the server stopped is marked failed on the next start rather than being
+silently executed twice.
+
+## Use the Existing Clients
+
+The regular `agate` client needs no special adapter:
+
+```bash
+agate health --url http://127.0.0.1:8000
+agate list hw --url http://127.0.0.1:8000
+
+agate dev "python -c 'import torch; print(torch.cuda.get_device_capability())'" \
+  --url http://127.0.0.1:8000 --gpu local
+```
+
+Submission, queue inspection, long polling, and cancellation use the normal commands:
+
+```bash
+agate dev "sleep 30" --url http://127.0.0.1:8000 --gpu local --no-wait
+agate jobs --url http://127.0.0.1:8000
+agate get <job_id> --url http://127.0.0.1:8000 --wait
+agate cancel <job_id> --url http://127.0.0.1:8000
+```
+
+The optimizer continues to use `tools/sandbox.py`, so correctness, performance, and profiler commands have
+the same packaging and artifact-return behavior as a remote gateway:
+
+```bash
+python orchestrator/optimize.py \
+  --op-dir /path/to/operator \
+  --platform LOCAL_GPU --framework Triton \
+  --sandbox-hardware local \
+  --sandbox-url http://127.0.0.1:8000
+```
+
+## Compatibility Surface
+
+The community scheduler implements:
+
+- `GET /healthz`
+- `GET /v1/env` and `GET /v1/env/local`
+- `POST /v1/jobs/dev`, including uploaded text files, environment variables, timeouts, and idempotency keys
+- `GET /v1/jobs` with the standard kind/user/status/limit filters
+- `GET /v1/jobs/<job_id>`, including `wait=true&timeout=<seconds>` long polling
+- `POST /v1/jobs/<job_id>/cancel`
+- legacy `GET /v1/evals/<job_id>` polling compatibility
+
+Specialized `eval`, `profile`, and `disassemble` submissions return a structured HTTP 501
+`kind_not_supported` response. The repository does not depend on those routes: `tools/sandbox.py` submits
+self-contained correctness, performance, and profiler work as `dev` commands. Keeping unsupported routes
+explicit avoids pretending that the community scheduler reproduces server-side evaluator internals.
+
+## Security Boundary
+
+This server is not a container or privilege boundary. Uploaded files and commands execute as the account
+running the server, and job payloads and output remain in the state directory. The server rejects a
+non-loopback bind unless `--allow-remote` is supplied, but that flag does not add authentication or
+isolation. Use trusted inputs and keep the default loopback bind.

--- a/docs/local_gateway.md
+++ b/docs/local_gateway.md
@@ -15,6 +15,13 @@ python tools/local_gateway.py serve \
   --state-dir .atrex-local-gateway
 ```
 
+If an existing workflow uses a hardware token instead of `local`, register it as an alias without changing
+the optimizer arguments:
+
+```bash
+python tools/local_gateway.py serve --gpu-alias YOUR_GPU_TOKEN
+```
+
 The default `--workers 1` serializes commands for one local GPU. A larger value enables parallel command
 execution and should only be used when the machine and workloads can safely share the device.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -58,21 +58,23 @@ run through `tools/sandbox.py` on `--sandbox-hardware`; `memory/` and Git stay l
 submittable SOL-ExecBench output after a passing run. Omit `--agent-cli` to use Claude, or pass
 `--agent-cli qodercli` after authenticating with `qodercli status`.
 
-To use the same gateway interface on a local GPU, run the server in a Python 3.12+ environment:
+To use the same gateway interface on a local GPU, start the bundled community scheduler. It has no
+third-party Python dependencies:
 
 ```bash
-pip install atrex-gateway-server==0.1.0 \
-  --index-url "${PYPI_INDEX_URL}" \
-  --extra-index-url "${PYPI_EXTRA_INDEX_URL}" \
-  --trusted-host "${PYPI_HOST}"
-atrex-gateway serve --local
+python tools/local_gateway.py serve \
+  --host 127.0.0.1 --port 8000 \
+  --state-dir .atrex-local-gateway
 ```
 
-`--local` provides interface compatibility, not process isolation: submitted code runs directly as the
-server user. Bind it to localhost and submit trusted code only.
-The local worker also inherits the server process's Python/toolchain environment. Install `torch`, Triton,
-and any kernel DSL needed by the workload into that same Python 3.12+ environment; otherwise `agate run`
-will fail during candidate/reference import.
+The default single worker executes jobs FIFO, so concurrent optimizer requests queue instead of contending
+for the GPU. `agate dev`, `agate get/jobs/cancel`, long polling, environment discovery, and
+`tools/sandbox.py` use the same HTTP shapes as atrex-gateway. See [local_gateway.md](local_gateway.md) for
+the exact compatibility surface.
+
+This is interface compatibility, not process isolation: submitted code runs directly as the server user.
+Bind it to localhost and submit trusted code only. The worker inherits the server process's Python/toolchain
+environment, so install `torch`, Triton, and any kernel DSL needed by the workload into that environment.
 
 Then select the localhost endpoint and the server's `local` GPU alias:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,13 +7,14 @@ AKA ships two independent ways to run the same profile-driven workflow. Use the 
 - `bash`
 - `git`
 - A compatible coding runtime installed
+- `agate` (`atrex-gateway-client`) configured with gateway URL and credentials
 - NVIDIA profiling: `ncu`, wrapped by `tools/profile_nvidia.sh`
 - AMD profiling: `rocprofv3`, wrapped by `tools/profile_kernel.sh`
 
 Route-specific prerequisites:
 
 - Route 1 requires `jq` for `install.sh`.
-- Route 2 requires Python 3, `torch`, and the `claude` CLI available on `PATH`.
+- Route 2 requires Python 3, `torch`, and either `claude` or `qodercli` available on `PATH`.
 
 ## 1. Clone the Repository
 
@@ -46,11 +47,47 @@ Run a single-operator campaign directly against a SOL-ExecBench op directory con
 ```bash
 python orchestrator/optimize.py \
     --op-dir /path/to/sol-execbench/op \
-    --platform H20 --framework CuteDSL \
+    --platform TARGET_GPU --sandbox-hardware REMOTE_GPU --framework CuteDSL \
+    --agent-cli qodercli \
     --max-iters 20 --token-budget 8000000 --target-util 90
 ```
 
-The orchestrator initializes its required submodules on first run, creates `kernel_opt_<name>/` under `--workspace` or the current directory, spawns fresh clean sessions per iteration, and finalizes a directly submittable SOL-ExecBench output after a passing run.
+The orchestrator initializes its required submodules on first run, creates `kernel_opt_<name>/` under
+`--workspace` or the current directory, and spawns fresh clean sessions per iteration. GPU tests and profiles
+run through `tools/sandbox.py` on `--sandbox-hardware`; `memory/` and Git stay local. It finalizes a directly
+submittable SOL-ExecBench output after a passing run. Omit `--agent-cli` to use Claude, or pass
+`--agent-cli qodercli` after authenticating with `qodercli status`.
+
+To use the same gateway interface on a local GPU, run the server in a Python 3.12+ environment:
+
+```bash
+pip install atrex-gateway-server==0.1.0 \
+  --index-url "${PYPI_INDEX_URL}" \
+  --extra-index-url "${PYPI_EXTRA_INDEX_URL}" \
+  --trusted-host "${PYPI_HOST}"
+atrex-gateway serve --local
+```
+
+`--local` provides interface compatibility, not process isolation: submitted code runs directly as the
+server user. Bind it to localhost and submit trusted code only.
+The local worker also inherits the server process's Python/toolchain environment. Install `torch`, Triton,
+and any kernel DSL needed by the workload into that same Python 3.12+ environment; otherwise `agate run`
+will fail during candidate/reference import.
+
+Then select the localhost endpoint and the server's `local` GPU alias:
+
+```bash
+python orchestrator/optimize.py \
+    --op-dir /path/to/sol-execbench/op \
+    --platform LOCAL_GPU --framework Triton \
+    --sandbox-hardware local \
+    --sandbox-url http://127.0.0.1:8000 \
+    --max-iters 20
+```
+
+`--sandbox-url` and `--sandbox-profile` are mutually exclusive. The localhost mode changes only where
+agate executes jobs; tests and profiles still go through `tools/sandbox.py`, while `memory/`, plans, edits,
+and Git remain workspace-local.
 
 ## 3. Inspect Outputs
 

--- a/orchestrator/optimize.py
+++ b/orchestrator/optimize.py
@@ -4,10 +4,10 @@
 Owns the OUTER optimization loop so termination no longer depends on the model's
 in-session judgment (the old Stage-6 "is README's Stop Conditions met?" self-call).
 
-Each iteration is a **fresh `claude` session** (`--print`, new `--session-id`) over the
-*same* git workspace. State crosses the session boundary only through disk — exactly the
-artifacts atrex already maintains: `memory/v<N>.json`, `plans/`, `profiles/`, and git.
-HEAD is always the best kernel (a regressing iteration reverts and is never committed).
+Each iteration is a **fresh coding-agent session** (`claude` by default, or `qodercli` via
+`--agent-cli`) over the *same* git workspace. State crosses the session boundary only through
+disk — exactly the artifacts atrex already maintains: `memory/v<N>.json`, `plans/`, `profiles/`,
+and git. HEAD is always the best kernel (a regressing iteration reverts and is never committed).
 
 Termination policy
 ------------------
@@ -25,7 +25,8 @@ Usage
     # single operator (default, unchanged):
     python orchestrator/optimize.py \
         --name mla_decode --kernel-demo /path/to/demo.py \
-        --platform H20 --framework CuteDSL \
+        --platform TARGET_GPU --sandbox-hardware REMOTE_GPU --framework CuteDSL \
+        --agent-cli qodercli \
         --max-iters 20 --token-budget 8000000 --target-util 90
 
     # whole LLM layer (optional decomposition overlay):
@@ -43,11 +44,14 @@ import json
 import os
 import random
 import re
+import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -55,6 +59,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
 WORKSPACE_INIT = REPO_ROOT / "reference" / "workspace_init.sh"
 SOL_SEED = REPO_ROOT / "reference" / "sol_seed.py"
+SANDBOX_TOOL = REPO_ROOT / "tools" / "sandbox.py"
 HUMANIZE_DIR = REPO_ROOT / "3rdparty" / "humanize"
 CONVERT_PERF_TOL = 0.05   # triton->gluon is a direct translation: gluon must be within +5% of triton
 CONVERT_MIN_TOKENS = 200_000  # a convert session below this (and no gluon) barely ran -> "bailed"
@@ -62,6 +67,8 @@ CONVERT_MIN_TOKENS = 200_000  # a convert session below this (and no gluon) bare
                               # exit bail we saw was ~85K — only that class should trip the give-up)
 CONVERT_MAX_BAILS = 2         # consecutive bails -> disable escalation, continue triton-only
 MEMORY_MASK_INTERVAL = 100    # periodically drop half of active optimization history
+TEST_RESULT_PREFIX = "[test_kernel] RESULT_JSON="
+AGENT_CLI_CHOICES = ("claude", "qodercli")
 
 
 def is_sol_op(op_dir: Path) -> bool:
@@ -122,11 +129,16 @@ def _tokens_from_stream(stdout: str) -> int:
         if not isinstance(u, dict):
             return 0
         return int(
-            (u.get("input_tokens") or 0)
-            + (u.get("output_tokens") or 0)
-            + (u.get("cache_creation_input_tokens") or 0)
-            + (u.get("cache_read_input_tokens") or 0)
+            (u.get("input_tokens") or u.get("inputTokens") or 0)
+            + (u.get("output_tokens") or u.get("outputTokens") or 0)
+            + (u.get("cache_creation_input_tokens") or u.get("cacheCreationInputTokens") or 0)
+            + (u.get("cache_read_input_tokens") or u.get("cacheReadInputTokens") or 0)
         )
+
+    def _model_usage_tokens(model_usage: dict) -> int:
+        if not isinstance(model_usage, dict):
+            return 0
+        return sum(_usage_tokens(usage) for usage in model_usage.values())
 
     result_total = None
     summed = 0
@@ -140,14 +152,16 @@ def _tokens_from_stream(stdout: str) -> int:
             continue
         if not isinstance(evt, dict):
             continue
-        if evt.get("type") == "result" and isinstance(evt.get("usage"), dict):
-            result_total = _usage_tokens(evt["usage"])
+        if evt.get("type") == "result":
+            usage_total = _usage_tokens(evt.get("usage"))
+            model_total = _model_usage_tokens(evt.get("modelUsage"))
+            result_total = usage_total or model_total
         usage = evt.get("usage")
         if usage is None and isinstance(evt.get("message"), dict):
             usage = evt["message"].get("usage")
         if isinstance(usage, dict):
             summed += _usage_tokens(usage)
-    return result_total if result_total is not None else summed
+    return result_total if result_total else summed
 
 
 def _run_bounded(cmd: list[str], cwd: Path, timeout: int, env: Optional[dict] = None) -> tuple[str, str, int, bool]:
@@ -174,16 +188,61 @@ def _run_bounded(cmd: list[str], cwd: Path, timeout: int, env: Optional[dict] = 
     return stdout or "", stderr or "", proc.returncode, timed_out
 
 
-def _session_env() -> dict:
-    """Env for a nested `claude` session. When a Bearer auth token is available
-    (ANTHROPIC_AUTH_TOKEN — e.g. an Anthropic-compatible gateway), drop ANTHROPIC_API_KEY so the
-    CLI authenticates via the token instead of sending x-api-key, which such gateways reject
-    with 401. On a plain api-key setup (no auth token) nothing is removed.
+def _session_env(agent_cli: str) -> dict:
+    """Build the environment for a nested coding-agent session.
+
+    Claude-specific auth normalization is deliberately not applied to Qoder CLI. When a Bearer
+    auth token is available for Claude (ANTHROPIC_AUTH_TOKEN — e.g. an Anthropic-compatible
+    gateway), drop ANTHROPIC_API_KEY so Claude authenticates via the token instead of sending
+    x-api-key, which such gateways reject with 401.
     """
     env = os.environ.copy()
-    if env.get("ANTHROPIC_AUTH_TOKEN"):
+    if agent_cli == "claude" and env.get("ANTHROPIC_AUTH_TOKEN"):
         env.pop("ANTHROPIC_API_KEY", None)
     return env
+
+
+def _session_command(agent_cli: str, prompt: str, session_id: str) -> list[str]:
+    """Return a non-interactive, fresh-session command for the selected coding CLI."""
+    if agent_cli == "claude":
+        cmd = [
+            "claude", "--print", "--verbose",
+            "--dangerously-skip-permissions",
+            "--output-format", "stream-json",
+            "--session-id", session_id,
+            "--effort", "max",
+        ]
+        provider_settings = "ATREX_CLAUDE_SESSION_SETTINGS"
+    elif agent_cli == "qodercli":
+        cmd = [
+            "qodercli", "--print",
+            "--dangerously-skip-permissions",
+            "--output-format", "stream-json",
+            "--session-id", session_id,
+            "--no-session-persistence",
+            "--reasoning-effort", "max",
+        ]
+        provider_settings = "ATREX_QODER_SESSION_SETTINGS"
+    else:
+        raise ValueError(f"unsupported agent CLI: {agent_cli!r}")
+
+    # Provider-specific settings win. ATREX_SESSION_SETTINGS remains the backward-compatible
+    # generic fallback and is interpreted by whichever CLI was selected.
+    session_settings = os.environ.get(provider_settings) or os.environ.get("ATREX_SESSION_SETTINGS")
+    if session_settings:
+        cmd += ["--settings", session_settings]
+    # Both supported CLIs accept Claude-compatible local plugins. humanize is loaded from the
+    # source submodule rather than installed into the user's global runtime.
+    if (HUMANIZE_DIR / "skills" / "humanize-gen-plan" / "SKILL.md").exists():
+        cmd += ["--plugin-dir", str(HUMANIZE_DIR)]
+    cmd.append(prompt)
+    return cmd
+
+
+def _agent_auth_hint(agent_cli: str) -> str:
+    if agent_cli == "qodercli":
+        return "run `qodercli status` and `qodercli --print \"test\"` to diagnose"
+    return "run `claude auth status` and `claude --print \"test\"` to diagnose"
 
 
 def ensure_submodules() -> None:
@@ -214,29 +273,30 @@ def ensure_submodules() -> None:
     print("[orchestrator] all submodules ready", flush=True)
 
 
-def run_session(workspace: Path, prompt: str, timeout: int) -> SessionResult:
-    """One clean `claude` session. Fresh session-id = no memory of prior sessions."""
+def run_session(
+    workspace: Path,
+    prompt: str,
+    timeout: int,
+    agent_cli: str = "claude",
+    sandbox_hardware: str = "",
+    sandbox_profile: str = "",
+    sandbox_url: str = "",
+    sandbox_timeout: int = 600,
+) -> SessionResult:
+    """Run one clean coding-agent session with no conversational memory from prior iterations."""
     session_id = str(uuid.uuid4())
-    cmd = [
-        "claude", "--print", "--verbose",
-        "--dangerously-skip-permissions",
-        "--output-format", "stream-json",
-        "--session-id", session_id,
-        "--effort", "max",
-    ]
-    # Route nested sessions to a specific settings profile (model/base-url/token) without touching
-    # the user's active ~/.claude/settings.json — e.g. run the experiment on a different backend
-    # than the monitoring session. Command-line --settings has higher precedence than user settings.
-    session_settings = os.environ.get("ATREX_SESSION_SETTINGS")
-    if session_settings:
-        cmd += ["--settings", session_settings]
-    # humanize is loaded via --plugin-dir pointing to the local 3rdparty submodule;
-    # it is NOT installed as a skill in .claude/skills/.
-    if (HUMANIZE_DIR / "skills" / "humanize-gen-plan" / "SKILL.md").exists():
-        cmd += ["--plugin-dir", str(HUMANIZE_DIR)]
-    cmd.append(prompt)
-    env = _session_env()
+    cmd = _session_command(agent_cli, prompt, session_id)
+    env = _session_env(agent_cli)
     env["IS_SANDBOX"] = "1"
+    if sandbox_hardware:
+        env["ATREX_SANDBOX_GPU"] = sandbox_hardware
+    if sandbox_url:
+        env["ATREX_SANDBOX_URL"] = sandbox_url
+        env.pop("ATREX_SANDBOX_PROFILE", None)
+    elif sandbox_profile:
+        env["ATREX_SANDBOX_PROFILE"] = sandbox_profile
+        env.pop("ATREX_SANDBOX_URL", None)
+    env["ATREX_SANDBOX_TIMEOUT"] = str(sandbox_timeout)
     stdout, stderr, exit_status, timed_out = _run_bounded(cmd, cwd=workspace, timeout=timeout, env=env)
     return SessionResult(
         exit_status=exit_status,
@@ -245,6 +305,114 @@ def run_session(workspace: Path, prompt: str, timeout: int) -> SessionResult:
         stdout_tail=stdout[-2000:],
         stderr_tail=stderr[-2000:],
     )
+
+
+def sandbox_directive(hardware: str, profile: str = "", url: str = "") -> str:
+    """Mandatory execution boundary injected into every optimization session."""
+    if url:
+        endpoint = f" using gateway URL `{url}`"
+    elif profile:
+        endpoint = f" using gateway profile `{profile}`"
+    else:
+        endpoint = " using agate's configured gateway"
+    return (
+        "## GPU sandbox execution (mandatory)\n\n"
+        f"- Target gateway hardware: **{hardware}**{endpoint}. All GPU execution must cross this "
+        "gateway boundary, including when the endpoint is localhost; source edits, optimizer state, and "
+        "Git operations remain in the workspace.\n"
+        "- Run every correctness or performance test through the gateway sandbox. Always pass `--no-memory`; "
+        "read the emitted `[test_kernel] RESULT_JSON=...` line, then update `memory/v<N>.json` locally.\n"
+        "  ```bash\n"
+        "  python tools/sandbox.py --no-sync -- python test_kernel.py --version v<N> --no-memory\n"
+        "  python tools/sandbox.py --no-sync -- python test_kernel.py --version v<N> --multi-seed 5 --no-memory\n"
+        "  ```\n"
+        "- Run NVIDIA/AMD profiling in the sandbox as one self-contained command; `profiles/` analysis "
+        "artifacts are synchronized back automatically:\n"
+        "  ```bash\n"
+        "  python tools/sandbox.py --sync profiles/v<N> -- bash tools/profile_nvidia.sh profiles/v<N>/harness/profile_driver.py --output-dir profiles/v<N> --source\n"
+        "  python tools/sandbox.py --sync profiles/v<N> -- bash tools/profile_kernel.sh profiles/v<N>/harness/profile_driver.py --output-dir profiles/v<N>\n"
+        "  ```\n"
+        "- Never run `test_kernel.py`, GPU timers, `ncu`, `rocprofv3`, or the profile wrappers outside "
+        "the gateway interface. Never upload or create optimizer `memory/` as worker state; memory updates, "
+        "plans, edits, and git operations stay local.\n"
+    )
+
+
+def _sandbox_command(
+    workspace: Path,
+    hardware: str,
+    profile: str,
+    url: str,
+    timeout: int,
+    command: list[str],
+    *,
+    sync: tuple[str, ...] = (),
+) -> subprocess.CompletedProcess[str]:
+    """Run one command through tools/sandbox.py and capture its user-visible output."""
+    cmd = [
+        sys.executable, str(SANDBOX_TOOL),
+        "--hardware", hardware,
+        "--workspace", str(workspace),
+        "--timeout", str(timeout),
+    ]
+    if url:
+        cmd += ["--url", url]
+    elif profile:
+        cmd += ["--gateway-profile", profile]
+    if sync:
+        for path in sync:
+            cmd += ["--sync", path]
+    else:
+        cmd.append("--no-sync")
+    cmd += ["--", *command]
+    return subprocess.run(
+        cmd,
+        cwd=str(workspace),
+        capture_output=True,
+        text=True,
+        timeout=timeout + 240,
+    )
+
+
+def _test_result_from_stdout(stdout: str) -> dict:
+    """Read the structured result emitted by reference/test_kernel.py."""
+    for line in reversed(stdout.splitlines()):
+        if line.startswith(TEST_RESULT_PREFIX):
+            result = json.loads(line[len(TEST_RESULT_PREFIX):])
+            if isinstance(result, dict):
+                return result
+    raise RuntimeError("sandbox test output has no structured RESULT_JSON line")
+
+
+def _record_local_test_result(workspace: Path, version: str, result: dict) -> Path:
+    """Merge a remote --no-memory test result into local optimizer memory."""
+    mem_dir = workspace / "memory"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    path = mem_dir / f"{version}.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+    except (OSError, json.JSONDecodeError):
+        data = {}
+    data.setdefault("version", version)
+    data.setdefault("masked", False)
+    data["timestamp"] = datetime.now(timezone.utc).isoformat()
+    perf = data.setdefault("performance", {})
+    perf["latency_us"] = result.get("latency_us_geomean", 0.0)
+    perf["latency_us_geomean"] = result.get("latency_us_geomean", 0.0)
+    perf["latency_us_arith_mean"] = result.get("latency_us_arith_mean", 0.0)
+    perf["latency_us_by_shape"] = result.get("latency_us_by_shape", {})
+    perf["speedup_vs_ref_geomean"] = result.get("speedup_vs_ref_geomean", 0.0)
+    all_pass = bool(result.get("all_pass"))
+    corr = data.setdefault("correctness", {})
+    corr["status"] = "PASS" if all_pass else "FAIL"
+    corr["max_abs_err"] = result.get("max_abs_err", 0.0)
+    corr["max_rel_err"] = result.get("max_rel_err", 0.0)
+    gate = data.setdefault("quality_gate", {})
+    gate["result"] = "PASS" if all_pass else "FAIL"
+    failures = result.get("failures") or []
+    gate["failure_reason"] = None if all_pass else "; ".join(map(str, failures))[:2000]
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return path
 
 
 # ── workspace / memory readers ────────────────────────────────────────────────
@@ -481,12 +649,17 @@ def incumbent_latency(workspace: Path, upto_n: int) -> Optional[float]:
     return best
 
 
-def detect_arch() -> str:
+def detect_arch(
+    sandbox_hardware: str = "",
+    sandbox_profile: str = "",
+    sandbox_url: str = "",
+) -> str:
     """Return the real runtime GPU architecture token (vendor-neutral), or '' if undetectable.
 
     NVIDIA/CUDA -> 'sm_<cap>' (e.g. 'sm_103'); AMD/ROCm -> the gfx arch (e.g. 'gfx942').
     Uses torch (get_device_capability / gcnArchName) — the AUTHORITATIVE source, which stays
-    correct even when the GPU name / vendor SMI is DESENSITIZED (e.g. a B300 reporting as 'L20D').
+    correct even when the GPU name / vendor SMI is DESENSITIZED (e.g. a target GPU reporting a
+    generic compatibility alias).
     """
     code = (
         "import torch\n"
@@ -496,6 +669,29 @@ def detect_arch() -> str:
         "else:\n"
         "    c=torch.cuda.get_device_capability(0); print('sm_%d%d'%(c[0],c[1]))\n"
     )
+    if sandbox_hardware:
+        try:
+            with tempfile.TemporaryDirectory(prefix="atrex-arch-") as temp_dir:
+                result = _sandbox_command(
+                    Path(temp_dir), sandbox_hardware, sandbox_profile, sandbox_url, 120,
+                    ["python", "-c", code],
+                )
+            if result.returncode == 0:
+                for line in reversed(result.stdout.splitlines()):
+                    value = line.strip()
+                    if re.fullmatch(r"sm_\d+|gfx[0-9a-fA-F]+", value):
+                        return value
+            print(
+                f"[orchestrator] WARNING: sandbox arch detection failed on {sandbox_hardware}: "
+                f"{result.stderr[-1000:]}",
+                file=sys.stderr,
+                flush=True,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            print(f"[orchestrator] WARNING: sandbox arch detection failed: {exc}",
+                  file=sys.stderr, flush=True)
+        return ""
+
     for py in ("python", "python3", sys.executable):
         try:
             out = subprocess.run([py, "-c", code], capture_output=True, text=True, timeout=120)
@@ -539,39 +735,34 @@ def link_runtime(workspace: Path) -> None:
     The gpu-kernel-* skills reference these by relative path; sessions run with cwd=workspace,
     so symlink them in (absolute targets, so the workspace can live anywhere). Idempotent.
 
-    Also installs agent definitions into ``.claude/`` so inner ``claude`` sessions can discover
-    subagents (gpu-kernel-baseline, gpu-kernel-profiler, etc.).
+    Also installs the same skills and agent definitions into ``.claude/`` and ``.qoder/`` so
+    either supported coding CLI can discover them.
 
     humanize is loaded via ``--plugin-dir`` (see ``run_session``); it is NOT installed as a
-    skill into ``.claude/skills/``.
+    workspace skill.
     """
     for sub in ("tools", "reference", "skills", "reference-projects", "gpu-wiki"):
         src, dst = REPO_ROOT / sub, workspace / sub
         if src.exists() and not dst.exists():
             os.symlink(src, dst)
-    # ── .claude/ skills ──
-    claude_dir = workspace / ".claude"
-    claude_skills_dir = claude_dir / "skills"
-    claude_agents_dir = claude_dir / "agents"
-    claude_skills_dir.mkdir(parents=True, exist_ok=True)
-    # Link 3rdparty/ncu-report-skill into .claude/skills/ so `claude` sessions can use it
+    # Claude and Qoder use parallel project-local discovery roots. Keep their contents identical
+    # so selecting a different --agent-cli does not change the available optimization knowledge.
     ncu_src = REPO_ROOT / "3rdparty" / "ncu-report-skill"
-    ncu_dst = claude_skills_dir / "ncu-report-skill"
-    if ncu_src.exists() and not ncu_dst.exists():
-        os.symlink(ncu_src, ncu_dst)
-    # Link gpu-wiki/3rdparty/KernelWiki into .claude/skills/ for kernel knowledge access
     kw_src = REPO_ROOT / "gpu-wiki" / "3rdparty" / "KernelWiki"
-    kw_dst = claude_skills_dir / "KernelWiki"
-    if kw_src.exists() and not kw_dst.exists():
-        os.symlink(kw_src, kw_dst)
-    # ── .claude/ agents ──
-    # The prompts (setup.md, convert.md, gpu-kernel-profile-optimizer) reference agents by
-    # name (gpu-kernel-baseline, gpu-kernel-convert, gpu-kernel-profiler, gpu-kernel-research,
-    # kernel-optimize). Link the repo's agents/ into .claude/agents/ so inner claude sessions
-    # discover them as subagent types.
     agents_src = REPO_ROOT / "agents"
-    if agents_src.exists() and not claude_agents_dir.exists():
-        os.symlink(agents_src, claude_agents_dir)
+    for runtime_dir_name in (".claude", ".qoder"):
+        runtime_dir = workspace / runtime_dir_name
+        runtime_skills_dir = runtime_dir / "skills"
+        runtime_agents_dir = runtime_dir / "agents"
+        runtime_skills_dir.mkdir(parents=True, exist_ok=True)
+        for src, name in ((ncu_src, "ncu-report-skill"), (kw_src, "KernelWiki")):
+            dst = runtime_skills_dir / name
+            if src.exists() and not dst.exists():
+                os.symlink(src, dst)
+        # The prompts reference these agent definitions by name (gpu-kernel-baseline,
+        # gpu-kernel-convert, gpu-kernel-profiler, gpu-kernel-research, kernel-optimize).
+        if agents_src.exists() and not runtime_agents_dir.exists():
+            os.symlink(agents_src, runtime_agents_dir)
     gi = workspace / ".gitignore"
     existing = gi.read_text(encoding="utf-8") if gi.exists() else ""
     add = ""
@@ -579,6 +770,8 @@ def link_runtime(workspace: Path) -> None:
         add += "\n# orchestrator runtime symlinks (not part of the workspace)\n/tools\n/reference\n/skills\n/reference-projects\n/gpu-wiki\n"
     if "/.claude" not in existing:
         add += "/.claude\n"
+    if "/.qoder" not in existing:
+        add += "/.qoder\n"
     if "/" + STALL_STATE_FILE not in existing:
         add += ("\n# orchestrator live stall counter (rebuilt on restart; never committed)\n"
                 "/" + STALL_STATE_FILE + "\n")
@@ -606,6 +799,11 @@ class Campaign:
     setup_timeout: int = 7200      # 120 min for the baseline session
     max_stall: int = 0             # 0 = disabled (budget-only); >0 = stop after N no-commit iters
     convert_after: int = 5         # triton-only: after N stalled iters, run ONE triton->gluon convert session (0=off)
+    sandbox_hardware: str = ""     # agate scheduler token, e.g. REMOTE_GPU (may differ from platform)
+    sandbox_profile: str = ""      # pre/prod; empty preserves normal agate URL resolution
+    sandbox_url: str = ""          # explicit endpoint, e.g. http://127.0.0.1:8000
+    sandbox_timeout: int = 600      # agate dev hard limit
+    agent_cli: str = "claude"       # clean-session coding backend: claude or qodercli
     tokens_spent: int = field(default=0, init=False)
 
     @property
@@ -623,10 +821,15 @@ class Campaign:
     def _link_runtime(self) -> None:
         link_runtime(self.workspace)
 
+    def _sandbox_directive(self) -> str:
+        return sandbox_directive(
+            self.sandbox_hardware, self.sandbox_profile, self.sandbox_url
+        )
+
     def setup_baseline(self) -> None:
         # SOL-ExecBench op: seed a correct, directly-submittable V0 mechanically
         # (no baseline session) — sol_seed.py copies the ground-truth files, writes
-        # the DPS wrapper kernel.py + solution.json, and benches V0 via test_kernel.py.
+        # the DPS wrapper kernel.py + solution.json; this method benches V0 in the sandbox.
         op_dir = Path(self.kernel_demo).resolve().parent
         if is_sol_op(op_dir):
             self._setup_baseline_sol(op_dir)
@@ -637,6 +840,14 @@ class Campaign:
         # so cwd must be the work_dir (or the process cwd when --workspace is absent).
         subprocess.run(["bash", str(WORKSPACE_INIT), self.name, self.kernel_demo],
                        cwd=str(self.workspace.parent), check=True)
+        # atrex-bench operators keep their immutable harness inputs beside
+        # reference.py.  workspace_init.sh only copies the reference itself;
+        # materialize the remaining ground truth before the baseline session.
+        for name in ("reference.py", "input.py", "shapes.json", "roofline.json",
+                     "metadata.json", "valid.py"):
+            source = op_dir / name
+            if source.is_file():
+                shutil.copy2(source, self.workspace / name)
         self._link_runtime()
         prompt = _render(
             PROMPTS_DIR / "setup.md",
@@ -644,14 +855,22 @@ class Campaign:
             FRAMEWORK=self.framework, KERNEL_DEMO=self.kernel_demo,
             NOTES=self.notes,
             HARDWARE=hardware_directive(self.platform, self.arch),
+            SANDBOX=self._sandbox_directive(),
         )
-        res = run_session(self.workspace, prompt, timeout=self.setup_timeout)
+        res = run_session(
+            self.workspace, prompt, timeout=self.setup_timeout,
+            agent_cli=self.agent_cli,
+            sandbox_hardware=self.sandbox_hardware,
+            sandbox_profile=self.sandbox_profile,
+            sandbox_url=self.sandbox_url,
+            sandbox_timeout=self.sandbox_timeout,
+        )
         self._account(res, "setup")
         if res.exit_status != 0 and res.tokens == 0:
             raise RuntimeError(
                 f"setup session failed immediately (exit={res.exit_status}, tokens=0) — "
                 "this is likely an API key / authentication issue. "
-                "Run `claude auth status` and `claude --print \"test\"` to diagnose."
+                f"{_agent_auth_hint(self.agent_cli)}."
             )
         if read_memory(self.workspace, 0) is None:
             raise RuntimeError("setup did not produce memory/v0.json (baseline failed)")
@@ -662,17 +881,42 @@ class Campaign:
         cmd = [sys.executable, str(SOL_SEED),
                "--op-dir", str(op_dir), "--name", self.name,
                "--workspace", str(self.workspace),
-               "--framework", self.framework, "--platform", self.platform]
-        # Set AKA_SKIP_BENCH_IF_V0=1 in the env if the operator pre-seeded
-        # memory/v0.json (e.g. via a synthetic seed script for ops whose torch
-        # reference is too slow to bench within a reasonable budget). When set,
-        # sol_seed.py skips the V0 bench step entirely.
-        if os.environ.get("AKA_SKIP_BENCH_IF_V0", "").lower() in ("1", "true", "yes"):
-            cmd.append("--skip-bench-if-v0-exists")
+               "--framework", self.framework, "--platform", self.platform,
+               # The local step only materializes sources and git state.  GPU
+               # correctness/performance is run below in the remote sandbox.
+               "--no-bench"]
         subprocess.run(cmd, check=True)
         self._link_runtime()
-        if read_memory(self.workspace, 0) is None:
-            raise RuntimeError("sol_seed did not produce memory/v0.json (V0 baseline failed)")
+        test = _sandbox_command(
+            self.workspace,
+            self.sandbox_hardware,
+            self.sandbox_profile,
+            self.sandbox_url,
+            self.sandbox_timeout,
+            ["python", "test_kernel.py", "--version", "v0", "--no-memory"],
+        )
+        if test.stdout:
+            print(test.stdout, end="" if test.stdout.endswith("\n") else "\n", flush=True)
+        if test.stderr:
+            print(test.stderr, end="" if test.stderr.endswith("\n") else "\n",
+                  file=sys.stderr, flush=True)
+        try:
+            result = _test_result_from_stdout(test.stdout)
+        except (RuntimeError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"sandbox V0 baseline produced no usable result: {exc}") from exc
+        memory_path = _record_local_test_result(self.workspace, "v0", result)
+        if test.returncode != 0 or not result.get("all_pass"):
+            raise RuntimeError("sandbox V0 baseline failed correctness/performance validation")
+
+        # sol_seed committed the source-only baseline. Fold the locally-owned
+        # memory record into that commit without ever sending memory to the pod.
+        mem = json.loads(memory_path.read_text(encoding="utf-8"))
+        mem["git_commit_hash"] = git_head(self.workspace)
+        mem.setdefault("optimization", {})["action_category"] = "baseline"
+        memory_path.write_text(json.dumps(mem, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        subprocess.run(["git", "add", "memory/v0.json"], cwd=str(self.workspace), check=True)
+        subprocess.run(["git", "commit", "--amend", "--no-edit"], cwd=str(self.workspace),
+                       check=True, stdout=subprocess.DEVNULL)
 
     def _record_failed_convert(self, n: int, reason: str) -> None:
         """Persist a failed/reverted triton->gluon conversion as memory/v<N>.json so the NEXT convert
@@ -735,14 +979,23 @@ class Campaign:
                                  WORKSPACE=str(self.workspace), N=n, PREV=n - 1,
                                  PLATFORM=self.platform, ARCH=self.arch or "the runtime GPU arch",
                                  NOTES=self.notes,
-                                 HARDWARE=hardware_directive(self.platform, self.arch))
+                                 HARDWARE=hardware_directive(self.platform, self.arch),
+                                 SANDBOX=self._sandbox_directive())
             else:
                 prompt = _render(PROMPTS_DIR / "iteration.md",
                                  WORKSPACE=str(self.workspace), N=n, PREV=n - 1,
                                  PLATFORM=self.platform, NOTES=self.notes,
-                                 HARDWARE=hardware_directive(self.platform, self.arch))
+                                 HARDWARE=hardware_directive(self.platform, self.arch),
+                                 SANDBOX=self._sandbox_directive())
             pre_head = git_head(self.workspace)  # win = a commit that changes kernel.py vs this
-            res = run_session(self.workspace, prompt, timeout=self.iter_timeout)
+            res = run_session(
+                self.workspace, prompt, timeout=self.iter_timeout,
+                agent_cli=self.agent_cli,
+                sandbox_hardware=self.sandbox_hardware,
+                sandbox_profile=self.sandbox_profile,
+                sandbox_url=self.sandbox_url,
+                sandbox_timeout=self.sandbox_timeout,
+            )
             self._account(res, f"{'convert' if do_convert else 'iter'} v{n}")
 
             # Robust infra-failure handling: distinguish crash vs timeout, retry up to 15
@@ -756,7 +1009,7 @@ class Campaign:
                 if infra_fails >= 15:
                     return self._finish(
                         f"infra: {infra_fails} consecutive sessions crashed (exit={res.exit_status}) "
-                        "(likely API key / auth issue — run `claude auth status`)"
+                        f"(likely API key / auth issue — {_agent_auth_hint(self.agent_cli)})"
                     )
                 # Back off before retrying to avoid hammering a rate-limited API
                 import time as _time
@@ -1018,6 +1271,11 @@ class LayerCampaign:
     setup_timeout: int = 7200
     decompose_timeout: int = 5400
     recombine_timeout: int = 5400
+    sandbox_hardware: str = ""
+    sandbox_profile: str = ""
+    sandbox_url: str = ""
+    sandbox_timeout: int = 600
+    agent_cli: str = "claude"
     tokens_spent: int = field(default=0, init=False)
 
     @property
@@ -1039,6 +1297,11 @@ class LayerCampaign:
     def budget_exhausted(self) -> bool:
         return self.token_budget > 0 and self.tokens_spent >= self.token_budget
 
+    def _sandbox_directive(self) -> str:
+        return sandbox_directive(
+            self.sandbox_hardware, self.sandbox_profile, self.sandbox_url
+        )
+
     def _manifest_path(self) -> Path:
         return self.layer_dir / "boundaries.json"
 
@@ -1055,8 +1318,16 @@ class LayerCampaign:
             OP_DIR=self.op_dir, NOTES=self.notes,
             DECOMPOSE_DOC=str(REPO_ROOT / "agents" / "gpu-kernel-decompose.md"),
             HARDWARE=hardware_directive(self.platform, self.arch),
+            SANDBOX=self._sandbox_directive(),
         )
-        res = run_session(self.layer_dir, prompt, timeout=self.decompose_timeout)
+        res = run_session(
+            self.layer_dir, prompt, timeout=self.decompose_timeout,
+            agent_cli=self.agent_cli,
+            sandbox_hardware=self.sandbox_hardware,
+            sandbox_profile=self.sandbox_profile,
+            sandbox_url=self.sandbox_url,
+            sandbox_timeout=self.sandbox_timeout,
+        )
         self._account(res, "decompose")
         if not self._manifest_path().exists():
             raise RuntimeError("decompose did not produce boundaries.json")
@@ -1082,8 +1353,16 @@ class LayerCampaign:
                 WORKSPACE=str(ws), PLATFORM=self.platform, FRAMEWORK=self.framework,
                 KERNEL_DEMO=str(demo), NOTES=self.notes,
                 HARDWARE=hardware_directive(self.platform, self.arch),
+                SANDBOX=self._sandbox_directive(),
             )
-            res = run_session(ws, prompt, timeout=self.setup_timeout)
+            res = run_session(
+                ws, prompt, timeout=self.setup_timeout,
+                agent_cli=self.agent_cli,
+                sandbox_hardware=self.sandbox_hardware,
+                sandbox_profile=self.sandbox_profile,
+                sandbox_url=self.sandbox_url,
+                sandbox_timeout=self.sandbox_timeout,
+            )
             self._account(res, f"baseline {b['name']}")
             if read_memory(ws, 0) is None:
                 raise RuntimeError(f"baseline failed for boundary {b['name']} (no memory/v0.json)")
@@ -1190,8 +1469,16 @@ class LayerCampaign:
             prompt = _render(PROMPTS_DIR / "iteration.md",
                              WORKSPACE=str(ws), N=n, PREV=n - 1,
                              PLATFORM=self.platform, NOTES=self.notes,
-                             HARDWARE=hardware_directive(self.platform, self.arch))
-            res = run_session(ws, prompt, timeout=self.iter_timeout)
+                             HARDWARE=hardware_directive(self.platform, self.arch),
+                             SANDBOX=self._sandbox_directive())
+            res = run_session(
+                ws, prompt, timeout=self.iter_timeout,
+                agent_cli=self.agent_cli,
+                sandbox_hardware=self.sandbox_hardware,
+                sandbox_profile=self.sandbox_profile,
+                sandbox_url=self.sandbox_url,
+                sandbox_timeout=self.sandbox_timeout,
+            )
             self._account(res, f"{target['name']} v{n}")
 
             # Guard: if the session exited without producing v<n>.json, write a
@@ -1236,8 +1523,16 @@ class LayerCampaign:
     def recombine(self) -> None:
         prompt = _render(PROMPTS_DIR / "recombine.md",
                          LAYER_DIR=str(self.layer_dir),
-                         HARDWARE=hardware_directive(self.platform, self.arch))
-        res = run_session(self.layer_dir, prompt, timeout=self.recombine_timeout)
+                         HARDWARE=hardware_directive(self.platform, self.arch),
+                         SANDBOX=self._sandbox_directive())
+        res = run_session(
+            self.layer_dir, prompt, timeout=self.recombine_timeout,
+            agent_cli=self.agent_cli,
+            sandbox_hardware=self.sandbox_hardware,
+            sandbox_profile=self.sandbox_profile,
+            sandbox_url=self.sandbox_url,
+            sandbox_timeout=self.sandbox_timeout,
+        )
         self._account(res, "recombine")
 
     def run(self) -> str:
@@ -1282,6 +1577,29 @@ def main(argv: Optional[list[str]] = None) -> int:
                          "per-shape SOL, and the priority anchor (metadata.production_performance). Never hardcoded.")
     ap.add_argument("--platform", required=True, help="Target hardware, e.g. B200 / H20 / MI308X "
                                                       "(cannot be deduced from the op dir).")
+    ap.add_argument(
+        "--sandbox-hardware", default="",
+        help="agate GPU scheduler token used for all tests/profiles, e.g. REMOTE_GPU. "
+             "Default: --platform (set explicitly when logical platform and gateway alias differ).",
+    )
+    ap.add_argument(
+        "--sandbox-profile", choices=("pre", "prod"), default="",
+        help="Optional agate endpoint profile. Default: preserve AGATE_URL/config resolution.",
+    )
+    ap.add_argument(
+        "--sandbox-url", default="",
+        help="Explicit agate endpoint URL for all tests/profiles, e.g. "
+             "http://127.0.0.1:8000 for `atrex-gateway serve --local`. "
+             "Mutually exclusive with --sandbox-profile.",
+    )
+    ap.add_argument(
+        "--sandbox-timeout", type=int, default=600,
+        help="Per sandbox test/profile command timeout in seconds (1..600; gateway dev limit).",
+    )
+    ap.add_argument(
+        "--agent-cli", choices=AGENT_CLI_CHOICES, default="claude",
+        help="Coding CLI used for clean optimization sessions (default: claude; alternative: qodercli).",
+    )
     ap.add_argument("--framework", required=True, help="Target DSL, e.g. CuteDSL / FlyDSL "
                                                        "(cannot be deduced from the op dir).")
     ap.add_argument("--layer", action="store_true",
@@ -1310,15 +1628,35 @@ def main(argv: Optional[list[str]] = None) -> int:
                     help="Working directory for the optimization campaign. The workspace (kernel_opt_<name>/) "
                          "will be created under this directory. Default: current working directory.")
     args = ap.parse_args(argv)
+    if not 1 <= args.sandbox_timeout <= 600:
+        ap.error("--sandbox-timeout must be in the gateway-supported range 1..600")
+    if args.sandbox_url and args.sandbox_profile:
+        ap.error("--sandbox-url and --sandbox-profile are mutually exclusive")
+    if shutil.which(args.agent_cli) is None:
+        ap.error(f"--agent-cli executable not found on PATH: {args.agent_cli}")
+    if args.agent_cli == "qodercli" and args.token_budget > 0:
+        print(
+            "[orchestrator] WARNING: qodercli token-budget enforcement depends on token usage "
+            "reported in stream-json; some Qoder models report zero, so --max-iters remains "
+            "the authoritative hard bound in that configuration.",
+            file=sys.stderr,
+            flush=True,
+        )
 
     # Create working directory if specified, so the campaign can write into it immediately.
     if args.workspace:
         Path(args.workspace).mkdir(parents=True, exist_ok=True)
 
-    arch = args.arch or detect_arch()
+    sandbox_hardware = args.sandbox_hardware or args.platform
+    arch = args.arch or detect_arch(
+        sandbox_hardware, args.sandbox_profile, args.sandbox_url
+    )
     op = _resolve_op(args.op_dir)
     ensure_submodules()
-    print(f"[orchestrator] op={op['name']} platform={args.platform} runtime_arch="
+    print(f"[orchestrator] op={op['name']} agent_cli={args.agent_cli} platform={args.platform} "
+          f"sandbox_hardware={sandbox_hardware} "
+          f"sandbox_endpoint={args.sandbox_url or args.sandbox_profile or 'agate-config'} "
+          "runtime_arch="
           f"{arch or 'UNKNOWN (detect failed)'} "
           f"(device name / vendor-smi may be desensitized; trusting the runtime API)", flush=True)
 
@@ -1326,6 +1664,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         layer = LayerCampaign(
             name=op["name"], layer_demo=op["reference"], platform=args.platform,
             framework=args.framework, notes=args.notes, arch=arch,
+            sandbox_hardware=sandbox_hardware, sandbox_profile=args.sandbox_profile,
+            sandbox_url=args.sandbox_url,
+            sandbox_timeout=args.sandbox_timeout,
+            agent_cli=args.agent_cli,
             work_dir=args.workspace,
             roofline_py=op["roofline_py"], op_dir=op["op_dir"],
             max_iters=args.max_iters, token_budget=args.token_budget,
@@ -1337,6 +1679,10 @@ def main(argv: Optional[list[str]] = None) -> int:
     campaign = Campaign(
         name=op["name"], kernel_demo=op["reference"], platform=args.platform,
         framework=args.framework, notes=args.notes, arch=arch,
+        sandbox_hardware=sandbox_hardware, sandbox_profile=args.sandbox_profile,
+        sandbox_url=args.sandbox_url,
+        sandbox_timeout=args.sandbox_timeout,
+        agent_cli=args.agent_cli,
         work_dir=args.workspace,
         max_iters=args.max_iters, token_budget=args.token_budget, target_util=args.target_util,
         iter_timeout=args.iter_timeout, setup_timeout=args.setup_timeout, max_stall=args.max_stall,

--- a/orchestrator/prompts/convert.md
+++ b/orchestrator/prompts/convert.md
@@ -17,6 +17,7 @@ launches work and exits early produces no v{{N}} and wastes the whole attempt.)
 - `tools/`, `reference/`, `skills/`, `reference-projects/`, and `gpu-wiki/` are symlinked in.
 
 {{HARDWARE}}
+{{SANDBOX}}
 
 ## Workflow
 
@@ -44,7 +45,8 @@ The sheet gives the Triton→Gluon API map, the critical pitfalls, and pointers 
 ### Step 2 — Extract TTGIR FIRST (before writing any Gluon)
 
 ```bash
-python tools/extract_ttgir.py <driver>.py -o v{{N}}.ttgir
+python tools/sandbox.py --sync v{{N}}.ttgir -- \
+  python tools/extract_ttgir.py <driver>.py -o v{{N}}.ttgir
 ```
 (The driver must launch the kernel; the kernel's `__main__` profiling block works.)
 Confirm the target matches `arch` (e.g. `cuda:100`). The Gluon kernel's layouts **must be the
@@ -65,9 +67,12 @@ accumulator-residency pattern, and reproduce the original `num_stages` (nothing 
 ### Step 4 — Validate (iterate on fixes until pass or give up)
 
 ```bash
-python -c "import kernel"    # must compile
-timeout 1800 python test_kernel.py --version v{{N}}    # real evaluator, every workload
+python tools/sandbox.py --no-sync -- python -c "import kernel"   # must compile remotely
+python tools/sandbox.py --no-sync -- \
+  python test_kernel.py --version v{{N}} --no-memory             # real evaluator, every workload
 ```
+
+Parse `RESULT_JSON` from the test and update `memory/v{{N}}.json` locally. Do not use remote memory.
 
 If RUNTIME_ERROR or correctness FAIL: **iterate on fixes** (up to 3-4 attempts). Common issues:
 - Wrong tensor shape/layout → re-check TTGIR layouts vs Gluon code

--- a/orchestrator/prompts/decompose.md
+++ b/orchestrator/prompts/decompose.md
@@ -20,6 +20,7 @@ Inputs:
 - additional_notes: `{{NOTES}}`
 
 {{HARDWARE}}
+{{SANDBOX}}
 
 Do exactly this, then STOP:
 

--- a/orchestrator/prompts/iteration.md
+++ b/orchestrator/prompts/iteration.md
@@ -20,6 +20,7 @@ Hard rules for this session:
 - `/humanize:gen-plan` — plan generation plugin (Stage 2, loaded via `--plugin-dir`).
 
 {{HARDWARE}}
+{{SANDBOX}}
 
 This prompt is **self-contained** — it defines all stages (1–4), commit/revert rules, and record format.
 Evidence format throughout: `evidence -> inference -> action`. Do Stages 1–4 once, then commit/revert/record and exit.
@@ -51,21 +52,40 @@ Execute each stage (1–4) directly in this session. All rules are defined inlin
 
 **Goal**: Profile the current kernel, place outputs in `profiles/v{{N}}/`, and extract concrete bottleneck evidence.
 
-**Execution**: Follow `.claude/skills/ncu-report-skill/SKILL.md` to complete profiling. Adapt its workflow to this iteration context:
+**Execution**: First create `profiles/v{{N}}/harness/profile_driver.py` locally. It must import the current
+`kernel.py` plus immutable `input.py`, select a representative workload from `shapes.json`, allocate inputs,
+warm up, and invoke `Model` repeatedly so the profiler captures real GPU kernels. The driver is profile-only;
+it must not update memory. Collection and analysis then finish inside one sandbox job so a fresh pod is safe
+and raw profiler binaries never become optimizer state. Run exactly one platform-specific command.
 
-1. **Run directory**: Use `profiles/v{{N}}/` as the run directory (replaces the skill's `profile/<run_name>/` convention). Create subdirs `harness/`, `reports/`, `analysis/` under it.
-2. **Harness**: Build a standalone harness (with `-lineinfo`) that invokes `kernel.py`'s entry point with representative workload shapes from `workload.jsonl`. Compile into `profiles/v{{N}}/harness/`.
-3. **Collection (initial)**: Run **one** ncu profile with `--set full` (overview metrics + PM sampling), outputs to `profiles/v{{N}}/reports/`. Do NOT collect `--set source` in this initial pass.
-4. **Analysis**: Parse with the skill's Python helpers (`.claude/skills/ncu-report-skill/helpers/`), work through the six analysis dimensions, and match to the diagnosis playbook. Write analysis artifacts to `profiles/v{{N}}/analysis/`.
-5. **Report**: Write the final report to `profiles/v{{N}}/REPORT.md` per the skill's template — evidence-backed, ranked by expected impact.
+**NVIDIA**:
+```bash
+python tools/sandbox.py --sync profiles/v{{N}} -- \
+  bash tools/profile_nvidia.sh profiles/v{{N}}/harness/profile_driver.py \
+    --output-dir profiles/v{{N}} --source
+```
 
-   **AMD** — run the AMD profiling path instead:
-   ```bash
-   bash tools/profile_kernel.sh kernel.py --output-dir profiles/v{{N}}
-   ```
-   Collects ATT, PMC, and ASM artifacts.
+For a named DSL kernel (especially a Triton `@triton.jit` function), append
+`--kernel-name <exact_base_function_name>` to both NCU collections through this
+wrapper. Use the exact name reported by NCU (for example
+`--kernel-name _attn_fwd_kernel`), not a substring or a `regex:.*...*` guess.
+Without a filter, NCU's default first-launch capture often selects a
+`torch.randn`/input-generation elementwise kernel instead of the candidate.
+After collection, verify that the `Kernel:` line in `summary.txt` names the
+intended candidate kernel; a mismatched or empty capture is invalid and must be
+rerun before writing `REPORT.md`.
 
-**Localization rule (mandatory)**: The initial collection is `--set full` only — no source-level counters. Escalate to a **second** collection with `--set source --section SourceCounters` only when the REPORT.md identifies a localization-worthy symptom **and** Stage 3 is about to choose a concrete code change based on that symptom. Then pin the change to the specific source line / SASS address the per-line stall analysis identifies.
+**AMD**:
+```bash
+python tools/sandbox.py --sync profiles/v{{N}} -- \
+  bash tools/profile_kernel.sh profiles/v{{N}}/harness/profile_driver.py \
+    --output-dir profiles/v{{N}}
+```
+
+The wrapper synchronizes the small profile analysis and summary artifacts back locally. Raw
+`.ncu-rep`/ATT binaries stay remote by default. Follow `.claude/skills/ncu-report-skill/SKILL.md` only for
+interpreting the returned evidence, then write `profiles/v{{N}}/REPORT.md` locally. Pin any source-targeted
+change to the line/SASS evidence produced by the NVIDIA `--source` run.
 
 **Output**: `profiles/v{{N}}/REPORT.md` with bottleneck evidence, diagnosis, and ranked recommendations — this feeds Stage 2.
 
@@ -130,9 +150,10 @@ Execution steps:
    - Do not mix unrelated refactors, formatting, or cleanup.
 4. **Correctness validation** — immediately after editing:
    ```bash
-   python test_kernel.py
+   python tools/sandbox.py --no-sync -- python test_kernel.py --version v{{N}} --no-memory
    ```
-   If validation fails, iteratively fix until it passes. Do not proceed to Stage 4 with broken correctness.
+   Parse the emitted `RESULT_JSON`, then update local `memory/v{{N}}.json`. If validation fails, iteratively
+   fix until it passes. Do not proceed to Stage 4 with broken correctness.
 
    **Multi-seed robustness (MANDATORY before commit)**: A single-seed PASS is NOT sufficient.
    The production evaluator uses **freshly randomized inputs every call**, and a kernel that
@@ -141,14 +162,15 @@ Execution steps:
 
    ```bash
    # Run 5 additional seeds (1..5). Reports PASS only if ALL seeds pass.
-   python test_kernel.py --version v{{N}} --multi-seed 5
+   python tools/sandbox.py --no-sync -- \
+     python test_kernel.py --version v{{N}} --multi-seed 5 --no-memory
    ```
 
    Or, if you want explicit per-seed traces, run them one at a time:
    ```bash
-   python test_kernel.py --version v{{N}}_seed1 --seed 1 --no-memory
-   python test_kernel.py --version v{{N}}_seed2 --seed 2 --no-memory
-   python test_kernel.py --version v{{N}}_seed3 --seed 3 --no-memory
+   python tools/sandbox.py --no-sync -- python test_kernel.py --seed 1 --no-memory
+   python tools/sandbox.py --no-sync -- python test_kernel.py --seed 2 --no-memory
+   python tools/sandbox.py --no-sync -- python test_kernel.py --seed 3 --no-memory
    ```
 
    **ALL seeds must PASS.** If ANY seed fails correctness, the kernel is BROKEN — revert
@@ -181,17 +203,20 @@ Execution steps:
 
 1. **Run the benchmark harness** with timeout guard:
    ```bash
-   timeout 1800 python test_kernel.py --version v{{N}}
+   python tools/sandbox.py --no-sync -- python test_kernel.py --version v{{N}} --no-memory
    ```
    This runs the real `sol-execbench` evaluator over **every workload in `workload.jsonl`** with each workload's own tolerance. Do NOT edit `test_kernel.py` or hand-roll a separate test.
+   Parse `RESULT_JSON` and write the metrics into local `memory/v{{N}}.json`; remote memory is never used.
 
-2. **Metrics recorded** (by the harness into `memory/v{{N}}.json`):
+2. **Metrics recorded** (locally from the sandbox `RESULT_JSON`):
    - `performance.latency_us` = **geomean** of per-workload kernel latency (primary objective: minimize)
    - `performance.latency_us_by_shape` — per-workload latency keyed by workload `uuid`
    - `performance.speedup_vs_ref_geomean` — geomean speedup vs reference
    - `correctness.status` / `quality_gate.result` — PASS iff ALL workloads pass
 
-3. **Measurement reliability guard**: Before accepting a large delta (especially regressions >30%), verify GPU is not occupied by other processes. Switch to a free GPU via `CUDA_VISIBLE_DEVICES` if needed and re-measure.
+3. **Measurement reliability guard**: Before accepting a large delta (especially regressions >30%), re-run
+   through the same sandbox hardware and compare; GPU selection belongs to the gateway, not local
+   `CUDA_VISIBLE_DEVICES`.
 
 4. **Quality gate**: PASS requires correctness PASS + geomean latency drop vs HEAD beyond measurement noise. A flat-within-noise result is NOT an improvement.
 

--- a/orchestrator/prompts/recombine.md
+++ b/orchestrator/prompts/recombine.md
@@ -10,6 +10,7 @@ Inputs:
   boundary's optimized workspace (its HEAD `kernel.py` is the best kernel).
 
 {{HARDWARE}}
+{{SANDBOX}}
 
 Do exactly this, then STOP:
 

--- a/orchestrator/prompts/setup.md
+++ b/orchestrator/prompts/setup.md
@@ -14,6 +14,7 @@ Environment (resolve all paths against your cwd = the workspace):
 - `.claude/skills/KernelWiki/` — kernel optimization knowledge base.
 
 {{HARDWARE}}
+{{SANDBOX}}
 Do the following, in order, but only through baseline:
 
 1. **Step 0 — Hardware specs + Roofline.** Source
@@ -24,6 +25,14 @@ Do the following, in order, but only through baseline:
 3. **Stage 1 — Baseline.** Launch the `gpu-kernel-baseline` subagent (by name). You may spawn it in the background, but **you MUST wait for it to complete before you exit**: implement `kernel.py` + `test_kernel.py`,
    validate correctness and baseline performance, write `baseline_report.md`, write `memory/v0.json` (via
    `tools/memory_manager.py`), and `git commit` ("V0: baseline kernel").
+   Include the mandatory sandbox block above verbatim in the subagent task: it must run `test_kernel.py
+   --no-memory` remotely, parse the result, and write `memory/v0.json` locally. Reject any local-GPU
+   measurement or remotely written memory.
+   Before the first run, make the immutable harness print one single-line structured result in this format:
+   `[test_kernel] RESULT_JSON=<json>`, including `all_pass`, `failures`, `latency_us_geomean`,
+   `latency_us_arith_mean`, `latency_us_by_shape`, `speedup_vs_ref_geomean`, `max_abs_err`, and
+   `max_rel_err`. This output is the transport from the remote test to local memory; do not edit the
+   benchmark methodology after V0.
    **`test_kernel.py` MUST bench every shape in the workspace `shapes.json`** (the full ground-truth set, keyed
    by integer sid) — not a hand-picked subset. This shape set + harness is the immutable per-campaign benchmark
    methodology (see `reference/CLAUDE.md` "Benchmark Harness Integrity"); later iterations reuse it unchanged.

--- a/reference/test_kernel.py
+++ b/reference/test_kernel.py
@@ -283,6 +283,9 @@ def main(argv: list[str] | None = None) -> int:
                   f"abs_err={ss['max_abs_err']:.2e}, rel_err={ss['max_rel_err']:.2e} -> {tag}")
             if not ss["all_pass"]:
                 all_seeds_pass = False
+                s["failures"].append(
+                    f"seed{seed_i}: " + ("; ".join(ss["failures"]) or "correctness failure")
+                )
             worst_abs_all = max(worst_abs_all, ss["max_abs_err"])
             worst_rel_all = max(worst_rel_all, ss["max_rel_err"])
             try:
@@ -292,9 +295,16 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  ────────────────────────────────────────────────────────────────")
         print(f"  MULTI-SEED RESULT        : {'PASS' if all_seeds_pass else 'FAIL'}")
         print(f"  worst abs / rel (all)    : {worst_abs_all:.2e} / {worst_rel_all:.2e}")
+        s["max_abs_err"] = worst_abs_all
+        s["max_rel_err"] = worst_rel_all
         if not all_seeds_pass:
             print(f"  *** KERNEL NOT ROBUST — fails on some seeds ***")
             s["all_pass"] = False
+
+    # The gateway sandbox intentionally does not receive or return memory/.
+    # Emit the full structured result so the local optimization session can
+    # update memory/v<N>.json after a remote --no-memory run.
+    print("[test_kernel] RESULT_JSON=" + json.dumps(s, ensure_ascii=False, sort_keys=True))
 
     if not args.no_memory:
         version = args.version or _infer_version(workspace)

--- a/tests/test_local_gateway.py
+++ b/tests/test_local_gateway.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from tools.local_gateway import JobStore, LocalGateway, LocalScheduler, create_server
+
+
+class LocalGatewayTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory(prefix="local-gateway-test-")
+        self.state_dir = Path(self.temp.name)
+        self.gateway = LocalGateway(self.state_dir, workers=1, max_output_bytes=1024 * 1024)
+        self.server = create_server(self.gateway, "127.0.0.1", 0)
+        self.gateway.start()
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.thread.join(timeout=5)
+        self.server.server_close()
+        self.gateway.close()
+        self.temp.cleanup()
+
+    def request(self, method: str, path: str, body: dict | None = None) -> tuple[int, object]:
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        headers = {"Content-Type": "application/json"} if data is not None else {}
+        request = urllib.request.Request(
+            self.base_url + path,
+            method=method,
+            data=data,
+            headers=headers,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=5) as response:
+                raw = response.read().decode("utf-8")
+                return response.status, json.loads(raw) if raw and raw != "ok" else raw
+        except urllib.error.HTTPError as exc:
+            return exc.code, json.loads(exc.read().decode("utf-8"))
+
+    @staticmethod
+    def dev_request(command: str, **extra: object) -> dict:
+        return {
+            "spec": {"target_hardware": ["local"]},
+            "command": command,
+            "timeout_s": 5,
+            "env_vars": {},
+            "files": {},
+            **extra,
+        }
+
+    def submit(self, command: str, **extra: object) -> str:
+        status, body = self.request("POST", "/v1/jobs/dev", self.dev_request(command, **extra))
+        self.assertEqual(status, 202)
+        self.assertIsInstance(body, dict)
+        return body["job_id"]
+
+    def wait_for_status(self, job_id: str, wanted: set[str], timeout: float = 5) -> dict:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            status, body = self.request("GET", f"/v1/jobs/{job_id}")
+            self.assertEqual(status, 200)
+            if body["status"] in wanted:
+                return body
+            time.sleep(0.02)
+        self.fail(f"job {job_id} did not reach {wanted}")
+
+    def test_health_env_and_dev_result_match_agate_shape(self) -> None:
+        status, body = self.request("GET", "/healthz")
+        self.assertEqual((status, body), (200, "ok"))
+        status, body = self.request("GET", "/v1/env")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["env"][0]["gpu"], "local")
+
+        job_id = self.submit(
+            "printf '%s:%s' \"$(cat nested/input.txt)\" \"$VALUE\"",
+            files={"nested/input.txt": "payload"},
+            env_vars={"VALUE": "environment"},
+        )
+        job = self.wait_for_status(job_id, {"succeeded"})
+        self.assertEqual(job["kind"], "dev")
+        self.assertEqual(job["result"]["exit_code"], 0)
+        self.assertEqual(job["result"]["stdout"], "payload:environment")
+        self.assertEqual(job["result"]["stderr"], "")
+
+    def test_fifo_queue_serializes_commands(self) -> None:
+        first = self.submit("sleep 0.5; printf first")
+        self.wait_for_status(first, {"running"})
+        second = self.submit("printf second")
+
+        _, second_queued = self.request("GET", f"/v1/jobs/{second}")
+        self.assertEqual(second_queued["status"], "queued")
+
+        status, first_done = self.request("GET", f"/v1/jobs/{first}?wait=true&timeout=2")
+        self.assertEqual(status, 200)
+        self.assertEqual(first_done["status"], "succeeded")
+        second_done = self.wait_for_status(second, {"succeeded"})
+        self.assertEqual(second_done["result"]["stdout"], "second")
+
+    def test_cancelled_queued_job_is_never_started(self) -> None:
+        first = self.submit("sleep 0.5")
+        self.wait_for_status(first, {"running"})
+        second = self.submit("printf should-not-run")
+        status, cancelled = self.request("POST", f"/v1/jobs/{second}/cancel")
+        self.assertEqual(status, 200)
+        self.assertEqual(cancelled["status"], "cancelled")
+
+        self.wait_for_status(first, {"succeeded"})
+        time.sleep(0.1)
+        self.assertFalse((self.state_dir / "jobs" / second).exists())
+
+    def test_cancel_running_job(self) -> None:
+        job_id = self.submit("sleep 30")
+        self.wait_for_status(job_id, {"running"})
+        status, cancelled = self.request("POST", f"/v1/jobs/{job_id}/cancel")
+        self.assertEqual(status, 200)
+        self.assertEqual(cancelled["status"], "cancelled")
+        self.assertEqual(self.gateway.store.get(job_id)["status"], "cancelled")
+
+    def test_state_directory_has_single_scheduler_owner(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "already in use"):
+            LocalGateway(self.state_dir, workers=1)
+
+    def test_configured_gpu_alias_is_accepted(self) -> None:
+        alias_dir = self.state_dir / "alias"
+        gateway = LocalGateway(alias_dir, workers=1, gpu_aliases=("TEST_GPU",))
+        gateway.start()
+        try:
+            payload = self.dev_request("printf alias")
+            payload["spec"]["target_hardware"] = ["TEST_GPU"]
+            accepted, _ = gateway.submit_dev(payload, "req-alias")
+            completed = gateway.scheduler.wait_for_job(accepted["job_id"], timeout=3)
+            self.assertEqual(completed["status"], "succeeded")
+            self.assertIn("TEST_GPU", gateway.environment()["aliases"])
+        finally:
+            gateway.close()
+
+    def test_rejects_unsafe_file_path_and_unsupported_kind(self) -> None:
+        payload = self.dev_request("true", files={"../escape": "bad"})
+        status, error = self.request("POST", "/v1/jobs/dev", payload)
+        self.assertEqual(status, 422)
+        self.assertEqual(error["reason"], "validation_error")
+
+        status, error = self.request("POST", "/v1/jobs/eval", {})
+        self.assertEqual(status, 501)
+        self.assertEqual(error["reason"], "kind_not_supported")
+
+    def test_restart_fails_running_job_and_preserves_queued_job(self) -> None:
+        restart_dir = self.state_dir / "restart"
+        store = JobStore(restart_dir / "jobs.db")
+        first, _ = store.create("dev", self.dev_request("printf first"), "req-first")
+        second, _ = store.create("dev", self.dev_request("printf second"), "req-second")
+        claimed = store.claim_next()
+        self.assertEqual(claimed[0], first["job_id"])
+        store.close()
+
+        recovered = JobStore(restart_dir / "jobs.db")
+        self.assertEqual(recovered.get(first["job_id"])["status"], "failed")
+        self.assertEqual(recovered.get(second["job_id"])["status"], "queued")
+        scheduler = LocalScheduler(recovered, restart_dir / "jobs", workers=1, max_output_bytes=1024)
+        scheduler.start()
+        try:
+            completed = scheduler.wait_for_job(second["job_id"], timeout=3)
+            self.assertEqual(completed["status"], "succeeded")
+            self.assertEqual(completed["result"]["stdout"], "second")
+        finally:
+            scheduler.stop()
+            recovered.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/local_gateway.py
+++ b/tools/local_gateway.py
@@ -1,0 +1,1006 @@
+#!/usr/bin/env python3
+# Copyright 2026 Alibaba Group.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Small localhost scheduler compatible with the public agate dev API.
+
+The server intentionally implements the subset used by ``tools/sandbox.py``:
+
+* ``GET /healthz``
+* ``GET /v1/env`` and ``GET /v1/env/local``
+* ``POST /v1/jobs/dev``
+* ``GET /v1/jobs`` and ``GET /v1/jobs/<job_id>``
+* ``POST /v1/jobs/<job_id>/cancel``
+
+Jobs are persisted in SQLite and consumed FIFO.  The default concurrency is
+one, so commands targeting a single local GPU are serialized.  The process is
+an interface-compatible execution adapter, not a security sandbox: submitted
+commands run as the server user and must be trusted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import platform
+import re
+import secrets
+import signal
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlsplit
+
+
+TERMINAL_STATUSES = frozenset({"succeeded", "failed", "cancelled"})
+VALID_STATUSES = frozenset({"queued", "running", *TERMINAL_STATUSES})
+SUPPORTED_KIND = "dev"
+KNOWN_KINDS = frozenset({"eval", "profile", "dev", "disassemble"})
+ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+DEFAULT_BODY_LIMIT = 32 * 1024 * 1024
+DEFAULT_OUTPUT_LIMIT = 32 * 1024 * 1024
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _json_loads(value: str | None) -> Any:
+    if value is None:
+        return None
+    return json.loads(value)
+
+
+def _error(reason: str, message: str, trace_id: str | None = None, **details: Any) -> dict[str, Any]:
+    return {
+        "error_class": "local_gateway",
+        "reason": reason,
+        "message": message,
+        "details": details,
+        "trace_id": trace_id,
+    }
+
+
+def _job_prefix(kind: str) -> str:
+    return {"dev": "dv", "eval": "ev", "profile": "pr", "disassemble": "ds"}.get(kind, "jb")
+
+
+class JobStore:
+    """Thread-safe SQLite persistence for the FIFO scheduler."""
+
+    def __init__(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._db = sqlite3.connect(path, check_same_thread=False)
+        path.chmod(0o600)
+        self._db.row_factory = sqlite3.Row
+        with self._lock:
+            self._db.execute("PRAGMA journal_mode=WAL")
+            self._db.execute("PRAGMA synchronous=NORMAL")
+            self._db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS jobs (
+                    job_id TEXT PRIMARY KEY,
+                    kind TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    request_json TEXT NOT NULL,
+                    result_json TEXT,
+                    error_json TEXT,
+                    trace_id TEXT,
+                    user_name TEXT,
+                    idempotency_key TEXT,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    pid INTEGER,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    started_at REAL,
+                    finished_at REAL
+                )
+                """
+            )
+            self._db.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS jobs_idempotency
+                ON jobs(kind, idempotency_key)
+                WHERE idempotency_key IS NOT NULL
+                """
+            )
+            now = time.time()
+            restart_error = _json_dumps(
+                _error("scheduler_restarted", "local scheduler stopped while the job was running")
+            )
+            self._db.execute(
+                """
+                UPDATE jobs
+                SET status='failed', error_json=?, updated_at=?, finished_at=?, pid=NULL
+                WHERE status='running'
+                """,
+                (restart_error, now, now),
+            )
+            self._db.commit()
+
+    def close(self) -> None:
+        with self._lock:
+            self._db.close()
+
+    def create(self, kind: str, request: dict[str, Any], trace_id: str) -> tuple[dict[str, Any], bool]:
+        idempotency_key = request.get("idempotency_key")
+        with self._lock:
+            if idempotency_key:
+                row = self._db.execute(
+                    "SELECT * FROM jobs WHERE kind=? AND idempotency_key=?",
+                    (kind, idempotency_key),
+                ).fetchone()
+                if row is not None:
+                    return self._view(row), False
+
+            now = time.time()
+            job_id = f"{_job_prefix(kind)}_{secrets.token_hex(6)}"
+            self._db.execute(
+                """
+                INSERT INTO jobs (
+                    job_id, kind, status, request_json, trace_id, user_name,
+                    idempotency_key, created_at, updated_at
+                ) VALUES (?, ?, 'queued', ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    job_id,
+                    kind,
+                    _json_dumps(request),
+                    trace_id,
+                    request.get("author"),
+                    idempotency_key,
+                    now,
+                    now,
+                ),
+            )
+            self._db.commit()
+            return self.get(job_id), True
+
+    def get(self, job_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._db.execute("SELECT * FROM jobs WHERE job_id=?", (job_id,)).fetchone()
+            return self._view(row) if row is not None else None
+
+    def request(self, job_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._db.execute("SELECT request_json FROM jobs WHERE job_id=?", (job_id,)).fetchone()
+            return _json_loads(row[0]) if row is not None else None
+
+    def list(
+        self,
+        *,
+        kind: str | None = None,
+        user: str | None = None,
+        status: str | None = None,
+        limit: int = 50,
+        descending: bool = True,
+    ) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        values: list[Any] = []
+        for column, value in (("kind", kind), ("user_name", user), ("status", status)):
+            if value is not None:
+                clauses.append(f"{column}=?")
+                values.append(value)
+        where = " WHERE " + " AND ".join(clauses) if clauses else ""
+        order = "DESC" if descending else "ASC"
+        values.append(limit)
+        with self._lock:
+            rows = self._db.execute(
+                f"SELECT * FROM jobs{where} ORDER BY created_at {order} LIMIT ?", values
+            ).fetchall()
+            return [self._view(row) for row in rows]
+
+    def claim_next(self) -> tuple[str, dict[str, Any]] | None:
+        with self._lock:
+            self._db.execute("BEGIN IMMEDIATE")
+            row = self._db.execute(
+                "SELECT job_id, request_json FROM jobs WHERE status='queued' ORDER BY created_at ASC LIMIT 1"
+            ).fetchone()
+            if row is None:
+                self._db.commit()
+                return None
+            now = time.time()
+            changed = self._db.execute(
+                """
+                UPDATE jobs SET status='running', attempts=attempts+1,
+                    started_at=?, updated_at=?
+                WHERE job_id=? AND status='queued'
+                """,
+                (now, now, row["job_id"]),
+            ).rowcount
+            self._db.commit()
+            if changed != 1:
+                return None
+            return row["job_id"], _json_loads(row["request_json"])
+
+    def set_pid(self, job_id: str, pid: int) -> None:
+        with self._lock:
+            self._db.execute(
+                "UPDATE jobs SET pid=?, updated_at=? WHERE job_id=? AND status='running'",
+                (pid, time.time(), job_id),
+            )
+            self._db.commit()
+
+    def complete(
+        self,
+        job_id: str,
+        *,
+        status: str,
+        result: dict[str, Any] | None,
+        error: dict[str, Any] | None,
+    ) -> bool:
+        if status not in TERMINAL_STATUSES:
+            raise ValueError(f"terminal status required, got {status!r}")
+        now = time.time()
+        with self._lock:
+            changed = self._db.execute(
+                """
+                UPDATE jobs SET status=?, result_json=?, error_json=?, pid=NULL,
+                    updated_at=?, finished_at=?
+                WHERE job_id=? AND status='running'
+                """,
+                (
+                    status,
+                    _json_dumps(result) if result is not None else None,
+                    _json_dumps(error) if error is not None else None,
+                    now,
+                    now,
+                    job_id,
+                ),
+            ).rowcount
+            self._db.commit()
+            return changed == 1
+
+    def cancel(self, job_id: str) -> tuple[dict[str, Any] | None, bool]:
+        with self._lock:
+            row = self._db.execute("SELECT * FROM jobs WHERE job_id=?", (job_id,)).fetchone()
+            if row is None:
+                return None, False
+            was_running = row["status"] == "running"
+            if row["status"] not in TERMINAL_STATUSES:
+                now = time.time()
+                self._db.execute(
+                    """
+                    UPDATE jobs SET status='cancelled', pid=NULL, updated_at=?, finished_at=?
+                    WHERE job_id=?
+                    """,
+                    (now, now, job_id),
+                )
+                self._db.commit()
+                row = self._db.execute("SELECT * FROM jobs WHERE job_id=?", (job_id,)).fetchone()
+            return self._view(row), was_running
+
+    def fail_running(self, reason: str, message: str) -> None:
+        now = time.time()
+        error = _json_dumps(_error(reason, message))
+        with self._lock:
+            self._db.execute(
+                """
+                UPDATE jobs SET status='failed', error_json=?, pid=NULL,
+                    updated_at=?, finished_at=? WHERE status='running'
+                """,
+                (error, now, now),
+            )
+            self._db.commit()
+
+    @staticmethod
+    def _view(row: sqlite3.Row) -> dict[str, Any]:
+        request = _json_loads(row["request_json"])
+        return {
+            "job_id": row["job_id"],
+            "kind": row["kind"],
+            "status": row["status"],
+            "mode": request.get("mode"),
+            "lock_clocks": request.get("lock_clocks"),
+            "mode_enforced": None,
+            "result": _json_loads(row["result_json"]),
+            "error": _json_loads(row["error_json"]),
+            "trace_id": row["trace_id"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+
+def _safe_destination(value: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if not value or path.is_absolute() or ".." in path.parts or path.as_posix() in ("", "."):
+        raise ValueError(f"file destination must be a safe relative path: {value!r}")
+    return path
+
+
+def _validate_dev_request(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("request body must be a JSON object")
+    spec = payload.get("spec")
+    targets = spec.get("target_hardware") if isinstance(spec, dict) else None
+    if not isinstance(targets, list) or not targets or not all(isinstance(v, str) for v in targets):
+        raise ValueError("spec.target_hardware must be a non-empty string array")
+    if "local" not in targets:
+        raise ValueError("localhost scheduler only accepts target_hardware=['local']")
+
+    command = payload.get("command")
+    if not isinstance(command, str) or not command.strip():
+        raise ValueError("command must be a non-empty string")
+    if len(command.encode("utf-8")) > 1024 * 1024:
+        raise ValueError("command exceeds the 1 MiB limit")
+
+    timeout_s = payload.get("timeout_s", 600)
+    if isinstance(timeout_s, bool) or not isinstance(timeout_s, int) or not 1 <= timeout_s <= 600:
+        raise ValueError("timeout_s must be an integer in the range 1..600")
+
+    env_vars = payload.get("env_vars") or {}
+    if not isinstance(env_vars, dict) or not all(
+        isinstance(k, str) and ENV_NAME_RE.fullmatch(k) and isinstance(v, str)
+        for k, v in env_vars.items()
+    ):
+        raise ValueError("env_vars must map valid environment names to strings")
+
+    files = payload.get("files") or {}
+    if not isinstance(files, dict) or len(files) > 128:
+        raise ValueError("files must be an object with at most 128 entries")
+    total_bytes = 0
+    for name, content in files.items():
+        if not isinstance(name, str) or not isinstance(content, str):
+            raise ValueError("files must map relative path strings to text contents")
+        _safe_destination(name)
+        total_bytes += len(content.encode("utf-8"))
+    if total_bytes > 24 * 1024 * 1024:
+        raise ValueError("uploaded files exceed the 24 MiB request limit")
+
+    idempotency_key = payload.get("idempotency_key")
+    if idempotency_key is not None and (
+        not isinstance(idempotency_key, str) or not idempotency_key or len(idempotency_key) > 256
+    ):
+        raise ValueError("idempotency_key must be a non-empty string of at most 256 characters")
+    return payload
+
+
+class LocalScheduler:
+    """Persistent FIFO worker pool for commands targeting the local GPU."""
+
+    def __init__(self, store: JobStore, jobs_dir: Path, workers: int, max_output_bytes: int) -> None:
+        self.store = store
+        self.jobs_dir = jobs_dir
+        self.jobs_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.workers = workers
+        self.max_output_bytes = max_output_bytes
+        self._condition = threading.Condition()
+        self._stop = threading.Event()
+        self._threads: list[threading.Thread] = []
+        self._process_lock = threading.Lock()
+        self._processes: dict[str, subprocess.Popen[bytes]] = {}
+
+    def start(self) -> None:
+        for number in range(self.workers):
+            thread = threading.Thread(
+                target=self._worker_loop,
+                name=f"local-gateway-worker-{number}",
+                daemon=True,
+            )
+            thread.start()
+            self._threads.append(thread)
+
+    def stop(self) -> None:
+        self._stop.set()
+        self.notify()
+        deadline = time.monotonic() + 5
+        while any(thread.is_alive() for thread in self._threads) and time.monotonic() < deadline:
+            # A worker may have claimed a job just before shutdown. Re-sample the
+            # process map so that launch/stop races cannot leave a child behind.
+            with self._process_lock:
+                processes = list(self._processes.values())
+            for process in processes:
+                self._terminate(process)
+            for thread in self._threads:
+                thread.join(timeout=0.1)
+        self.store.fail_running("scheduler_stopped", "local scheduler stopped during execution")
+
+    def notify(self) -> None:
+        with self._condition:
+            self._condition.notify_all()
+
+    def wait_for_job(self, job_id: str, timeout: float) -> dict[str, Any] | None:
+        deadline = time.monotonic() + timeout
+        with self._condition:
+            while True:
+                job = self.store.get(job_id)
+                if job is None or job["status"] in TERMINAL_STATUSES:
+                    return job
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return job
+                self._condition.wait(timeout=remaining)
+
+    def cancel(self, job_id: str) -> dict[str, Any] | None:
+        job, was_running = self.store.cancel(job_id)
+        if was_running:
+            with self._process_lock:
+                process = self._processes.get(job_id)
+            if process is not None:
+                self._terminate(process)
+        self.notify()
+        return job
+
+    def _worker_loop(self) -> None:
+        while not self._stop.is_set():
+            claimed = self.store.claim_next()
+            if claimed is None:
+                with self._condition:
+                    self._condition.wait(timeout=0.5)
+                continue
+            job_id, request = claimed
+            self.notify()
+            if self._stop.is_set():
+                self.store.complete(
+                    job_id,
+                    status="failed",
+                    result=None,
+                    error=_error("scheduler_stopped", "local scheduler stopped before execution"),
+                )
+                break
+            self._execute(job_id, request)
+            self.notify()
+
+    def _execute(self, job_id: str, request: dict[str, Any]) -> None:
+        workdir = self.jobs_dir / job_id
+        try:
+            if self._stop.is_set():
+                self.store.complete(
+                    job_id,
+                    status="failed",
+                    result=None,
+                    error=_error("scheduler_stopped", "local scheduler stopped before execution"),
+                )
+                return
+            workdir.mkdir(parents=False, exist_ok=False, mode=0o700)
+            for name, content in (request.get("files") or {}).items():
+                relative = _safe_destination(name)
+                target = workdir.joinpath(*relative.parts)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(content, encoding="utf-8")
+                target.chmod(0o600)
+
+            stdout_path = workdir / ".stdout"
+            stderr_path = workdir / ".stderr"
+            env = os.environ.copy()
+            env.update(request.get("env_vars") or {})
+            env["ATREX_LOCAL_JOB_ID"] = job_id
+            with stdout_path.open("wb") as stdout_file, stderr_path.open("wb") as stderr_file:
+                stdout_path.chmod(0o600)
+                stderr_path.chmod(0o600)
+                process = subprocess.Popen(
+                    ["bash", "-lc", request["command"]],
+                    cwd=workdir,
+                    env=env,
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                    start_new_session=True,
+                )
+                with self._process_lock:
+                    self._processes[job_id] = process
+                self.store.set_pid(job_id, process.pid)
+                current = self.store.get(job_id)
+                if current is not None and current["status"] == "cancelled":
+                    self._terminate(process)
+                timed_out = False
+                try:
+                    process.wait(timeout=int(request.get("timeout_s", 600)))
+                except subprocess.TimeoutExpired:
+                    timed_out = True
+                    self._terminate(process)
+
+            current = self.store.get(job_id)
+            if current is None or current["status"] == "cancelled":
+                return
+            stdout, stdout_truncated = self._read_output(stdout_path)
+            stderr, stderr_truncated = self._read_output(stderr_path)
+            result = {
+                "exit_code": process.returncode,
+                "stdout": stdout,
+                "stderr": stderr,
+            }
+            if timed_out:
+                self.store.complete(
+                    job_id,
+                    status="failed",
+                    result=result,
+                    error=_error("command_timeout", f"command exceeded {request.get('timeout_s', 600)} seconds"),
+                )
+            elif stdout_truncated or stderr_truncated:
+                self.store.complete(
+                    job_id,
+                    status="failed",
+                    result=result,
+                    error=_error(
+                        "output_too_large",
+                        f"command output exceeded the {self.max_output_bytes} byte stream limit",
+                    ),
+                )
+            elif process.returncode == 0:
+                self.store.complete(job_id, status="succeeded", result=result, error=None)
+            else:
+                self.store.complete(
+                    job_id,
+                    status="failed",
+                    result=result,
+                    error=_error("command_failed", f"command exited with status {process.returncode}"),
+                )
+        except Exception as exc:
+            self.store.complete(
+                job_id,
+                status="failed",
+                result=None,
+                error=_error("execution_error", f"{type(exc).__name__}: {exc}"),
+            )
+        finally:
+            with self._process_lock:
+                self._processes.pop(job_id, None)
+
+    def _read_output(self, path: Path) -> tuple[str, bool]:
+        size = path.stat().st_size
+        with path.open("rb") as stream:
+            data = stream.read(self.max_output_bytes)
+        return data.decode("utf-8", errors="replace"), size > self.max_output_bytes
+
+    @staticmethod
+    def _terminate(process: subprocess.Popen[bytes]) -> None:
+        if process.poll() is not None:
+            return
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        try:
+            process.wait(timeout=2)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+class LocalGateway:
+    def __init__(
+        self,
+        state_dir: Path,
+        *,
+        workers: int = 1,
+        max_output_bytes: int = DEFAULT_OUTPUT_LIMIT,
+    ) -> None:
+        self.state_dir = state_dir
+        self.state_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self._state_lock = (self.state_dir / ".scheduler.lock").open("a+")
+        self._state_lock_path = self.state_dir / ".scheduler.lock"
+        self._state_lock_path.chmod(0o600)
+        try:
+            fcntl.flock(self._state_lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            self._state_lock.close()
+            raise RuntimeError(f"state directory is already in use: {self.state_dir}") from exc
+        self.store = JobStore(self.state_dir / "jobs.db")
+        self.scheduler = LocalScheduler(
+            self.store,
+            self.state_dir / "jobs",
+            workers=workers,
+            max_output_bytes=max_output_bytes,
+        )
+        self._env_lock = threading.Lock()
+        self._env_cache: dict[str, Any] | None = None
+
+    def start(self) -> None:
+        self.scheduler.start()
+
+    def close(self) -> None:
+        self.scheduler.stop()
+        self.store.close()
+        fcntl.flock(self._state_lock.fileno(), fcntl.LOCK_UN)
+        self._state_lock.close()
+
+    def submit_dev(self, payload: Any, trace_id: str) -> tuple[dict[str, Any], bool]:
+        request = _validate_dev_request(payload)
+        job, created = self.store.create(SUPPORTED_KIND, request, trace_id)
+        if created:
+            self.scheduler.notify()
+        accepted = {
+            "job_id": job["job_id"],
+            "kind": job["kind"],
+            "status": job["status"],
+            "trace_id": job["trace_id"],
+        }
+        return accepted, created
+
+    def environment(self, force: bool = False) -> dict[str, Any]:
+        with self._env_lock:
+            if self._env_cache is None or force:
+                self._env_cache = _probe_environment()
+            return dict(self._env_cache)
+
+
+def _probe_environment() -> dict[str, Any]:
+    info: dict[str, Any] = {
+        "gpu": "local",
+        "vendor": "unknown",
+        "gpu_model": None,
+        "aliases": ["local"],
+        "arch": None,
+        "sm_count": None,
+        "total_memory_mb": None,
+        "driver_version": None,
+        "toolchain": {"python": platform.python_version()},
+        "source": "declared",
+        "probed_at": datetime.now(timezone.utc).isoformat(),
+        "probe_error": None,
+    }
+    errors: list[str] = []
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,memory.total,driver_version",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        first = result.stdout.splitlines()[0]
+        model, memory, driver = (part.strip() for part in first.split(",", 2))
+        info.update(
+            vendor="nvidia",
+            gpu_model=model,
+            total_memory_mb=int(float(memory)),
+            driver_version=driver,
+            source="probe",
+        )
+    except (OSError, subprocess.SubprocessError, ValueError, IndexError) as exc:
+        errors.append(f"nvidia-smi: {exc}")
+
+    try:
+        code = (
+            "import json, torch; p=torch.cuda.get_device_properties(0); "
+            "hip=getattr(torch.version,'hip',None); "
+            "arch=(getattr(p,'gcnArchName','').split(':')[0] if hip else "
+            "'sm_%d%d'%torch.cuda.get_device_capability(0)); "
+            "print(json.dumps({'arch':arch,'sm_count':p.multi_processor_count,"
+            "'torch':torch.__version__,'runtime':hip or torch.version.cuda}))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=True,
+        )
+        runtime = json.loads(result.stdout)
+        info["arch"] = runtime["arch"]
+        info["sm_count"] = runtime["sm_count"]
+        info["toolchain"].update(
+            torch=runtime["torch"],
+            runtime=runtime["runtime"],
+        )
+        info["source"] = "probe"
+        if info["vendor"] == "unknown":
+            info["vendor"] = "amd" if str(runtime["arch"]).startswith("gfx") else "nvidia"
+    except (OSError, subprocess.SubprocessError, ValueError, KeyError) as exc:
+        errors.append(f"torch: {exc}")
+    if errors and info["source"] == "declared":
+        info["probe_error"] = "; ".join(errors)
+    return info
+
+
+class GatewayRequestHandler(BaseHTTPRequestHandler):
+    gateway: LocalGateway
+    body_limit = DEFAULT_BODY_LIMIT
+    server_version = "atrex-local-gateway/0.1"
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+        parsed = urlsplit(self.path)
+        path = parsed.path.rstrip("/") or "/"
+        query = parse_qs(parsed.query)
+        trace_id = self._trace_id()
+        if path in ("/healthz", "/status.taobao"):
+            self._send_text(HTTPStatus.OK, "ok")
+            return
+        if path == "/v1/env":
+            env = self.gateway.environment(force=self._bool_query(query, "force"))
+            self._send_json(HTTPStatus.OK, {"env": [env]})
+            return
+        if path.startswith("/v1/env/"):
+            gpu = unquote(path.removeprefix("/v1/env/"))
+            if gpu != "local":
+                self._not_found("environment_not_found", f"environment {gpu!r} not found", trace_id)
+                return
+            self._send_json(
+                HTTPStatus.OK,
+                self.gateway.environment(force=self._bool_query(query, "force")),
+            )
+            return
+        if path == "/v1/jobs":
+            kind = self._first(query, "kind")
+            status = self._first(query, "status")
+            user = self._first(query, "user")
+            if kind is not None and kind not in KNOWN_KINDS:
+                self._bad_request("invalid_kind", f"unknown job kind {kind!r}", trace_id)
+                return
+            if status is not None and status not in VALID_STATUSES:
+                self._bad_request("invalid_status", f"unknown job status {status!r}", trace_id)
+                return
+            try:
+                limit = min(200, max(1, int(self._first(query, "limit") or "50")))
+            except ValueError:
+                self._bad_request("invalid_limit", "limit must be an integer", trace_id)
+                return
+            descending = (self._first(query, "sort") or "-created_at") != "created_at"
+            jobs = self.gateway.store.list(
+                kind=kind,
+                user=user,
+                status=status,
+                limit=limit,
+                descending=descending,
+            )
+            self._send_json(HTTPStatus.OK, {"jobs": jobs})
+            return
+        job_id = self._job_id_from_get_path(path)
+        if job_id is not None:
+            job = self.gateway.store.get(job_id)
+            if job is None:
+                self._not_found("job_not_found", f"job {job_id!r} not found", trace_id)
+                return
+            if self._bool_query(query, "wait") and job["status"] not in TERMINAL_STATUSES:
+                try:
+                    timeout = min(300.0, max(0.0, float(self._first(query, "timeout") or "30")))
+                except ValueError:
+                    self._bad_request("invalid_timeout", "timeout must be numeric", trace_id)
+                    return
+                job = self.gateway.scheduler.wait_for_job(job_id, timeout) or job
+            self._send_json(HTTPStatus.OK, job)
+            return
+        self._not_found("route_not_found", f"route {path!r} not found", trace_id)
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        parsed = urlsplit(self.path)
+        path = parsed.path.rstrip("/") or "/"
+        trace_id = self._trace_id()
+        cancel_match = re.fullmatch(r"/v1/jobs/([^/]+)/cancel", path)
+        if cancel_match:
+            job_id = unquote(cancel_match.group(1))
+            job = self.gateway.scheduler.cancel(job_id)
+            if job is None:
+                self._not_found("job_not_found", f"job {job_id!r} not found", trace_id)
+            else:
+                self._send_json(HTTPStatus.OK, job)
+            return
+        if path == "/v1/jobs/dev":
+            try:
+                payload = self._read_json()
+                accepted, _ = self.gateway.submit_dev(payload, trace_id)
+            except RequestError as exc:
+                self._send_json(exc.status, _error(exc.reason, str(exc), trace_id))
+                return
+            except ValueError as exc:
+                self._send_json(
+                    HTTPStatus.UNPROCESSABLE_ENTITY,
+                    _error("validation_error", str(exc), trace_id),
+                )
+                return
+            self._send_json(HTTPStatus.ACCEPTED, accepted)
+            return
+        kind_match = re.fullmatch(r"/v1/jobs/(eval|profile|disassemble)", path)
+        if kind_match or path == "/v1/evals":
+            kind = kind_match.group(1) if kind_match else "eval"
+            self._send_json(
+                HTTPStatus.NOT_IMPLEMENTED,
+                _error(
+                    "kind_not_supported",
+                    f"community localhost scheduler supports dev jobs; {kind} jobs are not implemented",
+                    trace_id,
+                ),
+            )
+            return
+        self._not_found("route_not_found", f"route {path!r} not found", trace_id)
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        print(f"[local-gateway] {self.address_string()} {fmt % args}", file=sys.stderr)
+
+    def _read_json(self) -> Any:
+        raw_length = self.headers.get("Content-Length")
+        try:
+            length = int(raw_length or "0")
+        except ValueError as exc:
+            raise RequestError(HTTPStatus.BAD_REQUEST, "invalid_content_length", "invalid Content-Length") from exc
+        if length <= 0:
+            raise RequestError(HTTPStatus.BAD_REQUEST, "empty_body", "request body is required")
+        if length > self.body_limit:
+            raise RequestError(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "request_too_large", "request body is too large")
+        try:
+            return json.loads(self.rfile.read(length))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise RequestError(HTTPStatus.BAD_REQUEST, "invalid_json", "request body is not valid JSON") from exc
+
+    def _job_id_from_get_path(self, path: str) -> str | None:
+        match = re.fullmatch(r"/v1/jobs/([^/]+)", path)
+        if match:
+            return unquote(match.group(1))
+        legacy = re.fullmatch(r"/v1/evals/([^/]+)", path)
+        return unquote(legacy.group(1)) if legacy else None
+
+    def _trace_id(self) -> str:
+        incoming = self.headers.get("X-Trace-Id")
+        return incoming if incoming and len(incoming) <= 128 else f"req-{secrets.token_hex(6)}"
+
+    @staticmethod
+    def _first(query: dict[str, list[str]], name: str) -> str | None:
+        values = query.get(name)
+        return values[0] if values else None
+
+    def _bool_query(self, query: dict[str, list[str]], name: str) -> bool:
+        value = (self._first(query, name) or "false").lower()
+        return value in {"1", "true", "yes", "on"}
+
+    def _bad_request(self, reason: str, message: str, trace_id: str) -> None:
+        self._send_json(HTTPStatus.BAD_REQUEST, _error(reason, message, trace_id))
+
+    def _not_found(self, reason: str, message: str, trace_id: str) -> None:
+        self._send_json(HTTPStatus.NOT_FOUND, _error(reason, message, trace_id))
+
+    def _send_text(self, status: HTTPStatus, value: str) -> None:
+        data = value.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_json(self, status: HTTPStatus, value: Any) -> None:
+        data = _json_dumps(value).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+class RequestError(Exception):
+    def __init__(self, status: HTTPStatus, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+        self.reason = reason
+
+
+def create_server(
+    gateway: LocalGateway,
+    host: str,
+    port: int,
+    *,
+    body_limit: int = DEFAULT_BODY_LIMIT,
+) -> ThreadingHTTPServer:
+    handler = type(
+        "BoundGatewayRequestHandler",
+        (GatewayRequestHandler,),
+        {"gateway": gateway, "body_limit": body_limit},
+    )
+    return ThreadingHTTPServer((host, port), handler)
+
+
+def _default_state_dir() -> Path:
+    base = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return base / "atrex-local-gateway"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Queue agate dev jobs on a trusted localhost GPU.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    serve = subparsers.add_parser("serve", help="start the localhost-compatible HTTP server")
+    serve.add_argument("--host", default="127.0.0.1")
+    serve.add_argument("--port", type=int, default=8000)
+    serve.add_argument("--state-dir", type=Path, default=_default_state_dir())
+    serve.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="concurrent local commands (default: 1, FIFO serialization)",
+    )
+    serve.add_argument("--max-request-mb", type=int, default=32)
+    serve.add_argument("--max-output-mb", type=int, default=32)
+    serve.add_argument(
+        "--allow-remote",
+        action="store_true",
+        help="allow a non-loopback bind; unsafe because commands run without isolation",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command != "serve":
+        parser.error("a command is required")
+    if not 1 <= args.port <= 65535:
+        parser.error("--port must be in 1..65535")
+    if not 1 <= args.workers <= 64:
+        parser.error("--workers must be in 1..64")
+    if args.max_request_mb <= 0 or args.max_output_mb <= 0:
+        parser.error("request/output limits must be positive")
+    if args.host not in {"127.0.0.1", "localhost", "::1"} and not args.allow_remote:
+        parser.error("non-loopback --host requires --allow-remote")
+
+    try:
+        gateway = LocalGateway(
+            args.state_dir.resolve(),
+            workers=args.workers,
+            max_output_bytes=args.max_output_mb * 1024 * 1024,
+        )
+    except RuntimeError as exc:
+        print(f"local-gateway: {exc}", file=sys.stderr)
+        return 2
+    server = create_server(
+        gateway,
+        args.host,
+        args.port,
+        body_limit=args.max_request_mb * 1024 * 1024,
+    )
+    gateway.start()
+    actual_host, actual_port = server.server_address[:2]
+    print(
+        f"[local-gateway] listening on http://{actual_host}:{actual_port} "
+        f"workers={args.workers} state={args.state_dir.resolve()}",
+        flush=True,
+    )
+    print(
+        "[local-gateway] WARNING: commands run as the current user without isolation; trusted inputs only",
+        file=sys.stderr,
+        flush=True,
+    )
+
+    stopping = threading.Event()
+
+    def stop_server(signum: int, _frame: Any) -> None:
+        if stopping.is_set():
+            return
+        stopping.set()
+        print(f"[local-gateway] received signal {signum}; shutting down", file=sys.stderr, flush=True)
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    previous_handlers: dict[int, Any] = {}
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        previous_handlers[signum] = signal.signal(signum, stop_server)
+    try:
+        server.serve_forever(poll_interval=0.25)
+    finally:
+        server.server_close()
+        gateway.close()
+        for signum, previous in previous_handlers.items():
+            signal.signal(signum, previous)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/local_gateway.py
+++ b/tools/local_gateway.py
@@ -336,9 +336,6 @@ def _validate_dev_request(payload: Any) -> dict[str, Any]:
     targets = spec.get("target_hardware") if isinstance(spec, dict) else None
     if not isinstance(targets, list) or not targets or not all(isinstance(v, str) for v in targets):
         raise ValueError("spec.target_hardware must be a non-empty string array")
-    if "local" not in targets:
-        raise ValueError("localhost scheduler only accepts target_hardware=['local']")
-
     command = payload.get("command")
     if not isinstance(command, str) or not command.strip():
         raise ValueError("command must be a non-empty string")
@@ -593,6 +590,7 @@ class LocalGateway:
         *,
         workers: int = 1,
         max_output_bytes: int = DEFAULT_OUTPUT_LIMIT,
+        gpu_aliases: tuple[str, ...] = (),
     ) -> None:
         self.state_dir = state_dir
         self.state_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -605,6 +603,7 @@ class LocalGateway:
             self._state_lock.close()
             raise RuntimeError(f"state directory is already in use: {self.state_dir}") from exc
         self.store = JobStore(self.state_dir / "jobs.db")
+        self.gpu_aliases = frozenset(("local", *gpu_aliases))
         self.scheduler = LocalScheduler(
             self.store,
             self.state_dir / "jobs",
@@ -625,6 +624,12 @@ class LocalGateway:
 
     def submit_dev(self, payload: Any, trace_id: str) -> tuple[dict[str, Any], bool]:
         request = _validate_dev_request(payload)
+        targets = request["spec"]["target_hardware"]
+        if not any(target in self.gpu_aliases for target in targets):
+            accepted = ", ".join(sorted(self.gpu_aliases))
+            raise ValueError(
+                f"localhost scheduler accepts target_hardware aliases: {accepted}"
+            )
         job, created = self.store.create(SUPPORTED_KIND, request, trace_id)
         if created:
             self.scheduler.notify()
@@ -640,7 +645,9 @@ class LocalGateway:
         with self._env_lock:
             if self._env_cache is None or force:
                 self._env_cache = _probe_environment()
-            return dict(self._env_cache)
+            result = dict(self._env_cache)
+            result["aliases"] = sorted(self.gpu_aliases)
+            return result
 
 
 def _probe_environment() -> dict[str, Any]:
@@ -928,6 +935,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=1,
         help="concurrent local commands (default: 1, FIFO serialization)",
     )
+    serve.add_argument(
+        "--gpu-alias",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="additional hardware token accepted as the local GPU (repeatable)",
+    )
     serve.add_argument("--max-request-mb", type=int, default=32)
     serve.add_argument("--max-output-mb", type=int, default=32)
     serve.add_argument(
@@ -949,6 +963,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--workers must be in 1..64")
     if args.max_request_mb <= 0 or args.max_output_mb <= 0:
         parser.error("request/output limits must be positive")
+    if any(not alias or len(alias) > 128 for alias in args.gpu_alias):
+        parser.error("--gpu-alias values must be non-empty and at most 128 characters")
     if args.host not in {"127.0.0.1", "localhost", "::1"} and not args.allow_remote:
         parser.error("non-loopback --host requires --allow-remote")
 
@@ -957,6 +973,7 @@ def main(argv: list[str] | None = None) -> int:
             args.state_dir.resolve(),
             workers=args.workers,
             max_output_bytes=args.max_output_mb * 1024 * 1024,
+            gpu_aliases=tuple(args.gpu_alias),
         )
     except RuntimeError as exc:
         print(f"local-gateway: {exc}", file=sys.stderr)

--- a/tools/profile_nvidia.sh
+++ b/tools/profile_nvidia.sh
@@ -187,6 +187,26 @@ if ! command -v nvidia-smi &>/dev/null; then
     exit 1
 fi
 
+# Nsight Compute ships its Python report API beside the GUI/CLI installation,
+# not in the active Python environment's site-packages.  Remote pods often set
+# this path for us; a localhost gateway intentionally inherits the host Python
+# environment and therefore needs explicit discovery.
+if ! python3 -c 'import ncu_report' &>/dev/null; then
+    shopt -s nullglob
+    NCU_PYTHON_CANDIDATES=(
+        /opt/nvidia/nsight-compute/*/extras/python
+        /usr/local/cuda/nsight-compute-*/extras/python
+        /usr/local/cuda-*/nsight-compute-*/extras/python
+    )
+    shopt -u nullglob
+    for candidate in "${NCU_PYTHON_CANDIDATES[@]}"; do
+        if [[ -f "$candidate/ncu_report.py" ]]; then
+            export PYTHONPATH="$candidate${PYTHONPATH:+:$PYTHONPATH}"
+            break
+        fi
+    done
+fi
+
 # Detect ncu report helpers path (bundled copy ships in tools/ncu_helpers/)
 if [[ -z "$NCU_HELPERS" ]]; then
     SEARCH_PATHS=(
@@ -225,6 +245,7 @@ echo "  Step 1: Collect ncu full report"
 echo "=========================================="
 
 ncu --set full \
+    --force-overwrite \
     --launch-skip "$LAUNCH_SKIP" \
     --launch-count "$LAUNCH_COUNT" \
     --kill yes \
@@ -245,6 +266,7 @@ if [[ "$COLLECT_SOURCE" == true ]]; then
     echo "=========================================="
 
     ncu --set source \
+        --force-overwrite \
         --section SourceCounters \
         --launch-skip "$LAUNCH_SKIP" \
         --launch-count "$LAUNCH_COUNT" \

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+# Copyright 2026 Alibaba Group.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run a workspace command in an atrex-gpu-gateway GPU sandbox.
+
+The gateway's sandbox primitive is ``agate dev``.  This wrapper makes it useful
+for the optimizer by shipping a self-contained workspace into the pod and
+copying the small, durable results back afterwards.  A new pod may be selected
+for every invocation; callers must not rely on remote filesystem persistence.
+
+Examples::
+
+    python tools/sandbox.py --hardware REMOTE_GPU --no-sync -- python test_kernel.py --no-memory
+    python tools/sandbox.py --hardware REMOTE_GPU --sync profiles/v1 -- \
+        bash tools/profile_nvidia.sh kernel.py --output-dir profiles/v1 --source
+    python tools/sandbox.py --hardware REMOTE_ACCELERATOR --gateway-profile pre --sync profiles/v1 -- \
+        bash tools/profile_kernel.sh kernel.py --output-dir profiles/v1
+
+``ATREX_SANDBOX_GPU``, ``ATREX_SANDBOX_PROFILE``, ``ATREX_SANDBOX_URL``, and
+``ATREX_SANDBOX_TIMEOUT`` provide defaults for the corresponding flags.  A
+localhost gateway uses the same transport as a remote worker, for example
+``ATREX_SANDBOX_GPU=local`` plus
+``ATREX_SANDBOX_URL=http://127.0.0.1:8000``.  Authentication and any remaining
+URL resolution stay agate's responsibility (AGATE_* or ~/.atrex/config.json).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SYNC_PATHS = ("profiles",)
+INPUT_SKIP_DIRS = {
+    ".git",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    # Memory is optimizer state owned and updated by the local agent.  The pod
+    # receives only code/harness inputs and returns test output/profile files.
+    "memory",
+    # Runtime/knowledge symlinks are useful to the local agent but are not
+    # required by correctness, performance, or profiler commands in the pod.
+    ".claude",
+    "gpu-wiki",
+    "reference-projects",
+    "skills",
+    # Plans and humanize state are local campaign inputs for the agent, never
+    # runtime inputs for the command executing in the GPU pod.  In particular,
+    # preserved implementation patches can be large enough to push agate's
+    # single uploaded-file argument past Linux MAX_ARG_STRLEN.
+    "plans",
+    ".humanize",
+}
+INPUT_SKIP_PATHS = {
+    # A pod must not recursively submit another sandbox job, and memory updates
+    # are deliberately local-only.  Omitting these also leaves useful headroom
+    # below the gateway worker's per-argument limit.
+    "tools/sandbox.py",
+    "tools/memory_manager.py",
+}
+INPUT_SKIP_SUFFIXES = {
+    ".pyc", ".pyo", ".ncu-rep", ".att", ".pftrace", ".otf2",
+    # Campaign documentation, plans, and prior profile reports are local agent
+    # state.  Remote correctness/profile commands only need executable sources
+    # and harness inputs; omitting Markdown also keeps agate's uploaded file
+    # arguments below the worker's argv size limit on long-running campaigns.
+    ".md",
+}
+OUTPUT_BEGIN = "__ATREX_SANDBOX_OUTPUT_BEGIN__"
+OUTPUT_END = "__ATREX_SANDBOX_OUTPUT_END__"
+
+
+def _safe_relative(value: str) -> str:
+    path = PurePosixPath(value)
+    if not value or path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"path must be relative to the workspace: {value!r}")
+    normalized = path.as_posix()
+    if normalized in ("", "."):
+        raise ValueError(f"path must not resolve to the workspace root: {value!r}")
+    return normalized
+
+
+def _walk_files(root: Path) -> Iterable[Path]:
+    """Yield regular files below root without following directory symlinks."""
+    for current, dirs, files in os.walk(root, followlinks=False):
+        dirs[:] = [
+            name for name in dirs
+            if name not in INPUT_SKIP_DIRS and not (Path(current) / name).is_symlink()
+        ]
+        for name in files:
+            path = Path(current) / name
+            if path.is_file() and not path.is_symlink():
+                yield path
+
+
+def _make_input_bundle(
+    workspace: Path,
+    max_file_bytes: int,
+    profile_input_paths: Iterable[str] = (),
+) -> tuple[str, int, list[str]]:
+    """Return a base64 tarball containing the workspace and runtime tools."""
+    archive = io.BytesIO()
+    seen: set[str] = set()
+    skipped: list[str] = []
+    count = 0
+    profile_roots = tuple(path.rstrip("/") for path in profile_input_paths)
+
+    def add_tree(tf: tarfile.TarFile, source: Path, prefix: str = "") -> None:
+        nonlocal count
+        if not source.is_dir():
+            return
+        for path in _walk_files(source):
+            rel = path.relative_to(source).as_posix()
+            arcname = f"{prefix}/{rel}" if prefix else rel
+            arc_parts = PurePosixPath(arcname).parts
+            # Profile reports/metrics are synchronized back for local analysis
+            # and must not be re-uploaded on every later test.  Only executable
+            # profile harnesses requested by this invocation are inputs to a
+            # fresh sandbox job.  Historical harnesses are local campaign state
+            # and accumulate indefinitely on long-running optimizations.
+            if arc_parts and arc_parts[0] == "profiles":
+                if "harness" not in arc_parts or not any(
+                    arcname == root or arcname.startswith(root + "/")
+                    for root in profile_roots
+                ):
+                    continue
+            if (
+                arcname in seen
+                or arcname in INPUT_SKIP_PATHS
+                or path.suffix in INPUT_SKIP_SUFFIXES
+            ):
+                continue
+            try:
+                size = path.stat().st_size
+            except OSError as exc:
+                skipped.append(f"{arcname} ({exc})")
+                continue
+            if size > max_file_bytes:
+                skipped.append(f"{arcname} ({size} bytes > input limit)")
+                continue
+            tf.add(path, arcname=arcname, recursive=False)
+            seen.add(arcname)
+            count += 1
+
+    with tarfile.open(fileobj=archive, mode="w:gz") as tf:
+        add_tree(tf, workspace)
+        # Optimization workspaces receive tools/ as a symlink.  Materialize the
+        # small tool directory so remote profile commands are self-contained.
+        workspace_tools = workspace / "tools"
+        if workspace_tools.is_symlink() or not workspace_tools.exists():
+            add_tree(tf, REPO_ROOT / "tools", "tools")
+
+    return base64.b64encode(archive.getvalue()).decode("ascii"), count, skipped
+
+
+REMOTE_COLLECTOR = r'''#!/usr/bin/env python3
+import base64
+import io
+import json
+import sys
+import tarfile
+from pathlib import Path, PurePosixPath
+
+BEGIN = "__ATREX_SANDBOX_OUTPUT_BEGIN__"
+END = "__ATREX_SANDBOX_OUTPUT_END__"
+RAW = {".ncu-rep", ".att", ".pftrace", ".otf2"}
+
+root = Path(sys.argv[1]).resolve()
+cfg = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+max_bytes = int(cfg["max_file_bytes"])
+include_raw = bool(cfg["include_raw_profile"])
+archive = io.BytesIO()
+skipped = []
+seen = set()
+
+def safe(value):
+    p = PurePosixPath(value)
+    return bool(value) and not p.is_absolute() and ".." not in p.parts
+
+def add_file(tf, path):
+    rel = path.relative_to(root).as_posix()
+    if rel in seen or path.is_symlink() or not path.is_file():
+        return
+    size = path.stat().st_size
+    if (not include_raw and path.suffix in RAW) or size > max_bytes:
+        skipped.append(f"{rel} ({size} bytes)")
+        return
+    tf.add(path, arcname=rel, recursive=False)
+    seen.add(rel)
+
+with tarfile.open(fileobj=archive, mode="w:gz") as tf:
+    for value in cfg["paths"]:
+        if not safe(value):
+            continue
+        path = root / value
+        if path.is_file():
+            add_file(tf, path)
+        elif path.is_dir():
+            for child in path.rglob("*"):
+                add_file(tf, child)
+
+if skipped:
+    print("[sandbox] artifacts not returned: " + ", ".join(skipped), file=sys.stderr)
+print(BEGIN)
+print(base64.b64encode(archive.getvalue()).decode("ascii"))
+print(END)
+'''
+
+
+def _runner_source() -> str:
+    return r'''#!/usr/bin/env bash
+set -uo pipefail
+mkdir -p workspace
+if ! base64 -d __atrex_workspace.tar.gz.b64 | tar -xzf - -C workspace; then
+    echo "[sandbox] failed to unpack workspace" >&2
+    exit 97
+fi
+cd workspace
+set +e
+bash ../__atrex_command.sh
+command_status=$?
+cd ..
+python __atrex_collect.py workspace __atrex_outputs.json
+collect_status=$?
+if [[ $collect_status -ne 0 ]]; then
+    exit 98
+fi
+exit $command_status
+'''
+
+
+def _extract_outputs(stdout: str, workspace: Path) -> str:
+    """Extract the returned archive and return command stdout without framing."""
+    if OUTPUT_BEGIN not in stdout or OUTPUT_END not in stdout:
+        raise RuntimeError("sandbox response did not contain an artifact frame")
+    command_stdout, framed = stdout.rsplit(OUTPUT_BEGIN, 1)
+    encoded, trailing = framed.split(OUTPUT_END, 1)
+    if trailing.strip():
+        command_stdout += trailing
+    payload = base64.b64decode("".join(encoded.split()), validate=True)
+    with tarfile.open(fileobj=io.BytesIO(payload), mode="r:gz") as tf:
+        for member in tf.getmembers():
+            path = PurePosixPath(member.name)
+            if path.is_absolute() or ".." in path.parts:
+                raise RuntimeError(f"unsafe artifact path returned by sandbox: {member.name!r}")
+            if member.issym() or member.islnk():
+                raise RuntimeError(f"sandbox artifact links are not accepted: {member.name!r}")
+            target = workspace / path.as_posix()
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                continue
+            source = tf.extractfile(member)
+            if source is None:
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(source.read())
+            try:
+                target.chmod(member.mode & 0o777)
+            except OSError:
+                pass
+    return command_stdout.rstrip("\n")
+
+
+def _command_text(parts: list[str]) -> str:
+    if parts and parts[0] == "--":
+        parts = parts[1:]
+    if not parts:
+        raise ValueError("a command is required after --")
+    # A single argument is commonly a deliberately quoted shell pipeline.
+    return parts[0] if len(parts) == 1 else shlex.join(parts)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run correctness, performance, or profile commands in an agate GPU sandbox.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--hardware",
+        default=os.environ.get("ATREX_SANDBOX_GPU", ""),
+        help="Gateway GPU hardware token, e.g. REMOTE_GPU (default: ATREX_SANDBOX_GPU).",
+    )
+    parser.add_argument(
+        "--gateway-profile",
+        choices=("pre", "prod"),
+        default=None,
+        help="Gateway endpoint profile (default: ATREX_SANDBOX_PROFILE, then normal agate resolution).",
+    )
+    parser.add_argument(
+        "--url",
+        default=None,
+        help="Explicit gateway URL (default: ATREX_SANDBOX_URL; overrides environment profile/config).",
+    )
+    parser.add_argument("--workspace", default=".", help="Local workspace to upload (default: cwd).")
+    parser.add_argument(
+        "--timeout", type=int, default=int(os.environ.get("ATREX_SANDBOX_TIMEOUT", "600")),
+        help="Remote command timeout in seconds, 1..600 (default: 600; gateway limit).",
+    )
+    parser.add_argument(
+        "--sync", action="append", default=[], metavar="PATH",
+        help="Relative profile/result path to copy back (repeatable; default: profiles).",
+    )
+    parser.add_argument("--no-sync", action="store_true", help="Do not copy any files back.")
+    parser.add_argument(
+        "--include-raw-profile", action="store_true",
+        help="Return raw .ncu-rep/ATT artifacts (can make the gateway response very large).",
+    )
+    parser.add_argument(
+        "--max-input-file-mb", type=int, default=16,
+        help="Skip individual workspace input files larger than this (default: 16 MiB).",
+    )
+    parser.add_argument(
+        "--max-output-file-mb", type=int, default=8,
+        help="Skip individual returned artifacts larger than this (default: 8 MiB).",
+    )
+    parser.add_argument("-e", "--env", action="append", default=[], metavar="KEY=VALUE")
+    parser.add_argument(
+        "--keep-pod", action="store_true",
+        help="Ask the gateway not to recycle the pod; filesystem persistence is still not assumed.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Package and print the request summary only.")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="Command after --.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not args.hardware:
+        raise SystemExit("sandbox: --hardware or ATREX_SANDBOX_GPU is required")
+    # Explicit endpoint flags override inherited sandbox endpoint variables.  This
+    # matters when a long-lived optimization shell switches between a remote
+    # profile and localhost without first scrubbing its environment.
+    if args.url and args.gateway_profile:
+        raise SystemExit("sandbox: --url and --gateway-profile are mutually exclusive")
+    if args.url is not None:
+        args.gateway_profile = None
+    elif args.gateway_profile is not None:
+        args.url = ""
+    else:
+        args.url = os.environ.get("ATREX_SANDBOX_URL", "")
+        args.gateway_profile = os.environ.get("ATREX_SANDBOX_PROFILE") or None
+        if args.url and args.gateway_profile:
+            raise SystemExit(
+                "sandbox: ATREX_SANDBOX_URL and ATREX_SANDBOX_PROFILE are mutually exclusive"
+            )
+    if not 1 <= args.timeout <= 600:
+        raise SystemExit("sandbox: --timeout must be in the gateway-supported range 1..600")
+    if args.max_input_file_mb <= 0 or args.max_output_file_mb <= 0:
+        raise SystemExit("sandbox: file size limits must be positive")
+    try:
+        command = _command_text(args.command)
+        sync_paths = [] if args.no_sync else [
+            _safe_relative(path) for path in (args.sync or list(DEFAULT_SYNC_PATHS))
+        ]
+    except ValueError as exc:
+        raise SystemExit(f"sandbox: {exc}") from exc
+
+    workspace = Path(args.workspace).resolve()
+    if any(PurePosixPath(path).parts[0] == "memory" for path in sync_paths):
+        raise SystemExit("sandbox: memory/ is local optimizer state and cannot be synchronized")
+    if not workspace.is_dir():
+        raise SystemExit(f"sandbox: workspace not found: {workspace}")
+    profile_input_paths = [
+        path for path in sync_paths
+        if PurePosixPath(path).parts and PurePosixPath(path).parts[0] == "profiles"
+    ]
+    bundle, file_count, skipped = _make_input_bundle(
+        workspace,
+        args.max_input_file_mb * 1024 * 1024,
+        profile_input_paths,
+    )
+    bundle_bytes = len(bundle.encode("ascii"))
+    # Linux limits each individual argv entry to 128 KiB (MAX_ARG_STRLEN).
+    # agate's worker materializes an uploaded file through one such argument,
+    # so leave headroom for its framing instead of creating a doomed job.
+    if bundle_bytes > 120 * 1024:
+        raise SystemExit(
+            f"sandbox: packaged payload is {bundle_bytes / 1024:.1f} KiB, "
+            "above the safe 120 KiB gateway argument limit; exclude additional "
+            "local-only workspace artifacts"
+        )
+    print(
+        f"[sandbox] hardware={args.hardware} files={file_count} "
+        f"payload={bundle_bytes / 1024:.1f} KiB command={command!r}",
+        file=sys.stderr,
+    )
+    if skipped:
+        print("[sandbox] inputs skipped: " + ", ".join(skipped), file=sys.stderr)
+    if args.dry_run:
+        print(json.dumps({
+            "hardware": args.hardware,
+            "url": args.url or None,
+            "gateway_profile": args.gateway_profile,
+            "workspace": str(workspace),
+            "files": file_count,
+            "payload_bytes": bundle_bytes,
+            "sync": sync_paths,
+            "command": command,
+        }, indent=2))
+        return 0
+
+    output_cfg = {
+        "paths": sync_paths,
+        "max_file_bytes": args.max_output_file_mb * 1024 * 1024,
+        "include_raw_profile": args.include_raw_profile,
+    }
+    with tempfile.TemporaryDirectory(prefix="atrex-sandbox-") as temp_dir:
+        temp = Path(temp_dir)
+        bundle_path = temp / "workspace.tar.gz.b64"
+        command_path = temp / "command.sh"
+        collector_path = temp / "collect.py"
+        outputs_path = temp / "outputs.json"
+        bundle_path.write_text(bundle, encoding="ascii")
+        command_path.write_text("#!/usr/bin/env bash\nset -o pipefail\n" + command + "\n", encoding="utf-8")
+        collector_path.write_text(REMOTE_COLLECTOR, encoding="utf-8")
+        outputs_path.write_text(json.dumps(output_cfg), encoding="utf-8")
+
+        agate = ["agate", "dev"]
+        if args.url:
+            agate += ["--url", args.url]
+        elif args.gateway_profile:
+            agate += ["--profile", args.gateway_profile]
+        agate += [
+            "--gpu", args.hardware,
+            "--dev-timeout", str(args.timeout),
+            "--timeout", str(args.timeout + 120),
+            "--file", f"__atrex_workspace.tar.gz.b64={bundle_path}",
+            "--file", f"__atrex_command.sh={command_path}",
+            "--file", f"__atrex_collect.py={collector_path}",
+            "--file", f"__atrex_outputs.json={outputs_path}",
+        ]
+        for item in args.env:
+            if "=" not in item or item.startswith("="):
+                raise SystemExit(f"sandbox: invalid --env {item!r}; expected KEY=VALUE")
+            agate += ["--env-var", item]
+        if args.keep_pod:
+            agate.append("--no-recycle")
+        agate.append("bash __atrex_runner.sh")
+
+        # The runner is uploaded separately after the command has been assembled.
+        runner_path = temp / "runner.sh"
+        runner_path.write_text(_runner_source(), encoding="utf-8")
+        agate[-1:-1] = ["--file", f"__atrex_runner.sh={runner_path}"]
+
+        try:
+            proc = subprocess.run(agate, capture_output=True, text=True)
+        except FileNotFoundError as exc:
+            raise SystemExit(
+                "sandbox: agate not found; install atrex-gateway-client first"
+            ) from exc
+
+    if proc.stderr:
+        print(proc.stderr.rstrip(), file=sys.stderr)
+    try:
+        job = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        if proc.stdout:
+            print(proc.stdout.rstrip())
+        return proc.returncode or 2
+
+    result = job.get("result") or {}
+    remote_stdout = str(result.get("stdout") or "")
+    remote_stderr = str(result.get("stderr") or "")
+    try:
+        command_stdout = _extract_outputs(remote_stdout, workspace)
+    except (RuntimeError, ValueError, tarfile.TarError) as exc:
+        if remote_stdout:
+            print(remote_stdout.rstrip())
+        if remote_stderr:
+            print(remote_stderr.rstrip(), file=sys.stderr)
+        print(f"sandbox: {exc}; job_id={job.get('job_id')}", file=sys.stderr)
+        return int(result.get("exit_code") or proc.returncode or 2)
+    if command_stdout:
+        print(command_stdout)
+    if remote_stderr:
+        print(remote_stderr.rstrip(), file=sys.stderr)
+    remote_rc = result.get("exit_code")
+    if isinstance(remote_rc, int):
+        return remote_rc
+    return 0 if job.get("status") == "succeeded" else (proc.returncode or 1)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -81,6 +81,7 @@ INPUT_SKIP_PATHS = {
     # are deliberately local-only.  Omitting these also leaves useful headroom
     # below the gateway worker's per-argument limit.
     "tools/sandbox.py",
+    "tools/local_gateway.py",
     "tools/memory_manager.py",
 }
 INPUT_SKIP_SUFFIXES = {


### PR DESCRIPTION
## Summary

  - Add sandbox execution for correctness, performance validation, and profiling.
  - Support Claude and Qoder CLI as optimization agents.
  - Add an atrex-compatible localhost gateway with FIFO command scheduling.
  - Support configurable local GPU aliases.
  - Keep optimizer memory and workspace state local.

  ## Testing

  - `python -m unittest discover -s tests -p 'test_local_gateway.py' -v`
  - All 8 local gateway tests passed.