### PR TITLE
feat: add ordinary-iteration phase token telemetry

### DIFF
--- a/orchestrator/optimize.py
+++ b/orchestrator/optimize.py
@@ -82,6 +82,7 @@ from typing import Callable, Optional
 try:
     from . import agent_runtime as _agent_runtime
     from .aggregate_dispatch import embed_bucket_sources
+    from .telemetry import IterationTelemetryRecorder, changed_paths_since
     from .optimization_policy import (
         OPTIMIZATION_MODE_CHOICES,
         install_workspace_policy,
@@ -93,6 +94,10 @@ try:
 except ImportError:  # direct script execution: python orchestrator/optimize.py
     import agent_runtime as _agent_runtime  # type: ignore[no-redef]
     from aggregate_dispatch import embed_bucket_sources  # type: ignore[no-redef]
+    from telemetry import (  # type: ignore[no-redef]
+        IterationTelemetryRecorder,
+        changed_paths_since,
+    )
     from optimization_policy import (  # type: ignore[no-redef]
         OPTIMIZATION_MODE_CHOICES,
         install_workspace_policy,
@@ -475,6 +480,10 @@ class SessionResult:
     stdout_tail: str
     stderr_tail: str
     session_id: str = ""
+    terminal_usage: _agent_runtime.TokenUsage | None = None
+    events: tuple[_agent_runtime.NormalizedAgentEvent, ...] = ()
+    capabilities: _agent_runtime.AgentRuntimeCapabilities | None = None
+    observation_errors: tuple[str, ...] = ()
 
 
 def _render(template_path: Path, **kw: str) -> str:
@@ -662,6 +671,7 @@ def run_session(
     sandbox_url: str = "",
     sandbox_timeout: int = DEFAULT_SANDBOX_TIMEOUT,
     reasoning_effort: str = "max",
+    extra_environment: Optional[dict[str, str]] = None,
 ) -> SessionResult:
     """Run one clean coding-agent session with no conversational memory from prior iterations."""
     session_id = str(uuid.uuid4())
@@ -681,6 +691,7 @@ def run_session(
             sandbox_url=sandbox_url,
             sandbox_timeout_s=sandbox_timeout,
             session_id=session_id,
+            extra_environment=extra_environment,
         )
     )
     return SessionResult(
@@ -690,6 +701,10 @@ def run_session(
         stdout_tail=result.stdout_tail,
         stderr_tail=result.stderr_tail,
         session_id=result.session_id,
+        terminal_usage=result.terminal_usage,
+        events=result.events,
+        capabilities=result.capabilities,
+        observation_errors=result.observation_errors,
     )
 
 
@@ -2561,6 +2576,53 @@ class Campaign:
                 flush=True,
             )
 
+    def _begin_iteration_telemetry(
+        self, n: int, pre_head: str
+    ) -> Optional[IterationTelemetryRecorder]:
+        try:
+            recorder = IterationTelemetryRecorder(
+                workspace=self.workspace,
+                campaign_id=self.campaign_name,
+                version=n,
+                runtime_id=self.agent_cli,
+                base_head=pre_head,
+                base_kernel_blob=git_kernel_blob(self.workspace),
+                monotonic_clock=time.monotonic,
+                utc_clock=lambda: datetime.now(timezone.utc).isoformat(),
+                attempt_id=str(uuid.uuid4()),
+            )
+            recorder.agent_started()
+            return recorder
+        except Exception as exc:
+            print(
+                f"[orchestrator] WARNING: could not start telemetry for v{n}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return None
+
+    def _finish_iteration_telemetry(
+        self,
+        recorder: Optional[IterationTelemetryRecorder],
+        n: int,
+        memory: Optional[dict],
+    ) -> None:
+        if recorder is None:
+            return
+        try:
+            recorder.finalize(
+                memory=memory,
+                post_head=git_head(self.workspace),
+                post_kernel_blob=git_kernel_blob(self.workspace),
+                changed_paths=changed_paths_since(self.workspace, recorder.base_head),
+            )
+        except Exception as exc:
+            print(
+                f"[orchestrator] WARNING: could not finalize telemetry for v{n}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+
     def run(self) -> str:
         if latest_version(self.workspace) < 0:
             self.setup_baseline()
@@ -2649,6 +2711,9 @@ class Campaign:
             previous_latency = incumbent_latency(self.workspace, n)
             pre_head_was_gluon = head_kernel_is_gluon(self.workspace)
             pre_head = git_head(self.workspace)  # win = a commit that changes kernel.py vs this
+            telemetry = (
+                None if do_convert else self._begin_iteration_telemetry(n, pre_head)
+            )
             res = run_session(
                 self.workspace, prompt, timeout=self.iter_timeout,
                 agent_cli=self.agent_cli,
@@ -2656,8 +2721,27 @@ class Campaign:
                 sandbox_profile=self.sandbox_profile,
                 sandbox_url=self.sandbox_url,
                 sandbox_timeout=self.sandbox_timeout,
+                extra_environment=(telemetry.environment() if telemetry else None),
             )
             self._account(res, f"{'convert' if do_convert else 'iter'} v{n}")
+            if telemetry is not None:
+                try:
+                    telemetry.agent_completed(
+                        session_id=res.session_id,
+                        exit_status=res.exit_status,
+                        timed_out=res.timed_out,
+                        terminal_usage=res.terminal_usage,
+                        events=res.events,
+                        capabilities=res.capabilities,
+                        observation_errors=res.observation_errors,
+                    )
+                except Exception as exc:
+                    print(
+                        f"[orchestrator] WARNING: could not record telemetry attempt v{n}: {exc}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    telemetry = None
 
             # Robust infra-failure handling: distinguish crash vs timeout, retry up to 15
             # consecutive failures with progressive backoff before giving up. A 2-fail
@@ -2681,6 +2765,9 @@ class Campaign:
                 # no memory, and an empty version forces the next session to re-derive everything.
                 self._ensure_iteration_memory(n, res, "convert" if do_convert else "iter")
                 if infra_fails >= 15:
+                    self._finish_iteration_telemetry(
+                        telemetry, n, read_memory(self.workspace, n)
+                    )
                     if do_convert:
                         raise RuntimeError(
                             "mandatory Triton->Gluon conversion could not complete after "
@@ -2713,6 +2800,8 @@ class Campaign:
                     )
                     mem = read_memory(self.workspace, n)
                     won = False
+            if not do_convert:
+                self._finish_iteration_telemetry(telemetry, n, mem)
             if do_convert:
                 # A direct triton->gluon translation must preserve BOTH correctness and performance.
                 # Accept only a committed gluon kernel whose geomean is within +CONVERT_PERF_TOL of the

--- a/orchestrator/prompts/iteration.md
+++ b/orchestrator/prompts/iteration.md
@@ -45,6 +45,28 @@ through `tools/sandbox.py`.
 This prompt is **self-contained** — it defines all stages (1–4), commit/revert rules, and record format.
 Evidence format throughout: `evidence -> inference -> action`. Do Stages 1–4 once, then commit/revert/record and exit.
 
+## Local iteration telemetry
+
+When `ATREX_TELEMETRY_TRACE` is present, mark phase boundaries with the local helper. Telemetry is best-effort and must never replace or block optimization work:
+
+```bash
+python tools/iteration_trace.py phase-start <profile|research|planning|implementation|correctness|benchmark|recording>
+python tools/iteration_trace.py phase-end <profile|research|planning|implementation|correctness|benchmark|recording>
+```
+
+Map the work as follows: start `research` as the first standalone tool call before reading history or sources; Stage 1 profiling is `profile`; source investigation in Step A or Stage 2 is `research`; selecting and documenting the one lever in Stage 2 is `planning`; Stage 3 is `implementation`; correctness checks in Stage 4 are `correctness`; final performance measurement in Stage 4 is `benchmark`; and all acceptance/revert, memory, Git, and handoff work in Steps C–D is `recording`.
+
+Use complete marker pairs around the corresponding work below. Execute `phase-start research` before any history read or other work. Execute each `phase-start` marker as a standalone tool call and wait for its receipt before issuing that phase's work; execute `phase-end` only after the work completes. Minimize gaps by starting the next phase immediately after ending the previous phase. At most one phase may be active at a time: end the current phase before starting another. A phase may be entered again later with a new complete pair. Missing, unclosed, nested, or overlapping markers are left unattributed rather than guessed. Before or immediately after reading a relevant source, record only its metadata (never its contents):
+
+```bash
+python tools/iteration_trace.py source-read gpu_wiki <workspace-relative-path>
+python tools/iteration_trace.py source-read reference_projects <workspace-relative-path>
+python tools/iteration_trace.py source-read workspace <workspace-relative-path>
+python tools/iteration_trace.py source-read public_web <sanitized-public-reference>
+```
+
+Do not record credentials, private URL parameters, absolute user paths, raw tool output, or transcript text. Before Step C, start `recording`; keep it active through acceptance/revert, memory updates, Git operations, and final checks, then end it as the last tool action before the final response. If the helper is unavailable or returns an error, continue the optimization normally and leave telemetry coverage partial.
+
 ## Step A — Learn from prior sessions (read; do not redo their work)
 
 1. Read `README.md` — the **Goal** (minimize the geomean of per-workload kernel latency), config (platform, target framework, `gpu_wiki_path`), and the ground-truth files. There are no pre-baked Stop Conditions — the orchestrator owns termination; your job is to cut the geomean latency this cycle while keeping every workload correct.

--- a/orchestrator/telemetry/__init__.py
+++ b/orchestrator/telemetry/__init__.py
@@ -1,0 +1,20 @@
+from .iteration import (
+    EVENT_SCHEMA_VERSION,
+    SUMMARY_SCHEMA_VERSION,
+    IterationTelemetryRecorder,
+    changed_paths_since,
+    observed_outcome,
+    render_iteration_brief,
+)
+from .phase_tokens import aggregate_attempt_tokens, summarize_phase_tokens
+
+__all__ = [
+    "EVENT_SCHEMA_VERSION",
+    "SUMMARY_SCHEMA_VERSION",
+    "IterationTelemetryRecorder",
+    "aggregate_attempt_tokens",
+    "changed_paths_since",
+    "observed_outcome",
+    "render_iteration_brief",
+    "summarize_phase_tokens",
+]

--- a/orchestrator/telemetry/iteration.py
+++ b/orchestrator/telemetry/iteration.py
@@ -1,0 +1,671 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+import time
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+try:
+    from ..agent_runtime.model import (
+        AgentRuntimeCapabilities,
+        NormalizedAgentEvent,
+        TokenUsage,
+    )
+except ImportError:  # direct script execution: python orchestrator/optimize.py
+    from agent_runtime.model import (  # type: ignore[no-redef]
+        AgentRuntimeCapabilities,
+        NormalizedAgentEvent,
+        TokenUsage,
+    )
+
+from .phase_tokens import (
+    PHASES,
+    aggregate_attempt_tokens,
+    summarize_phase_tokens,
+    usage_dict,
+)
+
+
+EVENT_SCHEMA_VERSION = "atrex_iteration_event_v1"
+SUMMARY_SCHEMA_VERSION = "atrex_iteration_summary_v2"
+TELEMETRY_ROOT = Path(".atrex") / "telemetry"
+def observed_outcome(
+    *,
+    exit_status: int,
+    timed_out: bool,
+    memory: Mapping[str, Any] | None,
+    kernel_changed: bool,
+) -> tuple[str, list[str]]:
+    """Normalize current runtime/memory/Git facts without changing authority."""
+    gate = (memory.get("quality_gate") or {}).get("result") if memory else None
+    correctness = (memory.get("correctness") or {}).get("status") if memory else None
+    gate = str(gate or "").strip().upper()
+    correctness = str(correctness or "").strip().upper()
+
+    if kernel_changed:
+        if gate == "PASS" and correctness == "PASS":
+            return "accepted", []
+        return "unknown", ["kernel_memory_disagreement"]
+    if timed_out or exit_status != 0:
+        return "runtime_failure", []
+    if gate == "PASS":
+        return "unknown", ["memory_git_disagreement"]
+    if gate in {"FAIL", "TIMEOUT_FAIL"}:
+        if correctness == "PASS":
+            return "performance_rejection", []
+        return "validation_failure", []
+    if memory is None:
+        return "interrupted", ["memory_missing"]
+    return "unknown", ["terminal_outcome_unclassified"]
+
+
+def changed_paths_since(workspace: Path, base_head: str) -> list[str]:
+    """Return committed and worktree paths changed since one pre-session HEAD."""
+    changed: set[str] = set()
+    if base_head:
+        diff = subprocess.run(
+            ["git", "diff", "--name-only", base_head, "HEAD", "--"],
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if diff.returncode == 0:
+            changed.update(path for path in diff.stdout.splitlines() if path)
+    status = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=all"],
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if status.returncode == 0:
+        for line in status.stdout.splitlines():
+            path = line[3:].strip() if len(line) >= 4 else ""
+            if " -> " in path:
+                path = path.split(" -> ", 1)[1]
+            if path and not path.startswith(".atrex/"):
+                changed.add(path)
+    return sorted(changed)
+
+
+def _summarize_events(
+    events: Sequence[Mapping[str, Any]], total_seconds: float
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    durations: dict[str, float] = {phase: 0.0 for phase in PHASES}
+    interval_counts: dict[str, int] = {phase: 0 for phase in PHASES}
+    invalid_phases: set[str] = set()
+    timing_reasons: set[str] = set()
+    active_phase: str | None = None
+    active_started = 0.0
+    invalid_stack: list[str] = []
+    sources: list[dict[str, Any]] = []
+    sandbox: list[dict[str, Any]] = []
+
+    for event in events:
+        kind = event.get("event")
+        phase = str(event.get("phase") or "")
+        stamp = event.get("monotonic_seconds")
+        if kind in {"phase_started", "phase_completed"}:
+            if phase not in durations or not isinstance(stamp, (int, float)):
+                timing_reasons.add("invalid_phase_marker")
+                continue
+            action = "start" if kind == "phase_started" else "end"
+            stamp = float(stamp)
+            if invalid_stack:
+                invalid_phases.add(phase)
+                if action == "start":
+                    invalid_stack.append(phase)
+                    timing_reasons.add("overlapping_phase")
+                elif phase == invalid_stack[-1]:
+                    invalid_stack.pop()
+                elif phase in invalid_stack:
+                    timing_reasons.add("mismatched_phase_end")
+                    while invalid_stack and invalid_stack[-1] != phase:
+                        invalid_stack.pop()
+                    if invalid_stack:
+                        invalid_stack.pop()
+                else:
+                    timing_reasons.add("orphan_phase_end")
+                continue
+            if action == "start":
+                if active_phase is None:
+                    active_phase = phase
+                    active_started = stamp
+                else:
+                    invalid_phases.update({active_phase, phase})
+                    timing_reasons.add("overlapping_phase")
+                    invalid_stack = [active_phase, phase]
+                    active_phase = None
+                continue
+            if active_phase is None:
+                invalid_phases.add(phase)
+                timing_reasons.add("orphan_phase_end")
+            elif active_phase != phase:
+                invalid_phases.update({active_phase, phase})
+                timing_reasons.add("mismatched_phase_end")
+                invalid_stack = [active_phase]
+                active_phase = None
+            elif stamp < active_started:
+                invalid_phases.add(phase)
+                timing_reasons.add("negative_phase_duration")
+                active_phase = None
+            else:
+                durations[phase] += stamp - active_started
+                interval_counts[phase] += 1
+                active_phase = None
+            continue
+        if kind == "source_read":
+            sources.append(
+                {
+                    "source_kind": event.get("source_kind") or "unknown",
+                    "reference": event.get("reference"),
+                    "measurement": event.get("measurement") or "explicit",
+                }
+            )
+        elif kind == "sandbox_operation_completed":
+            sandbox.append(
+                {
+                    key: event.get(key)
+                    for key in (
+                        "operation_id",
+                        "category",
+                        "duration_seconds",
+                        "status",
+                        "exit_status",
+                        "failure_type",
+                    )
+                    if event.get(key) is not None
+                }
+            )
+
+    if active_phase is not None:
+        invalid_phases.add(active_phase)
+        timing_reasons.add("unclosed_phase")
+    if invalid_stack:
+        invalid_phases.update(invalid_stack)
+        timing_reasons.add("unclosed_phase")
+
+    phases: dict[str, Any] = {}
+    for phase in PHASES:
+        count = interval_counts[phase]
+        measurement = (
+            "partial"
+            if count and phase in invalid_phases
+            else ("explicit" if count else "unavailable")
+        )
+        phases[phase] = {
+            "wall_seconds": round(durations[phase], 6) if count else None,
+            "percentage": (
+                round(durations[phase] / total_seconds * 100.0, 3)
+                if count and total_seconds > 0
+                else None
+            ),
+            "interval_count": count,
+            "measurement": measurement,
+        }
+
+    attributed_seconds = sum(durations.values())
+    if attributed_seconds > total_seconds:
+        timing_reasons.add("phase_time_exceeds_iteration")
+    orchestration_seconds = max(0.0, total_seconds - attributed_seconds)
+    semantic_coverage = (
+        round(attributed_seconds / total_seconds, 6)
+        if total_seconds > 0
+        else None
+    )
+    timing_summary = {
+        "attributed_seconds": round(attributed_seconds, 6),
+        "orchestration_seconds": round(orchestration_seconds, 6),
+        "unattributed_seconds": 0.0 if total_seconds >= attributed_seconds else None,
+        "coverage": semantic_coverage,
+        "semantic_phase_coverage": semantic_coverage,
+        "accounted_coverage": 1.0 if total_seconds >= attributed_seconds else None,
+        "measurement": (
+            "partial"
+            if timing_reasons
+            else ("explicit" if any(interval_counts.values()) else "unavailable")
+        ),
+        "reason_codes": sorted(timing_reasons),
+    }
+    source_summary = {
+        "coverage": "explicit" if sources else "unavailable",
+        "count": len(sources),
+        "unique_count": len(
+            {(item["source_kind"], item["reference"]) for item in sources}
+        ),
+        "items": sources,
+    }
+    sandbox_summary = {
+        "coverage": "exact" if sandbox else "unavailable",
+        "total_seconds": round(
+            sum(float(item.get("duration_seconds") or 0.0) for item in sandbox), 6
+        ),
+        "items": sandbox,
+    }
+    return phases, source_summary, sandbox_summary, timing_summary
+
+
+def _safe_id(value: str, *, fallback: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value or "")).strip("-.")
+    return normalized[:120] or fallback
+
+
+def _atomic_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _ensure_local_git_exclude(workspace: Path) -> None:
+    exclude = workspace / ".git" / "info" / "exclude"
+    if not exclude.parent.is_dir():
+        return
+    current = exclude.read_text(encoding="utf-8") if exclude.exists() else ""
+    entry = "/.atrex/"
+    if entry in current.splitlines():
+        return
+    exclude.parent.mkdir(parents=True, exist_ok=True)
+    with exclude.open("a", encoding="utf-8") as handle:
+        if current and not current.endswith("\n"):
+            handle.write("\n")
+        handle.write("\n# Atrex local iteration telemetry\n")
+        handle.write(entry + "\n")
+
+
+def render_iteration_brief(summary: Mapping[str, Any]) -> str:
+    """Render one decision-ready human summary without copying raw output."""
+    phases = summary.get("phases") if isinstance(summary.get("phases"), Mapping) else {}
+    ranked = sorted(
+        (
+            (name, float(value["wall_seconds"]), value.get("measurement"))
+            for name, value in phases.items()
+            if isinstance(value, Mapping) and isinstance(value.get("wall_seconds"), (int, float))
+            and name != "agent_session"
+        ),
+        key=lambda item: item[1],
+        reverse=True,
+    )
+    phase_text = ", ".join(
+        f"{name}={seconds:.1f}s ({measurement})"
+        for name, seconds, measurement in ranked[:4]
+    ) or "phase detail unavailable"
+    source_reads = summary.get("source_reads") if isinstance(summary.get("source_reads"), Mapping) else {}
+    sandbox = summary.get("sandbox_operations") if isinstance(summary.get("sandbox_operations"), Mapping) else {}
+    token_summary = summary.get("phase_tokens")
+    token_summary = token_summary if isinstance(token_summary, Mapping) else {}
+    token_phases = token_summary.get("phases")
+    token_phases = token_phases if isinstance(token_phases, Mapping) else {}
+
+    def token_cell(value: object) -> str:
+        return f"{value:,}" if isinstance(value, int) else "—"
+
+    token_rows: list[str] = []
+    for phase in PHASES:
+        phase_value = token_phases.get(phase)
+        phase_value = phase_value if isinstance(phase_value, Mapping) else {}
+        usage = phase_value.get("usage")
+        usage = usage if isinstance(usage, Mapping) else {}
+        token_rows.append(
+            "| "
+            + " | ".join(
+                [
+                    phase,
+                    token_cell(usage.get("input_tokens")),
+                    token_cell(usage.get("output_tokens")),
+                    token_cell(usage.get("cache_read_tokens")),
+                    token_cell(usage.get("cache_write_tokens")),
+                    token_cell(usage.get("total_tokens")),
+                    str(phase_value.get("measurement") or "unavailable"),
+                ]
+            )
+            + " |"
+        )
+    for label in ("orchestration", "unattributed"):
+        usage = token_summary.get(label)
+        usage = usage if isinstance(usage, Mapping) else {}
+        token_rows.append(
+            "| "
+            + " | ".join(
+                [
+                    label,
+                    token_cell(usage.get("input_tokens")),
+                    token_cell(usage.get("output_tokens")),
+                    token_cell(usage.get("cache_read_tokens")),
+                    token_cell(usage.get("cache_write_tokens")),
+                    token_cell(usage.get("total_tokens")),
+                    str(usage.get("measurement") or "unavailable"),
+                ]
+            )
+            + " |"
+        )
+    lines = [
+        f"# Iteration {summary.get('iteration_id') or 'unknown'}",
+        "",
+        f"- outcome: `{summary.get('observed_outcome') or 'unknown'}`",
+        f"- total wall: `{float(summary.get('total_wall_seconds') or 0.0):.1f}s`",
+        f"- agent wall: `{float(summary.get('agent_wall_seconds') or 0.0):.1f}s`",
+        f"- phases: {phase_text}",
+        f"- source reads: `{int(source_reads.get('count') or 0)}` / unique `{int(source_reads.get('unique_count') or 0)}` ({source_reads.get('coverage') or 'unavailable'})",
+        f"- sandbox: `{float(sandbox.get('total_seconds') or 0.0):.1f}s` ({sandbox.get('coverage') or 'unavailable'})",
+        f"- orchestration time: `{float(summary.get('orchestration_wall_seconds') or 0.0):.1f}s`",
+        f"- unattributed time: `{float(summary.get('unattributed_wall_seconds') or 0.0):.1f}s`",
+        "- semantic token coverage: `"
+        + (
+            str(token_summary.get("coverage"))
+            if isinstance(token_summary.get("coverage"), (int, float))
+            else "unavailable"
+        )
+        + f"` ({token_summary.get('measurement') or 'unavailable'})",
+        f"- accounted token coverage: `{token_summary.get('accounted_coverage') if token_summary.get('accounted_coverage') is not None else 'unavailable'}`",
+        "",
+        "## Phase token usage",
+        "",
+        "| Phase | Input | Output | Cache read | Cache write | Total | Measurement |",
+        "|---|---:|---:|---:|---:|---:|---|",
+        *token_rows,
+    ]
+    return "\n".join(lines)
+
+
+class IterationTelemetryRecorder:
+    """Write a bounded local trace for one ordinary optimization attempt."""
+
+    def __init__(
+        self,
+        *,
+        workspace: Path,
+        campaign_id: str,
+        version: int,
+        runtime_id: str,
+        base_head: str,
+        base_kernel_blob: str,
+        monotonic_clock: Callable[[], float] = time.monotonic,
+        utc_clock: Callable[[], str],
+        attempt_id: str,
+    ) -> None:
+        self.workspace = workspace
+        self.campaign_id = _safe_id(campaign_id, fallback="campaign")
+        self.version = int(version)
+        self.runtime_id = _safe_id(runtime_id, fallback="runtime")
+        self.base_head = str(base_head or "")
+        self.base_kernel_blob = str(base_kernel_blob or "")
+        self._monotonic = monotonic_clock
+        self._utc = utc_clock
+        self.attempt_id = _safe_id(attempt_id, fallback="attempt")
+        self._iteration_started = self._monotonic()
+        self._agent_started: float | None = None
+        self._agent_completed: float | None = None
+        self._runtime: dict[str, Any] = {}
+        self._phase_tokens = summarize_phase_tokens(
+            events=(),
+            terminal_usage=TokenUsage.unavailable(),
+            capabilities=AgentRuntimeCapabilities(False, False, False),
+            observation_errors=(),
+        )
+        _ensure_local_git_exclude(workspace)
+        self.directory = workspace / TELEMETRY_ROOT / f"v{self.version}"
+        self.trace_path = self.directory / f"attempt-{self.attempt_id}.jsonl"
+        self.attempt_summary_path = (
+            self.directory / f"attempt-{self.attempt_id}.summary.json"
+        )
+        self.iteration_summary_path = self.directory / "iteration.summary.json"
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self._append_event(
+            "iteration_started",
+            measurement="exact",
+            monotonic_seconds=self._iteration_started,
+        )
+
+    def _append_event(
+        self,
+        event: str,
+        *,
+        measurement: str,
+        fields: Mapping[str, Any] | None = None,
+        monotonic_seconds: float | None = None,
+    ) -> None:
+        payload = {
+            "schema_version": EVENT_SCHEMA_VERSION,
+            "campaign_id": self.campaign_id,
+            "iteration_id": f"v{self.version}",
+            "attempt_id": self.attempt_id,
+            "event": event,
+            "timestamp": self._utc(),
+            "monotonic_seconds": (
+                self._monotonic() if monotonic_seconds is None else monotonic_seconds
+            ),
+            "source": "orchestrator",
+            "measurement": measurement,
+            **dict(fields or {}),
+        }
+        with self.trace_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+    def environment(self) -> dict[str, str]:
+        return {
+            "ATREX_TELEMETRY_TRACE": str(self.trace_path),
+            "ATREX_TELEMETRY_CAMPAIGN_ID": self.campaign_id,
+            "ATREX_TELEMETRY_ITERATION_ID": f"v{self.version}",
+            "ATREX_TELEMETRY_ATTEMPT_ID": self.attempt_id,
+        }
+
+    def agent_started(self) -> None:
+        self._agent_started = self._monotonic()
+        self._append_event(
+            "agent_session_started",
+            measurement="exact",
+            monotonic_seconds=self._agent_started,
+        )
+
+    def agent_completed(
+        self,
+        *,
+        session_id: str,
+        exit_status: int,
+        timed_out: bool,
+        terminal_usage: TokenUsage | None = None,
+        events: Sequence[NormalizedAgentEvent] = (),
+        capabilities: AgentRuntimeCapabilities | None = None,
+        observation_errors: Sequence[str] = (),
+    ) -> None:
+        self._agent_completed = self._monotonic()
+        self._runtime = {
+            "runtime_id": self.runtime_id,
+            "session_id": _safe_id(session_id, fallback="unknown"),
+            "exit_status": int(exit_status),
+            "timed_out": bool(timed_out),
+        }
+        resolved_usage = terminal_usage or TokenUsage.unavailable()
+        resolved_capabilities = capabilities or AgentRuntimeCapabilities(
+            False, False, False
+        )
+        self._phase_tokens = summarize_phase_tokens(
+            events=events,
+            terminal_usage=resolved_usage,
+            capabilities=resolved_capabilities,
+            observation_errors=observation_errors,
+        )
+        for runtime_event in events:
+            fields: dict[str, Any] = {"sequence": runtime_event.sequence}
+            if runtime_event.usage is not None:
+                fields["usage"] = usage_dict(runtime_event.usage)
+            if runtime_event.phase is not None:
+                fields["phase"] = runtime_event.phase
+            if runtime_event.action is not None:
+                fields["action"] = runtime_event.action
+            if runtime_event.marker_id is not None:
+                fields["marker_id"] = runtime_event.marker_id
+            self._append_event(
+                f"agent_{runtime_event.kind}",
+                measurement=(
+                    runtime_event.usage.measurement
+                    if runtime_event.usage is not None
+                    else "explicit"
+                ),
+                fields=fields,
+                monotonic_seconds=self._agent_completed,
+            )
+        self._append_event(
+            "agent_session_completed",
+            measurement="exact",
+            fields={
+                "exit_status": int(exit_status),
+                "timed_out": bool(timed_out),
+                "observation_errors": list(observation_errors),
+            },
+            monotonic_seconds=self._agent_completed,
+        )
+        _atomic_json(self.attempt_summary_path, self._attempt_summary())
+
+    def _attempt_summary(self) -> dict[str, Any]:
+        agent_seconds = None
+        if self._agent_started is not None and self._agent_completed is not None:
+            agent_seconds = round(self._agent_completed - self._agent_started, 6)
+        return {
+            "schema_version": SUMMARY_SCHEMA_VERSION,
+            "campaign_id": self.campaign_id,
+            "iteration_id": f"v{self.version}",
+            "attempt_id": self.attempt_id,
+            "runtime": dict(self._runtime),
+            "agent_wall_seconds": agent_seconds,
+            "phase_tokens": self._phase_tokens,
+            "measurement": {
+                "agent_wall_time": "exact" if agent_seconds is not None else "unavailable",
+            },
+        }
+
+    def finalize(
+        self,
+        *,
+        memory: Mapping[str, Any] | None,
+        post_head: str,
+        post_kernel_blob: str,
+        changed_paths: Sequence[str],
+    ) -> Path:
+        completed = self._monotonic()
+        total_seconds = round(completed - self._iteration_started, 6)
+        kernel_changed = bool(
+            self.base_kernel_blob
+            and post_kernel_blob
+            and self.base_kernel_blob != post_kernel_blob
+        )
+        runtime_exit = int(self._runtime.get("exit_status") or 0)
+        timed_out = self._runtime.get("timed_out") is True
+        outcome, reasons = observed_outcome(
+            exit_status=runtime_exit,
+            timed_out=timed_out,
+            memory=memory,
+            kernel_changed=kernel_changed,
+        )
+        self._append_event(
+            "outcome_observed",
+            measurement="inferred",
+            fields={"observed_outcome": outcome, "reason_codes": reasons},
+            monotonic_seconds=completed,
+        )
+        self._append_event(
+            "iteration_completed",
+            measurement="exact",
+            monotonic_seconds=completed,
+        )
+
+        attempt = self._attempt_summary()
+        attempt_summaries: list[dict[str, Any]] = []
+        for path in sorted(self.directory.glob("attempt-*.summary.json")):
+            try:
+                value = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if (
+                isinstance(value, dict)
+                and value.get("campaign_id") == self.campaign_id
+                and value.get("iteration_id") == f"v{self.version}"
+            ):
+                attempt_summaries.append(value)
+        if not any(
+            value.get("attempt_id") == self.attempt_id
+            for value in attempt_summaries
+        ):
+            attempt_summaries.append(attempt)
+        attempt_summaries.sort(key=lambda value: str(value.get("attempt_id") or ""))
+        phase_tokens = aggregate_attempt_tokens(attempt_summaries)
+        agent_seconds = attempt["agent_wall_seconds"]
+        events = [
+            value
+            for line in self.trace_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+            for value in [json.loads(line)]
+            if isinstance(value, dict)
+        ]
+        phases, source_reads, sandbox_operations, phase_timing = _summarize_events(
+            events, total_seconds
+        )
+        summary = {
+            "schema_version": SUMMARY_SCHEMA_VERSION,
+            "campaign_id": self.campaign_id,
+            "iteration_id": f"v{self.version}",
+            "attempts": attempt_summaries,
+            "total_wall_seconds": total_seconds,
+            "agent_wall_seconds": agent_seconds,
+            "phases": {
+                "agent_session": {
+                    "wall_seconds": agent_seconds,
+                    "percentage": (
+                        round(agent_seconds / total_seconds * 100.0, 3)
+                        if agent_seconds is not None and total_seconds > 0
+                        else None
+                    ),
+                    "measurement": "exact" if agent_seconds is not None else "unavailable",
+                },
+                **phases,
+            },
+            "source_reads": source_reads,
+            "sandbox_operations": sandbox_operations,
+            "phase_timing": phase_timing,
+            "phase_tokens": phase_tokens,
+            "runtime": dict(self._runtime),
+            "git": {
+                "base_head": self.base_head,
+                "post_head": str(post_head or ""),
+                "base_kernel_blob": self.base_kernel_blob,
+                "post_kernel_blob": str(post_kernel_blob or ""),
+                "kernel_changed": kernel_changed,
+                "changed_paths": sorted({str(path) for path in changed_paths}),
+            },
+            "memory": {
+                "quality_gate": (memory.get("quality_gate") or {}).get("result") if memory else None,
+                "correctness": (memory.get("correctness") or {}).get("status") if memory else None,
+                "latency_us": (memory.get("performance") or {}).get("latency_us") if memory else None,
+            },
+            "observed_outcome": outcome,
+            "reason_codes": reasons,
+            "coverage": {
+                "phase_timing": phase_timing["measurement"],
+                "source_reads": source_reads["coverage"],
+                "sandbox_operations": sandbox_operations["coverage"],
+                "phase_tokens": phase_tokens["measurement"],
+            },
+            "orchestration_wall_seconds": phase_timing["orchestration_seconds"],
+            "unattributed_wall_seconds": phase_timing["unattributed_seconds"],
+        }
+        _atomic_json(self.attempt_summary_path, attempt)
+        _atomic_json(self.iteration_summary_path, summary)
+        (self.directory / "iteration.brief.md").write_text(
+            render_iteration_brief(summary) + "\n", encoding="utf-8"
+        )
+        return self.iteration_summary_path

--- a/orchestrator/telemetry/phase_tokens.py
+++ b/orchestrator/telemetry/phase_tokens.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+try:
+    from ..agent_runtime.model import (
+        AgentRuntimeCapabilities,
+        NormalizedAgentEvent,
+        TokenUsage,
+        subtract_token_usage,
+        sum_token_usages,
+        token_usage_exceeds,
+    )
+except ImportError:  # direct script execution: python orchestrator/optimize.py
+    from agent_runtime.model import (  # type: ignore[no-redef]
+        AgentRuntimeCapabilities,
+        NormalizedAgentEvent,
+        TokenUsage,
+        subtract_token_usage,
+        sum_token_usages,
+        token_usage_exceeds,
+    )
+
+
+PHASES = (
+    "profile",
+    "research",
+    "planning",
+    "implementation",
+    "correctness",
+    "benchmark",
+    "recording",
+)
+
+
+def usage_dict(usage: TokenUsage) -> dict[str, Any]:
+    return {
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "cache_read_tokens": usage.cache_read_tokens,
+        "cache_write_tokens": usage.cache_write_tokens,
+        "total_tokens": usage.total_tokens,
+        "measurement": usage.measurement,
+    }
+
+
+def _sum_phase_usages(usages: Sequence[TokenUsage]) -> TokenUsage:
+    return sum_token_usages(usages) if usages else TokenUsage.zero()
+
+
+def summarize_phase_tokens(
+    *,
+    events: Sequence[NormalizedAgentEvent],
+    terminal_usage: TokenUsage,
+    capabilities: AgentRuntimeCapabilities,
+    observation_errors: Sequence[str],
+) -> dict[str, Any]:
+    """Attribute normalized usage deltas only to complete explicit phase pairs."""
+    phase_intervals: dict[str, list[list[TokenUsage]]] = {
+        phase: [] for phase in PHASES
+    }
+    reason_codes = list(observation_errors)
+    all_deltas: list[TokenUsage] = []
+    active_phase: str | None = None
+    active_usage: list[TokenUsage] = []
+    pending_start_usage: TokenUsage | None = None
+    invalid_stack: list[str] = []
+
+    if not capabilities.usage_delta or not capabilities.usage_delta_observed:
+        reason_codes.append(
+            "backend_has_no_usage_delta"
+            if not capabilities.usage_delta
+            else "backend_usage_delta_unobserved"
+        )
+        return {
+            "terminal_usage": usage_dict(terminal_usage),
+            "phases": {
+                phase: {
+                    "usage": None,
+                    "interval_count": 0,
+                    "measurement": "unavailable",
+                    "reason": "phase_not_observed",
+                }
+                for phase in PHASES
+            },
+            "orchestration": None,
+            "unattributed": (
+                usage_dict(terminal_usage)
+                if terminal_usage.total_tokens is not None
+                else None
+            ),
+            "coverage": (
+                0.0 if terminal_usage.total_tokens is not None else None
+            ),
+            "semantic_phase_coverage": (
+                0.0 if terminal_usage.total_tokens is not None else None
+            ),
+            "accounted_coverage": (
+                0.0 if terminal_usage.total_tokens is not None else None
+            ),
+            "measurement": "unavailable",
+            "reconciliation_status": (
+                "reconciled"
+                if terminal_usage.total_tokens is not None
+                else "unavailable"
+            ),
+            "reason_codes": sorted(set(reason_codes)),
+        }
+
+    for event in events:
+        if event.kind == "usage_delta" and event.usage is not None:
+            all_deltas.append(event.usage)
+            if active_phase is not None and not invalid_stack:
+                active_usage.append(event.usage)
+                pending_start_usage = None
+            elif not invalid_stack:
+                pending_start_usage = event.usage
+            continue
+        if event.kind != "phase_marker":
+            continue
+        phase = event.phase or ""
+        action = event.action
+        if phase not in phase_intervals or action not in {"start", "end"}:
+            reason_codes.append("invalid_phase_marker")
+            pending_start_usage = None
+            continue
+
+        if invalid_stack:
+            if action == "start":
+                invalid_stack.append(phase)
+                reason_codes.append("overlapping_phase")
+            elif invalid_stack and phase == invalid_stack[-1]:
+                invalid_stack.pop()
+            elif phase in invalid_stack:
+                reason_codes.append("mismatched_phase_end")
+                while invalid_stack and invalid_stack[-1] != phase:
+                    invalid_stack.pop()
+                if invalid_stack:
+                    invalid_stack.pop()
+            else:
+                reason_codes.append("orphan_phase_end")
+            pending_start_usage = None
+            continue
+
+        if action == "start":
+            if active_phase is None:
+                active_phase = phase
+                active_usage = (
+                    [pending_start_usage] if pending_start_usage is not None else []
+                )
+                pending_start_usage = None
+            else:
+                reason_codes.append("overlapping_phase")
+                invalid_stack = [active_phase, phase]
+                active_phase = None
+                active_usage = []
+                pending_start_usage = None
+            continue
+
+        if active_phase is None:
+            reason_codes.append("orphan_phase_end")
+            pending_start_usage = None
+        elif active_phase == phase:
+            phase_intervals[phase].append(active_usage)
+            active_phase = None
+            active_usage = []
+        else:
+            reason_codes.append("mismatched_phase_end")
+            invalid_stack = [active_phase]
+            active_phase = None
+            active_usage = []
+
+    if active_phase is not None or invalid_stack:
+        reason_codes.append("unclosed_phase")
+
+    phase_payload: dict[str, Any] = {}
+    attributed_usages: list[TokenUsage] = []
+    for phase, intervals in phase_intervals.items():
+        if not intervals:
+            phase_payload[phase] = {
+                "usage": None,
+                "interval_count": 0,
+                "measurement": "unavailable",
+                "reason": "phase_not_observed",
+            }
+            continue
+        interval_usages = [_sum_phase_usages(interval) for interval in intervals]
+        phase_usage = _sum_phase_usages(interval_usages)
+        attributed_usages.append(phase_usage)
+        phase_payload[phase] = {
+            "usage": usage_dict(phase_usage),
+            "interval_count": len(intervals),
+            "measurement": phase_usage.measurement,
+            "reason": None,
+        }
+
+    attributed = _sum_phase_usages(attributed_usages)
+    observed_delta = _sum_phase_usages(all_deltas)
+    terminal_total = terminal_usage.total_tokens
+    attributed_total = attributed.total_tokens
+    observed_delta_total = observed_delta.total_tokens
+    orchestration: TokenUsage | None
+    unattributed: TokenUsage | None
+    accounted_coverage: float | None
+    if terminal_total is None:
+        orchestration = (
+            subtract_token_usage(observed_delta, attributed)
+            if observed_delta_total is not None
+            and attributed_total is not None
+            and not token_usage_exceeds(attributed, observed_delta)
+            else None
+        )
+        unattributed = None
+        coverage = None
+        accounted_coverage = None
+        reconciliation = "unavailable"
+        measurement = "partial" if attributed_usages else "unavailable"
+        reason_codes.append("terminal_usage_unavailable")
+    elif (
+        attributed_total is None
+        or observed_delta_total is None
+        or token_usage_exceeds(attributed, terminal_usage)
+        or token_usage_exceeds(observed_delta, terminal_usage)
+    ):
+        orchestration = None
+        unattributed = None
+        coverage = None
+        accounted_coverage = None
+        reconciliation = "inconsistent"
+        measurement = "partial"
+        reason_codes.append("usage_delta_exceeds_terminal")
+    else:
+        orchestration = subtract_token_usage(terminal_usage, attributed)
+        unattributed = TokenUsage.zero()
+        coverage = (
+            round(attributed_total / terminal_total, 6)
+            if terminal_total > 0
+            else (1.0 if attributed_total == 0 else None)
+        )
+        accounted_coverage = 1.0
+        reconciliation = "reconciled"
+        measurement = (
+            "exact"
+            if coverage == 1.0
+            and not reason_codes
+            and terminal_usage.measurement == "exact"
+            and attributed.measurement == "exact"
+            else ("partial" if attributed_usages else "unavailable")
+        )
+
+    return {
+        "terminal_usage": usage_dict(terminal_usage),
+        "phases": phase_payload,
+        "orchestration": usage_dict(orchestration) if orchestration else None,
+        "unattributed": usage_dict(unattributed) if unattributed else None,
+        "coverage": coverage,
+        "semantic_phase_coverage": coverage,
+        "accounted_coverage": accounted_coverage,
+        "measurement": measurement,
+        "reconciliation_status": reconciliation,
+        "reason_codes": sorted(set(reason_codes)),
+    }
+
+
+def _usage_from_dict(payload: object) -> TokenUsage:
+    if not isinstance(payload, Mapping):
+        return TokenUsage.unavailable()
+
+    def value(name: str) -> int | None:
+        item = payload.get(name)
+        return int(item) if isinstance(item, int) and not isinstance(item, bool) else None
+
+    measurement = payload.get("measurement")
+    return TokenUsage(
+        input_tokens=value("input_tokens"),
+        output_tokens=value("output_tokens"),
+        cache_read_tokens=value("cache_read_tokens"),
+        cache_write_tokens=value("cache_write_tokens"),
+        total_tokens=value("total_tokens"),
+        measurement=(
+            str(measurement)
+            if measurement in {"exact", "partial", "unavailable"}
+            else "unavailable"
+        ),
+    )
+
+
+def aggregate_attempt_tokens(attempts: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    token_summaries = [
+        attempt.get("phase_tokens")
+        for attempt in attempts
+        if isinstance(attempt.get("phase_tokens"), Mapping)
+    ]
+    terminal_usages = [
+        _usage_from_dict(summary.get("terminal_usage"))
+        for summary in token_summaries
+    ]
+    observed_terminal = [
+        usage for usage in terminal_usages if usage.total_tokens is not None
+    ]
+    terminal = (
+        _sum_phase_usages(observed_terminal)
+        if observed_terminal
+        else TokenUsage.unavailable()
+    )
+    if len(observed_terminal) != len(attempts) and terminal.total_tokens is not None:
+        terminal = TokenUsage(
+            terminal.input_tokens,
+            terminal.output_tokens,
+            terminal.cache_read_tokens,
+            terminal.cache_write_tokens,
+            terminal.total_tokens,
+            "partial",
+        )
+
+    phases: dict[str, Any] = {}
+    phase_aggregates: list[TokenUsage] = []
+    for phase in PHASES:
+        usages: list[TokenUsage] = []
+        interval_count = 0
+        unavailable_attempt = False
+        for summary in token_summaries:
+            phase_payload = summary.get("phases")
+            value = (
+                phase_payload.get(phase)
+                if isinstance(phase_payload, Mapping)
+                else None
+            )
+            if not isinstance(value, Mapping) or value.get("usage") is None:
+                unavailable_attempt = True
+                continue
+            phase_usage = _usage_from_dict(value.get("usage"))
+            if phase_usage.total_tokens is None:
+                unavailable_attempt = True
+                continue
+            usages.append(phase_usage)
+            count = value.get("interval_count")
+            if isinstance(count, int) and not isinstance(count, bool):
+                interval_count += count
+        if not usages:
+            phases[phase] = {
+                "usage": None,
+                "interval_count": 0,
+                "measurement": "unavailable",
+                "reason": "phase_not_observed",
+            }
+            continue
+        aggregate = _sum_phase_usages(usages)
+        if unavailable_attempt:
+            aggregate = TokenUsage(
+                aggregate.input_tokens,
+                aggregate.output_tokens,
+                aggregate.cache_read_tokens,
+                aggregate.cache_write_tokens,
+                aggregate.total_tokens,
+                "partial",
+            )
+        phase_aggregates.append(aggregate)
+        phases[phase] = {
+            "usage": usage_dict(aggregate),
+            "interval_count": interval_count,
+            "measurement": aggregate.measurement,
+            "reason": None,
+        }
+
+    displayed_attributed = _sum_phase_usages(phase_aggregates)
+    displayed_attributed_total = displayed_attributed.total_tokens or 0
+    reasons = {
+        str(reason)
+        for summary in token_summaries
+        for reason in (summary.get("reason_codes") or [])
+    }
+    attempts_with_terminal = len(observed_terminal)
+    if attempts_with_terminal != len(attempts):
+        reasons.add("attempt_terminal_usage_unavailable")
+
+    coverage_attributed_usages: list[TokenUsage] = []
+    observed_orchestration: list[TokenUsage] = []
+    observed_unattributed: list[TokenUsage] = []
+    reconciliation_values: set[str] = set()
+    for summary in token_summaries:
+        attempt_terminal = _usage_from_dict(summary.get("terminal_usage"))
+        if attempt_terminal.total_tokens is None:
+            continue
+        reconciliation_values.add(str(summary.get("reconciliation_status")))
+        phase_payload = summary.get("phases")
+        if isinstance(phase_payload, Mapping):
+            for phase in PHASES:
+                value = phase_payload.get(phase)
+                if not isinstance(value, Mapping):
+                    continue
+                phase_usage = _usage_from_dict(value.get("usage"))
+                if phase_usage.total_tokens is not None:
+                    coverage_attributed_usages.append(phase_usage)
+        attempt_orchestration = _usage_from_dict(summary.get("orchestration"))
+        if attempt_orchestration.total_tokens is not None:
+            observed_orchestration.append(attempt_orchestration)
+        attempt_unattributed = _usage_from_dict(summary.get("unattributed"))
+        if attempt_unattributed.total_tokens is not None:
+            observed_unattributed.append(attempt_unattributed)
+
+    coverage_attributed = _sum_phase_usages(coverage_attributed_usages)
+    coverage_attributed_total = coverage_attributed.total_tokens or 0
+    orchestration: TokenUsage | None
+    accounted_coverage: float | None
+    if "inconsistent" in reconciliation_values:
+        reconciliation = "inconsistent"
+        orchestration = None
+        unattributed = None
+        coverage = None
+        accounted_coverage = None
+    elif terminal.total_tokens is None:
+        reconciliation = "unavailable"
+        orchestration = None
+        unattributed = None
+        coverage = None
+        accounted_coverage = None
+    elif token_usage_exceeds(coverage_attributed, terminal):
+        reconciliation = "inconsistent"
+        orchestration = None
+        unattributed = None
+        coverage = None
+        accounted_coverage = None
+        reasons.add("usage_delta_exceeds_terminal")
+    else:
+        reconciliation = "reconciled"
+        orchestration = _sum_phase_usages(observed_orchestration)
+        unattributed = _sum_phase_usages(observed_unattributed)
+        coverage = (
+            round(coverage_attributed_total / terminal.total_tokens, 6)
+            if terminal.total_tokens > 0
+            else (1.0 if coverage_attributed_total == 0 else None)
+        )
+        accounted_total = coverage_attributed_total + (
+            orchestration.total_tokens or 0
+        )
+        accounted_coverage = (
+            round(accounted_total / terminal.total_tokens, 6)
+            if terminal.total_tokens > 0
+            else (1.0 if accounted_total == 0 else None)
+        )
+
+    measurement = (
+        "exact"
+        if coverage == 1.0
+        and attempts_with_terminal == len(attempts)
+        and terminal.measurement == "exact"
+        and not reasons
+        else ("partial" if displayed_attributed_total else "unavailable")
+    )
+    reasons = sorted(reasons)
+    return {
+        "terminal_usage": usage_dict(terminal),
+        "phases": phases,
+        "orchestration": usage_dict(orchestration) if orchestration else None,
+        "unattributed": usage_dict(unattributed) if unattributed else None,
+        "coverage": coverage,
+        "semantic_phase_coverage": coverage,
+        "accounted_coverage": accounted_coverage,
+        "measurement": measurement,
+        "reconciliation_status": reconciliation,
+        "reason_codes": reasons,
+        "attempts_with_terminal_usage": attempts_with_terminal,
+        "attempt_count": len(attempts),
+    }

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -10,6 +12,18 @@ from orchestrator import optimize
 
 
 class AgentCliTest(unittest.TestCase):
+    def test_optimize_help_supports_direct_script_execution(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, "orchestrator/optimize.py", "--help"],
+            cwd=Path(__file__).resolve().parents[1],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("--agent-cli", completed.stdout)
+
     def test_codex_and_pi_are_supported_backends(self) -> None:
         self.assertIn("codex", optimize.AGENT_CLI_CHOICES)
         self.assertIn("pi", optimize.AGENT_CLI_CHOICES)
@@ -166,6 +180,8 @@ class AgentCliTest(unittest.TestCase):
         self.assertEqual(env["ATREX_SANDBOX_URL"], "https://gateway.example.test")
         self.assertEqual(env["ATREX_SANDBOX_TIMEOUT"], "456")
         self.assertEqual(result.tokens, 9)
+        self.assertEqual(result.terminal_usage.total_tokens, 9)
+        self.assertEqual([event.kind for event in result.events], ["terminal_usage"])
 
     def test_pi_transcript_is_located_in_configured_session_directory(self) -> None:
         with tempfile.TemporaryDirectory(prefix="pi-sessions-") as temp_dir:

--- a/tests/test_iteration_telemetry.py
+++ b/tests/test_iteration_telemetry.py
@@ -1,0 +1,719 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+from orchestrator import optimize
+from orchestrator.agent_runtime import (
+    AgentRuntimeCapabilities,
+    NormalizedAgentEvent,
+    PiAdapter,
+    TokenUsage,
+)
+from orchestrator.telemetry import (
+    IterationTelemetryRecorder,
+    aggregate_attempt_tokens,
+    changed_paths_since,
+    observed_outcome,
+    summarize_phase_tokens,
+)
+from orchestrator.telemetry import iteration as telemetry_iteration
+
+
+class SequenceClock:
+    def __init__(self, *values: float) -> None:
+        self._values = iter(values)
+
+    def __call__(self) -> float:
+        return next(self._values)
+
+
+def usage(total: int) -> TokenUsage:
+    return TokenUsage(
+        input_tokens=total - 1,
+        output_tokens=1,
+        cache_read_tokens=None,
+        cache_write_tokens=None,
+        total_tokens=total,
+        measurement="exact",
+    )
+
+
+DELTA_CAPABILITIES = AgentRuntimeCapabilities(
+    terminal_usage=True,
+    usage_delta=True,
+    phase_marker_receipt=True,
+    usage_delta_observed=True,
+)
+
+
+class PhaseTokenSummaryTest(unittest.TestCase):
+    def test_pi_usage_and_receipts_feed_the_common_phase_summary(self) -> None:
+        fixture = (
+            Path(__file__).parent
+            / "fixtures"
+            / "agent_runtime"
+            / "pi_usage.jsonl"
+        )
+        adapter = PiAdapter(Path("missing"))
+        events, terminal = adapter.normalize_stream(fixture.read_text())
+
+        summary = summarize_phase_tokens(
+            events=events,
+            terminal_usage=terminal,
+            capabilities=replace(
+                adapter.capabilities, usage_delta_observed=True
+            ),
+            observation_errors=(),
+        )
+
+        self.assertEqual(
+            summary["phases"]["research"]["usage"]["total_tokens"], 214
+        )
+        self.assertEqual(summary["terminal_usage"]["total_tokens"], 326)
+        self.assertEqual(summary["orchestration"]["total_tokens"], 112)
+        self.assertEqual(summary["unattributed"]["total_tokens"], 0)
+        self.assertEqual(summary["accounted_coverage"], 1.0)
+        self.assertEqual(summary["reconciliation_status"], "reconciled")
+
+    def test_complete_non_overlapping_intervals_are_attributed_and_reconciled(self) -> None:
+        events = (
+            NormalizedAgentEvent(0, "usage_delta", usage=usage(2)),
+            NormalizedAgentEvent(1, "phase_marker", phase="research", action="start", marker_id="m1"),
+            NormalizedAgentEvent(2, "usage_delta", usage=usage(10)),
+            NormalizedAgentEvent(3, "phase_marker", phase="research", action="end", marker_id="m2"),
+            NormalizedAgentEvent(4, "phase_marker", phase="implementation", action="start", marker_id="m3"),
+            NormalizedAgentEvent(5, "usage_delta", usage=usage(20)),
+            NormalizedAgentEvent(6, "phase_marker", phase="implementation", action="end", marker_id="m4"),
+        )
+
+        summary = summarize_phase_tokens(
+            events=events,
+            terminal_usage=TokenUsage(37, 3, None, None, 40, "exact"),
+            capabilities=DELTA_CAPABILITIES,
+            observation_errors=(),
+        )
+
+        self.assertEqual(summary["phases"]["research"]["usage"]["total_tokens"], 12)
+        self.assertEqual(summary["phases"]["implementation"]["usage"]["total_tokens"], 20)
+        self.assertEqual(summary["phases"]["planning"]["measurement"], "unavailable")
+        self.assertEqual(summary["orchestration"]["total_tokens"], 8)
+        self.assertEqual(summary["unattributed"]["total_tokens"], 0)
+        self.assertEqual(summary["coverage"], 0.8)
+        self.assertEqual(summary["accounted_coverage"], 1.0)
+        self.assertEqual(summary["reconciliation_status"], "reconciled")
+
+    def test_repeated_phase_intervals_are_summed(self) -> None:
+        events = (
+            NormalizedAgentEvent(0, "phase_marker", phase="research", action="start", marker_id="m1"),
+            NormalizedAgentEvent(1, "usage_delta", usage=usage(3)),
+            NormalizedAgentEvent(2, "phase_marker", phase="research", action="end", marker_id="m2"),
+            NormalizedAgentEvent(3, "phase_marker", phase="research", action="start", marker_id="m3"),
+            NormalizedAgentEvent(4, "usage_delta", usage=usage(4)),
+            NormalizedAgentEvent(5, "phase_marker", phase="research", action="end", marker_id="m4"),
+        )
+
+        summary = summarize_phase_tokens(
+            events=events,
+            terminal_usage=TokenUsage(5, 2, None, None, 7, "exact"),
+            capabilities=DELTA_CAPABILITIES,
+            observation_errors=(),
+        )
+
+        self.assertEqual(summary["phases"]["research"]["interval_count"], 2)
+        self.assertEqual(summary["phases"]["research"]["usage"]["total_tokens"], 7)
+        self.assertEqual(summary["coverage"], 1.0)
+
+    def test_overlapping_and_unclosed_intervals_fail_closed(self) -> None:
+        events = (
+            NormalizedAgentEvent(0, "phase_marker", phase="research", action="start", marker_id="m1"),
+            NormalizedAgentEvent(1, "usage_delta", usage=usage(3)),
+            NormalizedAgentEvent(2, "phase_marker", phase="implementation", action="start", marker_id="m2"),
+            NormalizedAgentEvent(3, "usage_delta", usage=usage(4)),
+            NormalizedAgentEvent(4, "phase_marker", phase="implementation", action="end", marker_id="m3"),
+            NormalizedAgentEvent(5, "phase_marker", phase="research", action="end", marker_id="m4"),
+            NormalizedAgentEvent(6, "phase_marker", phase="benchmark", action="start", marker_id="m5"),
+            NormalizedAgentEvent(7, "usage_delta", usage=usage(5)),
+        )
+
+        summary = summarize_phase_tokens(
+            events=events,
+            terminal_usage=TokenUsage(9, 3, None, None, 12, "exact"),
+            capabilities=DELTA_CAPABILITIES,
+            observation_errors=(),
+        )
+
+        self.assertIsNone(summary["phases"]["research"]["usage"])
+        self.assertIsNone(summary["phases"]["benchmark"]["usage"])
+        self.assertEqual(summary["orchestration"]["total_tokens"], 12)
+        self.assertEqual(summary["unattributed"]["total_tokens"], 0)
+        self.assertEqual(summary["accounted_coverage"], 1.0)
+        self.assertIn("overlapping_phase", summary["reason_codes"])
+        self.assertIn("unclosed_phase", summary["reason_codes"])
+
+    def test_component_delta_above_terminal_is_inconsistent(self) -> None:
+        events = (
+            NormalizedAgentEvent(0, "phase_marker", phase="research", action="start", marker_id="m1"),
+            NormalizedAgentEvent(
+                1,
+                "usage_delta",
+                usage=TokenUsage(12, 0, None, None, 12, "exact"),
+            ),
+            NormalizedAgentEvent(2, "phase_marker", phase="research", action="end", marker_id="m2"),
+        )
+
+        summary = summarize_phase_tokens(
+            events=events,
+            terminal_usage=TokenUsage(10, 5, None, None, 15, "exact"),
+            capabilities=DELTA_CAPABILITIES,
+            observation_errors=(),
+        )
+
+        self.assertEqual(summary["reconciliation_status"], "inconsistent")
+        self.assertIsNone(summary["unattributed"])
+        self.assertIn("usage_delta_exceeds_terminal", summary["reason_codes"])
+
+    def test_delta_total_above_terminal_is_reported_without_correction(self) -> None:
+        events = (
+            NormalizedAgentEvent(0, "usage_delta", usage=usage(2)),
+            NormalizedAgentEvent(1, "phase_marker", phase="research", action="start", marker_id="m1"),
+            NormalizedAgentEvent(2, "usage_delta", usage=usage(9)),
+            NormalizedAgentEvent(3, "phase_marker", phase="research", action="end", marker_id="m2"),
+        )
+
+        summary = summarize_phase_tokens(
+            events=events,
+            terminal_usage=usage(10),
+            capabilities=DELTA_CAPABILITIES,
+            observation_errors=(),
+        )
+
+        self.assertEqual(summary["reconciliation_status"], "inconsistent")
+        self.assertIsNone(summary["unattributed"])
+        self.assertIsNone(summary["coverage"])
+        self.assertIn("usage_delta_exceeds_terminal", summary["reason_codes"])
+
+    def test_missing_attempt_terminal_does_not_distort_observed_coverage(self) -> None:
+        missing_terminal = summarize_phase_tokens(
+            events=(
+                NormalizedAgentEvent(0, "phase_marker", phase="research", action="start", marker_id="m1"),
+                NormalizedAgentEvent(1, "usage_delta", usage=usage(4)),
+                NormalizedAgentEvent(2, "phase_marker", phase="research", action="end", marker_id="m2"),
+            ),
+            terminal_usage=TokenUsage.unavailable(),
+            capabilities=DELTA_CAPABILITIES,
+            observation_errors=(),
+        )
+        observed_terminal = summarize_phase_tokens(
+            events=(
+                NormalizedAgentEvent(0, "phase_marker", phase="implementation", action="start", marker_id="m3"),
+                NormalizedAgentEvent(1, "usage_delta", usage=usage(10)),
+                NormalizedAgentEvent(2, "phase_marker", phase="implementation", action="end", marker_id="m4"),
+            ),
+            terminal_usage=usage(20),
+            capabilities=DELTA_CAPABILITIES,
+            observation_errors=(),
+        )
+
+        aggregate = aggregate_attempt_tokens(
+            [
+                {"phase_tokens": missing_terminal},
+                {"phase_tokens": observed_terminal},
+            ]
+        )
+
+        self.assertEqual(aggregate["terminal_usage"]["total_tokens"], 20)
+        self.assertEqual(aggregate["attempts_with_terminal_usage"], 1)
+        self.assertEqual(aggregate["phases"]["research"]["usage"]["total_tokens"], 4)
+        self.assertEqual(aggregate["coverage"], 0.5)
+        self.assertEqual(aggregate["orchestration"]["total_tokens"], 10)
+        self.assertEqual(aggregate["unattributed"]["total_tokens"], 0)
+        self.assertEqual(aggregate["accounted_coverage"], 1.0)
+        self.assertIn("attempt_terminal_usage_unavailable", aggregate["reason_codes"])
+
+    def test_supported_but_unobserved_deltas_do_not_become_exact_zero(self) -> None:
+        summary = summarize_phase_tokens(
+            events=(
+                NormalizedAgentEvent(0, "phase_marker", phase="research", action="start", marker_id="m1"),
+                NormalizedAgentEvent(1, "phase_marker", phase="research", action="end", marker_id="m2"),
+            ),
+            terminal_usage=usage(9),
+            capabilities=AgentRuntimeCapabilities(True, True, True, False),
+            observation_errors=(),
+        )
+
+        self.assertIsNone(summary["phases"]["research"]["usage"])
+        self.assertEqual(summary["unattributed"]["total_tokens"], 9)
+        self.assertEqual(summary["coverage"], 0.0)
+        self.assertIn("backend_usage_delta_unobserved", summary["reason_codes"])
+
+    def test_backend_without_delta_capability_attributes_nothing(self) -> None:
+        summary = summarize_phase_tokens(
+            events=(),
+            terminal_usage=usage(9),
+            capabilities=AgentRuntimeCapabilities(True, False, True),
+            observation_errors=(),
+        )
+
+        self.assertEqual(summary["unattributed"]["total_tokens"], 9)
+        self.assertEqual(summary["coverage"], 0.0)
+        self.assertEqual(summary["measurement"], "unavailable")
+        self.assertIn("backend_has_no_usage_delta", summary["reason_codes"])
+
+
+class IterationTelemetryTest(unittest.TestCase):
+    def test_phase_timing_rejects_overlap_and_tracks_orchestration(self) -> None:
+        events = [
+            {"event": "phase_started", "phase": "research", "monotonic_seconds": 1.0},
+            {"event": "phase_started", "phase": "implementation", "monotonic_seconds": 2.0},
+            {"event": "phase_completed", "phase": "implementation", "monotonic_seconds": 3.0},
+            {"event": "phase_completed", "phase": "research", "monotonic_seconds": 4.0},
+        ]
+
+        phases, _, _, timing = telemetry_iteration._summarize_events(events, 10.0)
+
+        self.assertIsNone(phases["research"]["wall_seconds"])
+        self.assertIsNone(phases["implementation"]["wall_seconds"])
+        self.assertEqual(timing["attributed_seconds"], 0.0)
+        self.assertEqual(timing["orchestration_seconds"], 10.0)
+        self.assertEqual(timing["unattributed_seconds"], 0.0)
+        self.assertEqual(timing["accounted_coverage"], 1.0)
+        self.assertIn("overlapping_phase", timing["reason_codes"])
+
+    def _recorder(
+        self,
+        workspace: Path,
+        *,
+        attempt_id: str,
+        clock: SequenceClock,
+    ) -> IterationTelemetryRecorder:
+        return IterationTelemetryRecorder(
+            workspace=workspace,
+            campaign_id="demo",
+            version=1,
+            runtime_id="claude",
+            base_head="",
+            base_kernel_blob="",
+            monotonic_clock=clock,
+            utc_clock=lambda: "2026-08-04T00:00:00+00:00",
+            attempt_id=attempt_id,
+        )
+
+    def test_recorder_persists_phase_tokens_and_renders_brief_table(self) -> None:
+        events = (
+            NormalizedAgentEvent(0, "phase_marker", phase="research", action="start", marker_id="m1"),
+            NormalizedAgentEvent(1, "usage_delta", usage=usage(10)),
+            NormalizedAgentEvent(2, "phase_marker", phase="research", action="end", marker_id="m2"),
+            NormalizedAgentEvent(3, "terminal_usage", usage=usage(20)),
+        )
+        with tempfile.TemporaryDirectory(prefix="phase-token-recorder-") as temp_dir:
+            recorder = self._recorder(
+                Path(temp_dir),
+                attempt_id="attempt-1",
+                clock=SequenceClock(1.0, 2.0, 3.0, 4.0),
+            )
+            recorder.agent_started()
+            recorder.agent_completed(
+                session_id="session-1",
+                exit_status=0,
+                timed_out=False,
+                terminal_usage=usage(20),
+                events=events,
+                capabilities=DELTA_CAPABILITIES,
+            )
+            summary_path = recorder.finalize(
+                memory=None,
+                post_head="",
+                post_kernel_blob="",
+                changed_paths=[],
+            )
+            summary = json.loads(summary_path.read_text())
+            attempt = json.loads(recorder.attempt_summary_path.read_text())
+            brief = (recorder.directory / "iteration.brief.md").read_text()
+            trace = recorder.trace_path.read_text()
+
+        self.assertEqual(
+            attempt["phase_tokens"]["phases"]["research"]["usage"]["total_tokens"],
+            10,
+        )
+        self.assertEqual(summary["phase_tokens"]["terminal_usage"]["total_tokens"], 20)
+        self.assertEqual(summary["phase_tokens"]["orchestration"]["total_tokens"], 10)
+        self.assertEqual(summary["phase_tokens"]["unattributed"]["total_tokens"], 0)
+        self.assertEqual(summary["phase_tokens"]["accounted_coverage"], 1.0)
+        self.assertIn("## Phase token usage", brief)
+        self.assertIn("| research | 9 | 1 |", brief)
+        self.assertIn("| orchestration | 10 | 0 |", brief)
+        self.assertNotIn("raw parser", trace)
+
+    def test_iteration_summary_aggregates_all_attempt_tokens(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="phase-token-attempts-") as temp_dir:
+            workspace = Path(temp_dir)
+            first = self._recorder(
+                workspace,
+                attempt_id="attempt-1",
+                clock=SequenceClock(1.0, 2.0, 3.0),
+            )
+            first.agent_started()
+            first.agent_completed(
+                session_id="session-1",
+                exit_status=1,
+                timed_out=False,
+                terminal_usage=usage(10),
+                events=(
+                    NormalizedAgentEvent(0, "phase_marker", phase="research", action="start", marker_id="m1"),
+                    NormalizedAgentEvent(1, "usage_delta", usage=usage(4)),
+                    NormalizedAgentEvent(2, "phase_marker", phase="research", action="end", marker_id="m2"),
+                ),
+                capabilities=DELTA_CAPABILITIES,
+            )
+            second = self._recorder(
+                workspace,
+                attempt_id="attempt-2",
+                clock=SequenceClock(4.0, 5.0, 6.0, 7.0),
+            )
+            second.agent_started()
+            second.agent_completed(
+                session_id="session-2",
+                exit_status=0,
+                timed_out=False,
+                terminal_usage=usage(20),
+                events=(
+                    NormalizedAgentEvent(0, "phase_marker", phase="implementation", action="start", marker_id="m3"),
+                    NormalizedAgentEvent(1, "usage_delta", usage=usage(10)),
+                    NormalizedAgentEvent(2, "phase_marker", phase="implementation", action="end", marker_id="m4"),
+                ),
+                capabilities=DELTA_CAPABILITIES,
+            )
+            summary_path = second.finalize(
+                memory=None,
+                post_head="",
+                post_kernel_blob="",
+                changed_paths=[],
+            )
+            summary = json.loads(summary_path.read_text())
+
+        tokens = summary["phase_tokens"]
+        self.assertEqual(tokens["attempt_count"], 2)
+        self.assertEqual(tokens["attempts_with_terminal_usage"], 2)
+        self.assertEqual(tokens["terminal_usage"]["total_tokens"], 30)
+        self.assertEqual(tokens["phases"]["research"]["usage"]["total_tokens"], 4)
+        self.assertEqual(tokens["phases"]["implementation"]["usage"]["total_tokens"], 10)
+        self.assertEqual(tokens["orchestration"]["input_tokens"], 16)
+        self.assertEqual(tokens["orchestration"]["output_tokens"], 0)
+        self.assertEqual(tokens["orchestration"]["total_tokens"], 16)
+        self.assertEqual(tokens["unattributed"]["total_tokens"], 0)
+        self.assertEqual(tokens["accounted_coverage"], 1.0)
+
+    def test_campaign_helpers_record_one_local_attempt(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="campaign-telemetry-") as temp_dir:
+            campaign = optimize.Campaign(
+                name="demo",
+                kernel_demo="/tmp/reference.py",
+                platform="H20",
+                framework="Triton",
+                work_dir=temp_dir,
+                agent_cli="codex",
+            )
+            workspace = campaign.workspace
+            (workspace / "memory").mkdir(parents=True)
+            (workspace / "kernel.py").write_text("# incumbent\n", encoding="utf-8")
+            (workspace / "memory" / "v1.json").write_text(
+                json.dumps(
+                    {
+                        "quality_gate": {"result": "FAIL"},
+                        "correctness": {"status": "PASS"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "init", "-q"], cwd=workspace, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "test@example.com"],
+                cwd=workspace, check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Test"], cwd=workspace, check=True,
+            )
+            subprocess.run(["git", "add", "-A"], cwd=workspace, check=True)
+            subprocess.run(
+                ["git", "commit", "-q", "-m", "baseline"], cwd=workspace, check=True,
+            )
+            head = optimize.git_head(workspace)
+            recorder = campaign._begin_iteration_telemetry(1, head)
+            self.assertIsNotNone(recorder)
+            assert recorder is not None
+            recorder.agent_completed(
+                session_id="session-1", exit_status=0, timed_out=False
+            )
+            campaign._finish_iteration_telemetry(
+                recorder, 1, optimize.read_memory(workspace, 1)
+            )
+            summary = json.loads(
+                (
+                    workspace
+                    / ".atrex"
+                    / "telemetry"
+                    / "v1"
+                    / "iteration.summary.json"
+                ).read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(summary["runtime"]["runtime_id"], "codex")
+        self.assertNotIn("tokens", summary)
+        self.assertEqual(summary["observed_outcome"], "performance_rejection")
+
+    def test_changed_paths_include_committed_and_untracked_files(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="telemetry-paths-") as temp_dir:
+            workspace = Path(temp_dir)
+            (workspace / "kernel.py").write_text("# baseline\n", encoding="utf-8")
+            subprocess.run(["git", "init", "-q"], cwd=workspace, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "test@example.com"],
+                cwd=workspace,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Test"], cwd=workspace, check=True
+            )
+            subprocess.run(["git", "add", "kernel.py"], cwd=workspace, check=True)
+            subprocess.run(
+                ["git", "commit", "-q", "-m", "baseline"], cwd=workspace, check=True
+            )
+            head = subprocess.run(
+                ["git", "rev-parse", "HEAD"], cwd=workspace, check=True,
+                capture_output=True, text=True,
+            ).stdout.strip()
+            (workspace / "kernel.py").write_text("# candidate\n", encoding="utf-8")
+            subprocess.run(["git", "add", "kernel.py"], cwd=workspace, check=True)
+            subprocess.run(
+                ["git", "commit", "-q", "-m", "candidate"], cwd=workspace, check=True
+            )
+            (workspace / "plans").mkdir()
+            (workspace / "plans" / "v1_plan.md").write_text("plan\n", encoding="utf-8")
+
+            changed = changed_paths_since(workspace, head)
+
+        self.assertEqual(changed, ["kernel.py", "plans/v1_plan.md"])
+
+    def test_observed_outcome_is_read_only_and_explicit_about_disagreement(self) -> None:
+        self.assertEqual(
+            observed_outcome(
+                exit_status=0,
+                timed_out=False,
+                memory={"quality_gate": {"result": "PASS"}, "correctness": {"status": "PASS"}},
+                kernel_changed=True,
+            ),
+            ("accepted", []),
+        )
+        self.assertEqual(
+            observed_outcome(
+                exit_status=0,
+                timed_out=False,
+                memory={"quality_gate": {"result": "FAIL"}, "correctness": {"status": "PASS"}},
+                kernel_changed=False,
+            ),
+            ("performance_rejection", []),
+        )
+        self.assertEqual(
+            observed_outcome(
+                exit_status=0,
+                timed_out=False,
+                memory={"quality_gate": {"result": "FAIL"}, "correctness": {"status": "FAIL"}},
+                kernel_changed=False,
+            ),
+            ("validation_failure", []),
+        )
+        self.assertEqual(
+            observed_outcome(
+                exit_status=0,
+                timed_out=False,
+                memory={"quality_gate": {"result": "PASS"}},
+                kernel_changed=False,
+            ),
+            ("unknown", ["memory_git_disagreement"]),
+        )
+        self.assertEqual(
+            observed_outcome(
+                exit_status=1,
+                timed_out=False,
+                memory=None,
+                kernel_changed=False,
+            ),
+            ("runtime_failure", []),
+        )
+        self.assertEqual(
+            observed_outcome(
+                exit_status=1,
+                timed_out=False,
+                memory={
+                    "quality_gate": {"result": "FAIL"},
+                    "correctness": {"status": "FAIL"},
+                },
+                kernel_changed=False,
+            ),
+            ("runtime_failure", []),
+        )
+
+    def test_recorder_writes_ignored_local_trace_and_summary(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="iteration-telemetry-") as temp_dir:
+            workspace = Path(temp_dir)
+            (workspace / "memory").mkdir()
+            (workspace / "kernel.py").write_text("# incumbent\n", encoding="utf-8")
+            (workspace / "memory" / "v1.json").write_text(
+                json.dumps(
+                    {
+                        "quality_gate": {"result": "FAIL"},
+                        "correctness": {"status": "PASS"},
+                        "performance": {"latency_us": 12.5},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "init", "-q"], cwd=workspace, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "test@example.com"],
+                cwd=workspace,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Test"], cwd=workspace, check=True
+            )
+            subprocess.run(["git", "add", "-A"], cwd=workspace, check=True)
+            subprocess.run(
+                ["git", "commit", "-q", "-m", "baseline"], cwd=workspace, check=True
+            )
+            head = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=workspace,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            recorder = IterationTelemetryRecorder(
+                workspace=workspace,
+                campaign_id="demo-triton",
+                version=1,
+                runtime_id="codex",
+                base_head=head,
+                base_kernel_blob="blob-before",
+                monotonic_clock=SequenceClock(10.0, 12.0, 22.0, 25.0),
+                utc_clock=lambda: "2026-08-04T00:00:00+00:00",
+                attempt_id="attempt-1",
+            )
+            recorder.agent_started()
+            recorder._append_event(
+                "phase_started",
+                measurement="explicit",
+                fields={"phase": "research"},
+                monotonic_seconds=13.0,
+            )
+            recorder._append_event(
+                "source_read",
+                measurement="explicit",
+                fields={
+                    "source_kind": "gpu_wiki",
+                    "reference": "docs/kernel-opt/example.md",
+                },
+                monotonic_seconds=14.0,
+            )
+            recorder._append_event(
+                "phase_completed",
+                measurement="explicit",
+                fields={"phase": "research"},
+                monotonic_seconds=15.0,
+            )
+            recorder._append_event(
+                "sandbox_operation_completed",
+                measurement="exact",
+                fields={
+                    "operation_id": "sandbox-1",
+                    "category": "profile",
+                    "duration_seconds": 3.0,
+                    "status": "succeeded",
+                },
+                monotonic_seconds=16.0,
+            )
+            recorder.agent_completed(
+                session_id="session-1",
+                exit_status=0,
+                timed_out=False,
+            )
+            summary_path = recorder.finalize(
+                memory=json.loads(
+                    (workspace / "memory" / "v1.json").read_text(encoding="utf-8")
+                ),
+                post_head=head,
+                post_kernel_blob="blob-before",
+                changed_paths=[],
+            )
+
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            attempt_summary = json.loads(
+                (
+                    workspace
+                    / ".atrex"
+                    / "telemetry"
+                    / "v1"
+                    / "attempt-attempt-1.summary.json"
+                ).read_text(encoding="utf-8")
+            )
+            trace_path = (
+                workspace
+                / ".atrex"
+                / "telemetry"
+                / "v1"
+                / "attempt-attempt-1.jsonl"
+            )
+            brief = (
+                workspace / ".atrex" / "telemetry" / "v1" / "iteration.brief.md"
+            ).read_text(encoding="utf-8")
+            events = [json.loads(line) for line in trace_path.read_text().splitlines()]
+            status = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=workspace,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+
+        self.assertEqual(summary["observed_outcome"], "performance_rejection")
+        self.assertEqual(summary["total_wall_seconds"], 15.0)
+        self.assertEqual(summary["agent_wall_seconds"], 10.0)
+        self.assertNotIn("tokens", summary)
+        self.assertEqual(summary["phases"]["research"]["measurement"], "explicit")
+        self.assertEqual(summary["phases"]["research"]["wall_seconds"], 2.0)
+        self.assertEqual(summary["phase_timing"]["attributed_seconds"], 2.0)
+        self.assertEqual(summary["orchestration_wall_seconds"], 13.0)
+        self.assertEqual(summary["unattributed_wall_seconds"], 0.0)
+        self.assertEqual(summary["phase_timing"]["accounted_coverage"], 1.0)
+        self.assertEqual(summary["source_reads"]["coverage"], "explicit")
+        self.assertEqual(summary["source_reads"]["unique_count"], 1)
+        self.assertEqual(summary["sandbox_operations"]["coverage"], "exact")
+        self.assertEqual(summary["sandbox_operations"]["total_seconds"], 3.0)
+        self.assertEqual(attempt_summary["attempt_id"], "attempt-1")
+        self.assertIn("outcome: `performance_rejection`", brief)
+        self.assertIn("research=2.0s", brief)
+        self.assertEqual(
+            [event["event"] for event in events],
+            [
+                "iteration_started",
+                "agent_session_started",
+                "phase_started",
+                "source_read",
+                "phase_completed",
+                "sandbox_operation_completed",
+                "agent_session_completed",
+                "outcome_observed",
+                "iteration_completed",
+            ],
+        )
+        self.assertEqual(status, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_iteration_trace_tools.py
+++ b/tests/test_iteration_trace_tools.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from orchestrator.telemetry.phase_tokens import PHASES as TELEMETRY_PHASES
+from tools import iteration_trace, sandbox
+
+
+class IterationTraceToolTest(unittest.TestCase):
+    def test_tool_and_telemetry_share_the_same_phase_contract(self) -> None:
+        self.assertEqual(iteration_trace.PHASES, set(TELEMETRY_PHASES))
+
+    def test_phase_and_source_commands_append_metadata_only_events(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="trace-tool-") as temp_dir:
+            trace = Path(temp_dir) / "trace.jsonl"
+            environment = {
+                "ATREX_TELEMETRY_TRACE": str(trace),
+                "ATREX_TELEMETRY_CAMPAIGN_ID": "demo",
+                "ATREX_TELEMETRY_ITERATION_ID": "v3",
+                "ATREX_TELEMETRY_ATTEMPT_ID": "attempt-1",
+            }
+            output = io.StringIO()
+            with (
+                mock.patch.dict(iteration_trace.os.environ, environment, clear=True),
+                redirect_stdout(output),
+            ):
+                self.assertEqual(iteration_trace.main(["phase-start", "research"]), 0)
+                self.assertEqual(
+                    iteration_trace.main(
+                        ["source-read", "gpu_wiki", "docs/kernel-opt/example.md"]
+                    ),
+                    0,
+                )
+                self.assertEqual(iteration_trace.main(["phase-end", "research"]), 0)
+            events = [json.loads(line) for line in trace.read_text().splitlines()]
+            receipts = [
+                json.loads(line.removeprefix("ATREX_TRACE_EVENT="))
+                for line in output.getvalue().splitlines()
+            ]
+
+        self.assertEqual(
+            [event["event"] for event in events],
+            ["phase_started", "source_read", "phase_completed"],
+        )
+        self.assertEqual(events[1]["source_kind"], "gpu_wiki")
+        self.assertEqual(events[1]["reference"], "docs/kernel-opt/example.md")
+        self.assertNotIn("content", events[1])
+        self.assertEqual([receipt["action"] for receipt in receipts], ["start", "end"])
+        self.assertEqual({receipt["phase"] for receipt in receipts}, {"research"})
+        self.assertTrue(all(receipt["marker_id"] for receipt in receipts))
+
+    def test_phase_command_emits_no_receipt_when_trace_write_is_disabled(self) -> None:
+        output = io.StringIO()
+        with (
+            mock.patch.dict(iteration_trace.os.environ, {}, clear=True),
+            redirect_stdout(output),
+        ):
+            self.assertEqual(iteration_trace.main(["phase-start", "research"]), 0)
+
+        self.assertEqual(output.getvalue(), "")
+
+    def test_source_command_rejects_absolute_or_parent_paths(self) -> None:
+        for reference in ("/absolute/private/file", "../private/file"):
+            with self.subTest(reference=reference):
+                with self.assertRaisesRegex(ValueError, "safe relative reference"):
+                    iteration_trace.main(["source-read", "workspace", reference])
+
+    def test_public_source_strips_query_fragment_and_rejects_userinfo(self) -> None:
+        sanitized = iteration_trace._safe_ref(
+            "https://example.test/docs/page?credential=sensitive#private",
+            source_kind="public_web",
+        )
+
+        self.assertEqual(sanitized, "https://example.test/docs/page")
+        with self.assertRaisesRegex(ValueError, "credential-free HTTP URL"):
+            iteration_trace._safe_ref(
+                "https://user:password@example.test/docs",
+                source_kind="public_web",
+            )
+
+    def test_sandbox_wrapper_records_operation_without_changing_execution(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="sandbox-trace-") as temp_dir:
+            trace = Path(temp_dir) / "trace.jsonl"
+            with (
+                mock.patch.dict(
+                    sandbox.os.environ,
+                    {
+                        "ATREX_TELEMETRY_TRACE": str(trace),
+                        "ATREX_TELEMETRY_CAMPAIGN_ID": "demo",
+                        "ATREX_TELEMETRY_ITERATION_ID": "v3",
+                        "ATREX_TELEMETRY_ATTEMPT_ID": "attempt-1",
+                    },
+                    clear=True,
+                ),
+                mock.patch.object(sandbox, "_main", return_value=0) as run,
+            ):
+                result = sandbox.main(
+                    ["--kind", "run", "--", "python", "test_kernel.py"]
+                )
+            events = [json.loads(line) for line in trace.read_text().splitlines()]
+
+        self.assertEqual(result, 0)
+        run.assert_called_once()
+        self.assertEqual(
+            [event["event"] for event in events],
+            ["sandbox_operation_started", "sandbox_operation_completed"],
+        )
+        self.assertEqual(events[0]["category"], "benchmark")
+        self.assertEqual(events[1]["status"], "succeeded")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/iteration_trace.py
+++ b/tools/iteration_trace.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Append explicit, metadata-only events to the current local iteration trace."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+PHASES = {
+    "profile",
+    "research",
+    "planning",
+    "implementation",
+    "correctness",
+    "benchmark",
+    "recording",
+}
+SOURCE_KINDS = {"gpu_wiki", "reference_projects", "workspace", "public_web", "unknown"}
+
+
+def _safe_ref(value: str, *, source_kind: str) -> str:
+    value = value.strip().replace("\\", "/")
+    if source_kind == "public_web":
+        parsed = urlsplit(value)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise ValueError("public source reference must be a credential-free HTTP URL")
+        return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))[:500]
+    if not value or value.startswith("/") or ".." in Path(value).parts:
+        raise ValueError("source reference must be a safe relative reference")
+    return value[:500]
+
+
+def append_event(event: str, **fields: object) -> bool:
+    trace = os.environ.get("ATREX_TELEMETRY_TRACE")
+    if not trace:
+        return False
+    payload = {
+        "schema_version": "atrex_iteration_event_v1",
+        "campaign_id": os.environ.get("ATREX_TELEMETRY_CAMPAIGN_ID", "campaign"),
+        "iteration_id": os.environ.get("ATREX_TELEMETRY_ITERATION_ID", "unknown"),
+        "attempt_id": os.environ.get("ATREX_TELEMETRY_ATTEMPT_ID", "attempt"),
+        "event": event,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "monotonic_seconds": time.monotonic(),
+        "source": "agent_marker",
+        "measurement": "explicit",
+        **fields,
+    }
+    path = Path(trace)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("phase-start", "phase-end"):
+        command = sub.add_parser(name)
+        command.add_argument("phase", choices=sorted(PHASES))
+    source = sub.add_parser("source-read")
+    source.add_argument("source_kind", choices=sorted(SOURCE_KINDS))
+    source.add_argument("reference")
+    args = parser.parse_args(argv)
+    if args.command.startswith("phase-"):
+        action = "start" if args.command == "phase-start" else "end"
+        event = "phase_started" if action == "start" else "phase_completed"
+        marker_id = uuid.uuid4().hex
+        if append_event(
+            event,
+            phase=args.phase,
+            action=action,
+            marker_id=marker_id,
+        ):
+            receipt = {
+                "schema": "atrex.iteration_trace.v1",
+                "kind": "phase_marker",
+                "action": action,
+                "phase": args.phase,
+                "marker_id": marker_id,
+            }
+            print(
+                "ATREX_TRACE_EVENT="
+                + json.dumps(receipt, ensure_ascii=False, sort_keys=True),
+                flush=True,
+            )
+    else:
+        append_event(
+            "source_read",
+            source_kind=args.source_kind,
+            reference=_safe_ref(args.reference, source_kind=args.source_kind),
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -59,6 +59,7 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any, Iterable
 
@@ -1543,7 +1544,7 @@ def _run_typed_gateway(
     return 0
 
 
-def main(argv: list[str] | None = None) -> int:
+def _main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     if not args.hardware:
         raise SystemExit("sandbox: --hardware or ATREX_SANDBOX_GPU is required")
@@ -1862,6 +1863,70 @@ def main(argv: list[str] | None = None) -> int:
     if isinstance(remote_rc, int):
         return remote_rc
     return 0 if job.get("status") == "succeeded" else (proc.returncode or 1)
+
+
+def _sandbox_telemetry_category(arguments: list[str]) -> str:
+    names = {Path(value).name for value in arguments}
+    if names & {"profile_nvidia.sh", "profile_kernel.sh"}:
+        return "profile"
+    if "test_kernel.py" in names:
+        return "correctness" if "--multi-seed" in arguments else "benchmark"
+    return "dev"
+
+
+def _append_sandbox_telemetry(event: str, **fields: object) -> None:
+    trace = os.environ.get("ATREX_TELEMETRY_TRACE")
+    if not trace:
+        return
+    payload = {
+        "schema_version": "atrex_iteration_event_v1",
+        "campaign_id": os.environ.get("ATREX_TELEMETRY_CAMPAIGN_ID", "campaign"),
+        "iteration_id": os.environ.get("ATREX_TELEMETRY_ITERATION_ID", "unknown"),
+        "attempt_id": os.environ.get("ATREX_TELEMETRY_ATTEMPT_ID", "attempt"),
+        "event": event,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "monotonic_seconds": time.monotonic(),
+        "source": "sandbox",
+        "measurement": "exact",
+        **fields,
+    }
+    path = Path(trace)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(argv if argv is not None else sys.argv[1:])
+    operation_id = f"sandbox-{os.getpid()}-{time.monotonic_ns()}"
+    category = _sandbox_telemetry_category(arguments)
+    started = time.monotonic()
+    _append_sandbox_telemetry(
+        "sandbox_operation_started",
+        operation_id=operation_id,
+        category=category,
+    )
+    try:
+        returncode = _main(argv)
+    except BaseException as exc:
+        _append_sandbox_telemetry(
+            "sandbox_operation_completed",
+            operation_id=operation_id,
+            category=category,
+            duration_seconds=round(time.monotonic() - started, 6),
+            status="failed",
+            failure_type=type(exc).__name__,
+        )
+        raise
+    _append_sandbox_telemetry(
+        "sandbox_operation_completed",
+        operation_id=operation_id,
+        category=category,
+        duration_seconds=round(time.monotonic() - started, 6),
+        status="succeeded" if returncode == 0 else "failed",
+        exit_status=returncode,
+    )
+    return returncode
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add local-only telemetry for ordinary optimization iterations
- normalize per-attempt Runtime usage deltas, terminal usage, and successful phase-marker receipts
- attribute input/output/cache-read/cache-write tokens to explicit workflow phases
- add a `recording` phase for acceptance/revert, memory, Git, and handoff work
- classify valid usage outside semantic intervals as derived `orchestration` overhead
- reserve `unattributed` for unavailable or inconsistent terminal accounting
- report semantic phase coverage, accounted coverage, per-component reconciliation, timing, source metadata, sandbox operations, and observed Git/memory outcome
- write ignored JSONL/JSON telemetry plus a human-readable iteration brief without changing acceptance authority

## Accounting semantics

- complete, non-overlapping explicit marker intervals may repeat
- the assistant turn that successfully issues a standalone phase-start marker is included in the new phase
- missing or invalid markers fail closed and are never inferred from elapsed time
- component or total overflow against terminal usage is reported as inconsistent rather than clamped
- valid residual usage is reported as orchestration, so semantic phases + orchestration + truly unattributed usage reconcile to terminal usage
- backend streams without observed usage deltas degrade to unavailable without blocking optimization

## Scope

- ordinary optimization `vN` only
- long-horizon episodes remain unchanged and uninstrumented
- source metadata remains an explicit best-effort marker rather than automatic reconstruction of every backend tool read
- telemetry stays below ignored `.atrex/telemetry/` and does not modify Git, memory, stall, acceptance, or retry decisions

## Validation

- 47 long-horizon tests passed
- 115 Runtime/Telemetry/orchestrator tests passed, 1 skipped
- modified Python modules pass `py_compile`
- three clean Pi optimization rounds against a remote GPU evaluator completed with exact terminal usage, reconciled per-component totals, zero unattributed tokens, and 100% accounted coverage
- semantic phase coverage across those rounds was 95.0% to 95.9%; the remaining 4.1% to 5.0% was explicitly classified as orchestration overhead
- the final candidate passed all three matmul workloads with zero correctness error