### PR TITLE
fix(sandbox): package Atrex-Bench SDK for evaluator jobs

### DIFF
--- a/tests/test_sandbox_runtime_bundle.py
+++ b/tests/test_sandbox_runtime_bundle.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import base64
+import io
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.sandbox import _make_atrex_bench_runtime_bundle
+
+
+class SandboxRuntimeBundleTest(unittest.TestCase):
+    def _runtime_workspace(self, root: Path, *, with_sdk: bool) -> Path:
+        runtime = root / "runtime"
+        package = runtime / "src" / "atrex_bench"
+        (package / "eval").mkdir(parents=True)
+        (runtime / "scripts").mkdir()
+        (runtime / "scripts" / "run_eval.py").write_text("# evaluator\n")
+        (package / "__init__.py").write_text("# package\n")
+        (package / "utils.py").write_text("# utilities\n")
+        (package / "eval" / "_runtime.py").write_text("# runtime\n")
+        if with_sdk:
+            (package / "sdk.py").write_text("SDK_MARKER = 'included'\n")
+
+        workspace = root / "workspace"
+        workspace.mkdir()
+        (workspace / "atrex-bench").symlink_to(runtime, target_is_directory=True)
+        return workspace
+
+    def _members(self, bundle: str) -> dict[str, bytes]:
+        payload = base64.b64decode(bundle, validate=True)
+        with tarfile.open(fileobj=io.BytesIO(payload), mode="r:gz") as archive:
+            return {
+                member.name: archive.extractfile(member).read()
+                for member in archive.getmembers()
+                if member.isfile()
+            }
+
+    def test_evaluator_bundle_includes_sdk_when_available(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="sandbox-runtime-sdk-") as temp:
+            workspace = self._runtime_workspace(Path(temp), with_sdk=True)
+            bundle = _make_atrex_bench_runtime_bundle(workspace, evaluator_only=True)
+
+        self.assertIsNotNone(bundle)
+        members = self._members(bundle)
+        sdk_path = "atrex-bench/src/atrex_bench/sdk.py"
+        self.assertEqual(members[sdk_path], b"SDK_MARKER = 'included'\n")
+
+    def test_evaluator_bundle_remains_compatible_without_sdk(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="sandbox-runtime-legacy-") as temp:
+            workspace = self._runtime_workspace(Path(temp), with_sdk=False)
+            bundle = _make_atrex_bench_runtime_bundle(workspace, evaluator_only=True)
+
+        self.assertIsNotNone(bundle)
+        members = self._members(bundle)
+        self.assertNotIn("atrex-bench/src/atrex_bench/sdk.py", members)
+        self.assertIn("atrex-bench/src/atrex_bench/__init__.py", members)
+        self.assertIn("atrex-bench/src/atrex_bench/utils.py", members)
+        self.assertIn("atrex-bench/src/atrex_bench/eval/_runtime.py", members)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -662,6 +662,7 @@ def _make_atrex_bench_runtime_bundle(
     package = runtime_root / "src" / "atrex_bench"
     runtime_module = package / "eval" / "_runtime.py"
     utils_module = package / "utils.py"
+    sdk_module = package / "sdk.py"
     if (
         not package.is_dir()
         or (minimal and not runtime_module.is_file())
@@ -680,6 +681,12 @@ def _make_atrex_bench_runtime_bundle(
             )
         elif evaluator_only:
             evaluator_files = [package / "__init__.py", utils_module]
+            # Newer Atrex-Bench releases re-export the Python evaluation API
+            # from ``atrex_bench.__init__``.  Keep the file optional so the
+            # evaluator-only bundle remains compatible with older releases
+            # that predate sdk.py.
+            if sdk_module.is_file():
+                evaluator_files.append(sdk_module)
             evaluator_files.extend(_walk_files(package / "eval"))
             tf.add(run_eval, arcname="atrex-bench/scripts/run_eval.py", recursive=False)
             for path in evaluator_files:


### PR DESCRIPTION
## Summary

- include src/atrex_bench/sdk.py in evaluator-only runtime bundles when the file exists
- keep sdk.py optional so older Atrex-Bench checkouts remain supported
- add regression coverage for both SDK-enabled and legacy package layouts

## Why

Newer Atrex-Bench versions re-export the Python evaluation API from atrex_bench/__init__.py. Long Horizon ABBA verification uses the evaluator-only agate dev bundle, which previously uploaded __init__.py without sdk.py and failed before kernel evaluation with ModuleNotFoundError.

## Compatibility

The change only affects evaluator-only runtime packaging. Minimal dispatch-signature bundles, full runtime bundles, typed gateway evaluation, and legacy Atrex-Bench trees without sdk.py retain their existing behavior.

## Tests

- python -m unittest tests.test_sandbox_runtime_bundle -v
- python -m compileall -q tools/sandbox.py tests/test_sandbox_runtime_bundle.py
- git diff --check

The two new compatibility tests pass. Full-suite collection on this machine also encounters pre-existing unrelated constraints: torch is unavailable for test_aggregate_dispatch, and test_local_gateway expects HTTP 501 while current main returns 422.