### PR TITLE
feat: add long-horizon episode token telemetry

### DIFF
--- a/long_horizon/campaign.py
+++ b/long_horizon/campaign.py
@@ -23,6 +23,7 @@ from .journal import validate_terminal
 from .models import EpisodeHandoff, SupervisorState, VerificationResult
 from .session import LongSessionRunner
 from .store import CampaignStore, RUNTIME_DIR, VERIFY_DIR
+from .telemetry import summarize_episode
 from .verifier import GatewayABBAValidator
 
 
@@ -672,6 +673,14 @@ class LongHorizonCampaign:
                 conversion_pending=conversion_pending,
             )
             store.write_brief(episode, prompt)
+            telemetry_environment = {
+                "ATREX_TELEMETRY_TRACE": str(runtime / "telemetry.jsonl"),
+                "ATREX_TELEMETRY_CAMPAIGN_ID": str(
+                    getattr(self.base_campaign, "campaign_name", self.workspace.name)
+                ),
+                "ATREX_TELEMETRY_ITERATION_ID": f"episode-{episode:04d}",
+                "ATREX_TELEMETRY_ATTEMPT_ID": "invocation",
+            }
             result = runner.run(
                 worktree.path,
                 prompt,
@@ -681,6 +690,7 @@ class LongHorizonCampaign:
                 completion_check=lambda handoff: self._completion_check(
                     worktree, journal_path, handoff
                 ),
+                telemetry_environment=telemetry_environment,
             )
             state.episodes = episode
             state.tokens += result.tokens
@@ -765,6 +775,34 @@ class LongHorizonCampaign:
                 "next_directions": outcome.get("next_directions") if isinstance(outcome, dict) else None,
                 "verification": verification.as_dict() if verification else None,
             }
+            try:
+                telemetry = summarize_episode(
+                    episode=episode,
+                    version=memory_version,
+                    status=status,
+                    accepted=accepted,
+                    control_tokens=result.tokens,
+                    resume_count=result.resume_count,
+                    invocations=result.invocations,
+                )
+                telemetry_path = store.archive_telemetry(episode, telemetry)
+                attempt["telemetry"] = {
+                    "summary": str(telemetry_path.relative_to(store.workspace)),
+                    "measurement": telemetry["measurement"],
+                    "reason_codes": telemetry["reason_codes"],
+                }
+            except Exception as exc:
+                reason_code = f"telemetry_finalize_failed:{type(exc).__name__}"
+                attempt["telemetry"] = {
+                    "summary": None,
+                    "measurement": "unavailable",
+                    "reason_codes": [reason_code],
+                }
+                print(
+                    f"[long-horizon] WARNING: could not finalize episode {episode} "
+                    f"telemetry: {reason_code}",
+                    flush=True,
+                )
             valid_blocked = status == "blocked" and not violation
             if valid_blocked:
                 retry_of = state.attempts[-1] if self._blocked_retry_pending(state) else None

--- a/long_horizon/main_adapter.py
+++ b/long_horizon/main_adapter.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 from orchestrator import optimize as base
+from orchestrator.agent_runtime.adapter import DEFAULT_BACKEND_REGISTRY
+from orchestrator.agent_runtime.model import (
+    AgentRuntimeCapabilities,
+    NormalizedAgentEvent,
+    TokenUsage,
+)
+from orchestrator.agent_runtime.runtime import (
+    DEFAULT_HUMANIZE_DIR,
+    terminal_usage_from_stream,
+)
 from orchestrator.optimization_policy import install_workspace_policy
 
 
@@ -164,6 +175,32 @@ def run_bounded(
 
 def tokens_from_stream(stdout: str) -> int:
     return base._tokens_from_stream(stdout)
+
+
+def normalize_stream(
+    agent_cli: str, stdout: str
+) -> tuple[
+    tuple[NormalizedAgentEvent, ...],
+    TokenUsage,
+    AgentRuntimeCapabilities,
+    tuple[str, ...],
+]:
+    """Observe one long-session invocation through main's backend adapter."""
+    adapter = DEFAULT_BACKEND_REGISTRY.create(agent_cli, DEFAULT_HUMANIZE_DIR)
+    observation_errors: tuple[str, ...] = ()
+    try:
+        events, terminal_usage = adapter.normalize_stream(stdout)
+    except Exception as exc:
+        events = ()
+        terminal_usage = terminal_usage_from_stream(stdout)
+        observation_errors = (
+            f"stream_normalization_failed:{type(exc).__name__}",
+        )
+    capabilities = replace(
+        adapter.capabilities,
+        usage_delta_observed=any(event.kind == "usage_delta" for event in events),
+    )
+    return events, terminal_usage, capabilities, observation_errors
 
 
 def latest_version(workspace: Path) -> int:

--- a/long_horizon/models.py
+++ b/long_horizon/models.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
+from orchestrator.agent_runtime.model import (
+    AgentRuntimeCapabilities,
+    NormalizedAgentEvent,
+    TokenUsage,
+)
+
 
 TERMINAL_STATUSES = frozenset({"candidate_ready", "pivot", "blocked"})
 
@@ -17,6 +23,14 @@ class EpisodeHandoff:
         return {key: value for key, value in asdict(self).items() if value}
 
 
+@dataclass(frozen=True)
+class InvocationObservation:
+    terminal_usage: TokenUsage
+    events: tuple[NormalizedAgentEvent, ...]
+    capabilities: AgentRuntimeCapabilities
+    observation_errors: tuple[str, ...] = ()
+
+
 @dataclass
 class SessionResult:
     exit_status: int
@@ -28,6 +42,7 @@ class SessionResult:
     stdout_tail: str = ""
     stderr_tail: str = ""
     completion_diagnosis: str = ""
+    invocations: tuple[InvocationObservation, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/long_horizon/session.py
+++ b/long_horizon/session.py
@@ -144,9 +144,13 @@ class LongSessionRunner:
             )
             stdout_parts.append(stdout)
             stderr_parts.append(stderr)
-            total_tokens += main_adapter.tokens_from_stream(stdout)
             events, terminal_usage, capabilities, observation_errors = (
                 main_adapter.normalize_stream(self.agent_cli, stdout)
+            )
+            total_tokens += (
+                terminal_usage.total_tokens
+                if terminal_usage.total_tokens is not None
+                else main_adapter.tokens_from_stream(stdout)
             )
             invocations.append(
                 InvocationObservation(

--- a/long_horizon/session.py
+++ b/long_horizon/session.py
@@ -82,6 +82,7 @@ class LongSessionRunner:
             environment.update(
                 {str(key): str(value) for key, value in telemetry_environment.items()}
             )
+        telemetry_attempt_prefix = environment.get("ATREX_TELEMETRY_ATTEMPT_ID")
         stdout_parts: list[str] = []
         stderr_parts: list[str] = []
         total_tokens = 0
@@ -138,6 +139,10 @@ class LongSessionRunner:
                     else main_adapter.resume_session_command(
                         turn_prompt, active_session_id, reasoning_effort, self.agent_cli
                     )
+                )
+            if telemetry_attempt_prefix:
+                environment["ATREX_TELEMETRY_ATTEMPT_ID"] = (
+                    f"{telemetry_attempt_prefix}-{attempt + 1}"
                 )
             stdout, stderr, exit_status, turn_timed_out = self.executor(
                 command, workspace, remaining, environment

--- a/long_horizon/session.py
+++ b/long_horizon/session.py
@@ -5,10 +5,11 @@ import signal
 import time
 import uuid
 from pathlib import Path
+from collections.abc import Mapping
 from typing import Callable
 
 from . import main_adapter
-from .models import EpisodeHandoff, SessionResult
+from .models import EpisodeHandoff, InvocationObservation, SessionResult
 from .protocol import handoff_diagnosis, read_handoff
 
 
@@ -64,6 +65,7 @@ class LongSessionRunner:
         completion_check: CompletionCheck,
         reasoning_effort: str = "max",
         session_id: str = "",
+        telemetry_environment: Mapping[str, str] | None = None,
     ) -> SessionResult:
         session_id = session_id or str(uuid.uuid4())
         active_session_id = session_id if self.agent_cli != "codex" else ""
@@ -76,6 +78,10 @@ class LongSessionRunner:
             else main_adapter.session_environment(self.agent_cli)
         )
         environment["IS_SANDBOX"] = "1"
+        if telemetry_environment:
+            environment.update(
+                {str(key): str(value) for key, value in telemetry_environment.items()}
+            )
         stdout_parts: list[str] = []
         stderr_parts: list[str] = []
         total_tokens = 0
@@ -84,6 +90,7 @@ class LongSessionRunner:
         exit_status = 0
         timed_out = False
         resume_count = 0
+        invocations: list[InvocationObservation] = []
 
         for attempt in range(max(0, handoff_resumes) + 1):
             remaining = int(deadline - time.monotonic())
@@ -138,6 +145,17 @@ class LongSessionRunner:
             stdout_parts.append(stdout)
             stderr_parts.append(stderr)
             total_tokens += main_adapter.tokens_from_stream(stdout)
+            events, terminal_usage, capabilities, observation_errors = (
+                main_adapter.normalize_stream(self.agent_cli, stdout)
+            )
+            invocations.append(
+                InvocationObservation(
+                    terminal_usage=terminal_usage,
+                    events=events,
+                    capabilities=capabilities,
+                    observation_errors=observation_errors,
+                )
+            )
             observed_session_id = main_adapter.session_id_from_stream(
                 self.agent_cli, stdout, session_id
             )
@@ -194,4 +212,5 @@ class LongSessionRunner:
             stdout_tail=stdout_all[-4000:],
             stderr_tail=stderr_all[-4000:],
             completion_diagnosis=completion_diagnosis,
+            invocations=tuple(invocations),
         )

--- a/long_horizon/store.py
+++ b/long_horizon/store.py
@@ -8,6 +8,7 @@ from typing import Any
 from . import main_adapter
 from .models import SupervisorState
 from .protocol import atomic_write_json, atomic_write_text
+from .telemetry import render_episode_brief
 
 
 RUNTIME_DIR = ".atrex_long_horizon"
@@ -88,4 +89,11 @@ class CampaignStore:
     def archive_attempt(self, episode: int, value: dict[str, Any]) -> Path:
         path = self.episode_dir(episode) / "attempt.json"
         atomic_write_json(path, value)
+        return path
+
+    def archive_telemetry(self, episode: int, value: dict[str, Any]) -> Path:
+        directory = self.episode_dir(episode)
+        path = directory / "telemetry.summary.json"
+        atomic_write_json(path, value)
+        atomic_write_text(directory / "telemetry.brief.md", render_episode_brief(value) + "\n")
         return path

--- a/long_horizon/store.py
+++ b/long_horizon/store.py
@@ -94,6 +94,7 @@ class CampaignStore:
     def archive_telemetry(self, episode: int, value: dict[str, Any]) -> Path:
         directory = self.episode_dir(episode)
         path = directory / "telemetry.summary.json"
+        brief = render_episode_brief(value) + "\n"
         atomic_write_json(path, value)
-        atomic_write_text(directory / "telemetry.brief.md", render_episode_brief(value) + "\n")
+        atomic_write_text(directory / "telemetry.brief.md", brief)
         return path

--- a/long_horizon/telemetry.py
+++ b/long_horizon/telemetry.py
@@ -31,7 +31,11 @@ def _fallback_phase_tokens(control_tokens: int) -> dict[str, Any]:
     return summarize_phase_tokens(
         events=(),
         terminal_usage=terminal,
-        capabilities=AgentRuntimeCapabilities(False, False, False),
+        capabilities=AgentRuntimeCapabilities(
+            terminal_usage=False,
+            usage_delta=False,
+            phase_marker_receipt=False,
+        ),
         observation_errors=("structured_usage_unavailable",),
     )
 
@@ -48,12 +52,12 @@ def summarize_episode(
 ) -> dict[str, Any]:
     """Summarize one episode without changing its existing control-token contract."""
     invocation_summaries: list[dict[str, Any]] = []
-    for index, invocation in enumerate(invocations, start=1):
+    for index, observation in enumerate(invocations, start=1):
         phase_tokens = summarize_phase_tokens(
-            events=invocation.events,
-            terminal_usage=invocation.terminal_usage,
-            capabilities=invocation.capabilities,
-            observation_errors=invocation.observation_errors,
+            events=observation.events,
+            terminal_usage=observation.terminal_usage,
+            capabilities=observation.capabilities,
+            observation_errors=observation.observation_errors,
         )
         invocation_summaries.append(
             {
@@ -68,35 +72,38 @@ def summarize_episode(
         if invocation_summaries
         else _fallback_phase_tokens(control_tokens)
     )
-    aggregate_phases = phase_tokens.get("phases")
-    if isinstance(aggregate_phases, Mapping):
+    phase_intervals: dict[str, list[dict[str, Any]]] = {
+        phase: [] for phase in PHASES
+    }
+    for invocation_summary in invocation_summaries:
+        invocation_number = int(invocation_summary["invocation"])
+        invocation_tokens = invocation_summary.get("phase_tokens")
+        invocation_tokens = (
+            invocation_tokens if isinstance(invocation_tokens, Mapping) else {}
+        )
+        invocation_phases = invocation_tokens.get("phases")
+        invocation_phases = (
+            invocation_phases if isinstance(invocation_phases, Mapping) else {}
+        )
         for phase in PHASES:
-            intervals: list[dict[str, Any]] = []
-            for invocation_summary in invocation_summaries:
-                invocation = int(invocation_summary["invocation"])
-                invocation_tokens = invocation_summary.get("phase_tokens")
-                invocation_tokens = (
-                    invocation_tokens if isinstance(invocation_tokens, Mapping) else {}
+            phase_payload = invocation_phases.get(phase)
+            phase_payload = phase_payload if isinstance(phase_payload, Mapping) else {}
+            for interval in phase_payload.get("intervals") or []:
+                if not isinstance(interval, Mapping):
+                    continue
+                interval_usage = interval.get("usage")
+                if (
+                    not isinstance(interval_usage, Mapping)
+                    or not isinstance(interval_usage.get("total_tokens"), int)
+                ):
+                    continue
+                phase_intervals[phase].append(
+                    {
+                        "invocation": invocation_number,
+                        "index": interval.get("index"),
+                        "usage": interval_usage,
+                    }
                 )
-                invocation_phases = invocation_tokens.get("phases")
-                invocation_phases = (
-                    invocation_phases if isinstance(invocation_phases, Mapping) else {}
-                )
-                phase_payload = invocation_phases.get(phase)
-                phase_payload = phase_payload if isinstance(phase_payload, Mapping) else {}
-                for interval in phase_payload.get("intervals") or []:
-                    if not isinstance(interval, Mapping):
-                        continue
-                    intervals.append(
-                        {
-                            "invocation": invocation,
-                            "index": interval.get("index"),
-                            "usage": interval.get("usage"),
-                        }
-                    )
-            aggregate_phase = aggregate_phases.get(phase)
-            if isinstance(aggregate_phase, dict):
-                aggregate_phase["intervals"] = intervals
     reasons = set(str(value) for value in phase_tokens.get("reason_codes", []))
     if not invocation_summaries:
         reasons.add("structured_usage_unavailable")
@@ -110,7 +117,7 @@ def summarize_episode(
         reasons.add("control_token_total_mismatch")
 
     measurement = str(phase_tokens.get("measurement") or "unavailable")
-    if invocation_summaries and reasons:
+    if reasons and measurement == "exact":
         measurement = "partial"
     phase_tokens["reason_codes"] = sorted(reasons)
     if reasons and phase_tokens.get("measurement") == "exact":
@@ -127,6 +134,7 @@ def summarize_episode(
         "invocation_count": len(invocation_summaries),
         "invocations": invocation_summaries,
         "phase_tokens": phase_tokens,
+        "phase_intervals": phase_intervals,
         "measurement": measurement,
         "reason_codes": sorted(reasons),
     }
@@ -137,6 +145,10 @@ def render_episode_brief(summary: Mapping[str, Any]) -> str:
     tokens = tokens if isinstance(tokens, Mapping) else {}
     phases = tokens.get("phases")
     phases = phases if isinstance(phases, Mapping) else {}
+    phase_intervals = summary.get("phase_intervals")
+    phase_intervals = (
+        phase_intervals if isinstance(phase_intervals, Mapping) else {}
+    )
 
     def cell(value: object) -> str:
         return f"{value:,}" if isinstance(value, int) else "—"
@@ -185,9 +197,7 @@ def render_episode_brief(summary: Mapping[str, Any]) -> str:
 
     interval_rows: list[str] = []
     for phase in PHASES:
-        payload = phases.get(phase)
-        payload = payload if isinstance(payload, Mapping) else {}
-        for interval in payload.get("intervals") or []:
+        for interval in phase_intervals.get(phase) or []:
             if not isinstance(interval, Mapping):
                 continue
             usage = interval.get("usage")

--- a/long_horizon/telemetry.py
+++ b/long_horizon/telemetry.py
@@ -68,6 +68,35 @@ def summarize_episode(
         if invocation_summaries
         else _fallback_phase_tokens(control_tokens)
     )
+    aggregate_phases = phase_tokens.get("phases")
+    if isinstance(aggregate_phases, Mapping):
+        for phase in PHASES:
+            intervals: list[dict[str, Any]] = []
+            for invocation_summary in invocation_summaries:
+                invocation = int(invocation_summary["invocation"])
+                invocation_tokens = invocation_summary.get("phase_tokens")
+                invocation_tokens = (
+                    invocation_tokens if isinstance(invocation_tokens, Mapping) else {}
+                )
+                invocation_phases = invocation_tokens.get("phases")
+                invocation_phases = (
+                    invocation_phases if isinstance(invocation_phases, Mapping) else {}
+                )
+                phase_payload = invocation_phases.get(phase)
+                phase_payload = phase_payload if isinstance(phase_payload, Mapping) else {}
+                for interval in phase_payload.get("intervals") or []:
+                    if not isinstance(interval, Mapping):
+                        continue
+                    intervals.append(
+                        {
+                            "invocation": invocation,
+                            "index": interval.get("index"),
+                            "usage": interval.get("usage"),
+                        }
+                    )
+            aggregate_phase = aggregate_phases.get(phase)
+            if isinstance(aggregate_phase, dict):
+                aggregate_phase["intervals"] = intervals
     reasons = set(str(value) for value in phase_tokens.get("reason_codes", []))
     if not invocation_summaries:
         reasons.add("structured_usage_unavailable")
@@ -154,27 +183,64 @@ def render_episode_brief(summary: Mapping[str, Any]) -> str:
             + " |"
         )
 
+    interval_rows: list[str] = []
+    for phase in PHASES:
+        payload = phases.get(phase)
+        payload = payload if isinstance(payload, Mapping) else {}
+        for interval in payload.get("intervals") or []:
+            if not isinstance(interval, Mapping):
+                continue
+            usage = interval.get("usage")
+            usage = usage if isinstance(usage, Mapping) else {}
+            interval_rows.append(
+                "| "
+                + " | ".join(
+                    [
+                        phase,
+                        str(interval.get("invocation") or "—"),
+                        str(interval.get("index") or "—"),
+                        cell(usage.get("input_tokens")),
+                        cell(usage.get("output_tokens")),
+                        cell(usage.get("cache_read_tokens")),
+                        cell(usage.get("cache_write_tokens")),
+                        cell(usage.get("total_tokens")),
+                        str(usage.get("measurement") or "unavailable"),
+                    ]
+                )
+                + " |"
+            )
+
     terminal = tokens.get("terminal_usage")
     terminal = terminal if isinstance(terminal, Mapping) else {}
-    return "\n".join(
-        [
-            f"# Long-horizon Episode {summary.get('episode', 'unknown')}",
-            "",
-            f"- version: `{summary.get('version', 'unknown')}`",
-            f"- status: `{summary.get('status', 'unknown')}`",
-            f"- accepted: `{bool(summary.get('accepted'))}`",
-            f"- invocations/resumes: `{summary.get('invocation_count', 0)}` / `{summary.get('resume_count', 0)}`",
-            f"- control tokens: `{cell(summary.get('control_tokens'))}`",
-            f"- structured terminal tokens: `{cell(terminal.get('total_tokens'))}`",
-            f"- semantic coverage: `{tokens.get('semantic_phase_coverage', 'unavailable')}`",
-            f"- accounted coverage: `{tokens.get('accounted_coverage', 'unavailable')}`",
-            f"- measurement: `{summary.get('measurement', 'unavailable')}`",
-            f"- reason codes: `{', '.join(summary.get('reason_codes') or []) or 'none'}`",
-            "",
-            "## Phase token usage",
-            "",
-            "| Phase | Input | Output | Cache read | Cache write | Total | Intervals | Measurement |",
-            "|---|---:|---:|---:|---:|---:|---:|---|",
-            *rows,
-        ]
-    )
+    lines = [
+        f"# Long-horizon Episode {summary.get('episode', 'unknown')}",
+        "",
+        f"- version: `{summary.get('version', 'unknown')}`",
+        f"- status: `{summary.get('status', 'unknown')}`",
+        f"- accepted: `{bool(summary.get('accepted'))}`",
+        f"- invocations/resumes: `{summary.get('invocation_count', 0)}` / `{summary.get('resume_count', 0)}`",
+        f"- control tokens: `{cell(summary.get('control_tokens'))}`",
+        f"- structured terminal tokens: `{cell(terminal.get('total_tokens'))}`",
+        f"- semantic coverage: `{tokens.get('semantic_phase_coverage', 'unavailable')}`",
+        f"- accounted coverage: `{tokens.get('accounted_coverage', 'unavailable')}`",
+        f"- measurement: `{summary.get('measurement', 'unavailable')}`",
+        f"- reason codes: `{', '.join(summary.get('reason_codes') or []) or 'none'}`",
+        "",
+        "## Phase token usage",
+        "",
+        "| Phase | Input | Output | Cache read | Cache write | Total | Intervals | Measurement |",
+        "|---|---:|---:|---:|---:|---:|---:|---|",
+        *rows,
+    ]
+    if interval_rows:
+        lines.extend(
+            [
+                "",
+                "## Phase interval token usage",
+                "",
+                "| Phase | Invocation | Interval | Input | Output | Cache read | Cache write | Total | Measurement |",
+                "|---|---:|---:|---:|---:|---:|---:|---:|---|",
+                *interval_rows,
+            ]
+        )
+    return "\n".join(lines)

--- a/long_horizon/telemetry.py
+++ b/long_horizon/telemetry.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from orchestrator.agent_runtime.model import (
+    AgentRuntimeCapabilities,
+    TokenUsage,
+)
+from orchestrator.telemetry.phase_tokens import (
+    PHASES,
+    aggregate_attempt_tokens,
+    summarize_phase_tokens,
+)
+
+from .models import InvocationObservation
+
+
+EPISODE_TELEMETRY_SCHEMA_VERSION = "atrex_long_horizon_episode_telemetry_v1"
+
+
+def _fallback_phase_tokens(control_tokens: int) -> dict[str, Any]:
+    terminal = TokenUsage(
+        input_tokens=None,
+        output_tokens=None,
+        cache_read_tokens=None,
+        cache_write_tokens=None,
+        total_tokens=max(0, int(control_tokens)),
+        measurement="partial",
+    )
+    return summarize_phase_tokens(
+        events=(),
+        terminal_usage=terminal,
+        capabilities=AgentRuntimeCapabilities(False, False, False),
+        observation_errors=("structured_usage_unavailable",),
+    )
+
+
+def summarize_episode(
+    *,
+    episode: int,
+    version: int,
+    status: str,
+    accepted: bool,
+    control_tokens: int,
+    resume_count: int,
+    invocations: Sequence[InvocationObservation],
+) -> dict[str, Any]:
+    """Summarize one episode without changing its existing control-token contract."""
+    invocation_summaries: list[dict[str, Any]] = []
+    for index, invocation in enumerate(invocations, start=1):
+        phase_tokens = summarize_phase_tokens(
+            events=invocation.events,
+            terminal_usage=invocation.terminal_usage,
+            capabilities=invocation.capabilities,
+            observation_errors=invocation.observation_errors,
+        )
+        invocation_summaries.append(
+            {
+                "invocation": index,
+                "phase_tokens": phase_tokens,
+                "measurement": phase_tokens["measurement"],
+            }
+        )
+
+    phase_tokens = (
+        aggregate_attempt_tokens(invocation_summaries)
+        if invocation_summaries
+        else _fallback_phase_tokens(control_tokens)
+    )
+    reasons = set(str(value) for value in phase_tokens.get("reason_codes", []))
+    if not invocation_summaries:
+        reasons.add("structured_usage_unavailable")
+    if resume_count > 0 or len(invocation_summaries) > 1:
+        reasons.add("same_session_resume_usage_semantics_unqualified")
+    structured_total = (phase_tokens.get("terminal_usage") or {}).get("total_tokens")
+    if (
+        isinstance(structured_total, int)
+        and structured_total != max(0, int(control_tokens))
+    ):
+        reasons.add("control_token_total_mismatch")
+
+    measurement = str(phase_tokens.get("measurement") or "unavailable")
+    if invocation_summaries and reasons:
+        measurement = "partial"
+    phase_tokens["reason_codes"] = sorted(reasons)
+    if reasons and phase_tokens.get("measurement") == "exact":
+        phase_tokens["measurement"] = "partial"
+
+    return {
+        "schema_version": EPISODE_TELEMETRY_SCHEMA_VERSION,
+        "episode": int(episode),
+        "version": f"v{int(version)}",
+        "status": str(status),
+        "accepted": bool(accepted),
+        "control_tokens": max(0, int(control_tokens)),
+        "resume_count": max(0, int(resume_count)),
+        "invocation_count": len(invocation_summaries),
+        "invocations": invocation_summaries,
+        "phase_tokens": phase_tokens,
+        "measurement": measurement,
+        "reason_codes": sorted(reasons),
+    }
+
+
+def render_episode_brief(summary: Mapping[str, Any]) -> str:
+    tokens = summary.get("phase_tokens")
+    tokens = tokens if isinstance(tokens, Mapping) else {}
+    phases = tokens.get("phases")
+    phases = phases if isinstance(phases, Mapping) else {}
+
+    def cell(value: object) -> str:
+        return f"{value:,}" if isinstance(value, int) else "—"
+
+    rows: list[str] = []
+    for phase in PHASES:
+        payload = phases.get(phase)
+        payload = payload if isinstance(payload, Mapping) else {}
+        usage = payload.get("usage")
+        usage = usage if isinstance(usage, Mapping) else {}
+        rows.append(
+            "| "
+            + " | ".join(
+                [
+                    phase,
+                    cell(usage.get("input_tokens")),
+                    cell(usage.get("output_tokens")),
+                    cell(usage.get("cache_read_tokens")),
+                    cell(usage.get("cache_write_tokens")),
+                    cell(usage.get("total_tokens")),
+                    str(payload.get("interval_count") or 0),
+                    str(payload.get("measurement") or "unavailable"),
+                ]
+            )
+            + " |"
+        )
+    for label in ("orchestration", "unattributed"):
+        usage = tokens.get(label)
+        usage = usage if isinstance(usage, Mapping) else {}
+        rows.append(
+            "| "
+            + " | ".join(
+                [
+                    label,
+                    cell(usage.get("input_tokens")),
+                    cell(usage.get("output_tokens")),
+                    cell(usage.get("cache_read_tokens")),
+                    cell(usage.get("cache_write_tokens")),
+                    cell(usage.get("total_tokens")),
+                    "—",
+                    str(usage.get("measurement") or "unavailable"),
+                ]
+            )
+            + " |"
+        )
+
+    terminal = tokens.get("terminal_usage")
+    terminal = terminal if isinstance(terminal, Mapping) else {}
+    return "\n".join(
+        [
+            f"# Long-horizon Episode {summary.get('episode', 'unknown')}",
+            "",
+            f"- version: `{summary.get('version', 'unknown')}`",
+            f"- status: `{summary.get('status', 'unknown')}`",
+            f"- accepted: `{bool(summary.get('accepted'))}`",
+            f"- invocations/resumes: `{summary.get('invocation_count', 0)}` / `{summary.get('resume_count', 0)}`",
+            f"- control tokens: `{cell(summary.get('control_tokens'))}`",
+            f"- structured terminal tokens: `{cell(terminal.get('total_tokens'))}`",
+            f"- semantic coverage: `{tokens.get('semantic_phase_coverage', 'unavailable')}`",
+            f"- accounted coverage: `{tokens.get('accounted_coverage', 'unavailable')}`",
+            f"- measurement: `{summary.get('measurement', 'unavailable')}`",
+            f"- reason codes: `{', '.join(summary.get('reason_codes') or []) or 'none'}`",
+            "",
+            "## Phase token usage",
+            "",
+            "| Phase | Input | Output | Cache read | Cache write | Total | Intervals | Measurement |",
+            "|---|---:|---:|---:|---:|---:|---:|---|",
+            *rows,
+        ]
+    )

--- a/long_horizon/tests/test_campaign.py
+++ b/long_horizon/tests/test_campaign.py
@@ -12,6 +12,7 @@ from long_horizon.git_episode import EpisodeWorktree, git_head, record_episode_o
 from long_horizon.journal import append_experiment, finalize
 from long_horizon.models import (
     EpisodeHandoff,
+    InvocationObservation,
     SessionResult,
     VerificationResult,
     VerificationRun,
@@ -19,11 +20,21 @@ from long_horizon.models import (
 from long_horizon.protocol import atomic_write_json
 from long_horizon.store import CampaignStore
 from long_horizon.tests.helpers import init_repo, run_git
+from orchestrator.agent_runtime.model import (
+    AgentRuntimeCapabilities,
+    NormalizedAgentEvent,
+    TokenUsage,
+)
 
 
 class CandidateRunner:
-    def __init__(self, value: int = 5):
+    def __init__(
+        self,
+        value: int = 5,
+        invocations: tuple[InvocationObservation, ...] = (),
+    ):
         self.value = value
+        self.invocations = invocations
         self.telemetry_environment = None
 
     def run(
@@ -71,6 +82,7 @@ class CandidateRunner:
             session_id="session-1",
             resume_count=0,
             handoff=handoff,
+            invocations=self.invocations,
         )
 
 
@@ -285,6 +297,61 @@ class CampaignIntegrationTests(unittest.TestCase):
             self.assertTrue(
                 (repo / ".atrex_long_horizon/episodes/e0001/telemetry.brief.md").is_file()
             )
+
+    def test_campaign_persists_default_structured_phase_telemetry(self) -> None:
+        usage = lambda total: TokenUsage(total, 0, 0, 0, total, "exact")
+        capabilities = AgentRuntimeCapabilities(True, True, True, True)
+        observation = InvocationObservation(
+            terminal_usage=usage(123),
+            events=(
+                NormalizedAgentEvent(0, "usage_delta", usage=usage(10)),
+                NormalizedAgentEvent(
+                    1, "phase_marker", phase="research", action="start", marker_id="r1"
+                ),
+                NormalizedAgentEvent(2, "usage_delta", usage=usage(20)),
+                NormalizedAgentEvent(
+                    3, "phase_marker", phase="research", action="end", marker_id="r2"
+                ),
+                NormalizedAgentEvent(
+                    4, "phase_marker", phase="recording", action="start", marker_id="w1"
+                ),
+                NormalizedAgentEvent(5, "usage_delta", usage=usage(70)),
+                NormalizedAgentEvent(
+                    6, "phase_marker", phase="recording", action="end", marker_id="w2"
+                ),
+                NormalizedAgentEvent(7, "usage_delta", usage=usage(23)),
+                NormalizedAgentEvent(8, "terminal_usage", usage=usage(123)),
+            ),
+            capabilities=capabilities,
+        )
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            repo = root / "campaign"
+            init_repo(repo)
+            patches = self._patches()
+            with patches[0], patches[1], patches[2], patches[3], patches[4]:
+                runner = CandidateRunner(5, invocations=(observation,))
+                LongHorizonCampaign(
+                    base_campaign=fake_base(repo),
+                    max_episodes=1,
+                    verifier=FixedVerifier(True),
+                    session_runner=runner,
+                    worktree_root=root / "worktrees",
+                ).run()
+
+            telemetry = json.loads(
+                (repo / ".atrex_long_horizon/episodes/e0001/telemetry.summary.json").read_text()
+            )
+            tokens = telemetry["phase_tokens"]
+            self.assertEqual(telemetry["control_tokens"], 123)
+            self.assertEqual(tokens["terminal_usage"]["total_tokens"], 123)
+            self.assertEqual(tokens["phases"]["research"]["usage"]["total_tokens"], 30)
+            self.assertEqual(tokens["phases"]["recording"]["usage"]["total_tokens"], 70)
+            self.assertEqual(tokens["orchestration"]["total_tokens"], 23)
+            self.assertEqual(tokens["unattributed"]["total_tokens"], 0)
+            self.assertEqual(tokens["accounted_coverage"], 1.0)
+            self.assertEqual(tokens["reconciliation_status"], "reconciled")
+            self.assertIn("ATREX_TELEMETRY_TRACE", runner.telemetry_environment)
 
     def test_telemetry_failure_does_not_block_candidate_promotion(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/long_horizon/tests/test_campaign.py
+++ b/long_horizon/tests/test_campaign.py
@@ -24,6 +24,7 @@ from long_horizon.tests.helpers import init_repo, run_git
 class CandidateRunner:
     def __init__(self, value: int = 5):
         self.value = value
+        self.telemetry_environment = None
 
     def run(
         self,
@@ -36,6 +37,7 @@ class CandidateRunner:
         completion_check,
         **kwargs,
     ):
+        self.telemetry_environment = kwargs.get("telemetry_environment")
         (workspace / "kernel.py").write_text(f"VALUE = {self.value}\n", encoding="utf-8")
         run_git(workspace, "add", "kernel.py")
         run_git(workspace, "commit", "-m", "candidate")
@@ -253,11 +255,12 @@ class CampaignIntegrationTests(unittest.TestCase):
             patches = self._patches()
             with patches[0], patches[1], patches[2], patches[3], patches[4]:
                 base_campaign = fake_base(repo)
+                runner = CandidateRunner(5)
                 reason = LongHorizonCampaign(
                     base_campaign=base_campaign,
                     max_episodes=1,
                     verifier=FixedVerifier(True),
-                    session_runner=CandidateRunner(5),
+                    session_runner=runner,
                     worktree_root=root / "worktrees",
                 ).run()
             self.assertEqual(reason, "max-episodes")
@@ -269,6 +272,56 @@ class CampaignIntegrationTests(unittest.TestCase):
             base_campaign._notify_improvement.assert_called_once()
             base_campaign._notify_iteration.assert_called_once()
             self.assertTrue(base_campaign._notify_iteration.call_args.args[2])
+            self.assertIn("ATREX_TELEMETRY_TRACE", runner.telemetry_environment)
+            telemetry_path = (
+                repo
+                / ".atrex_long_horizon/episodes/e0001/telemetry.summary.json"
+            )
+            telemetry = json.loads(telemetry_path.read_text(encoding="utf-8"))
+            self.assertEqual(telemetry["control_tokens"], 123)
+            self.assertEqual(
+                telemetry["phase_tokens"]["unattributed"]["total_tokens"], 123
+            )
+            self.assertTrue(
+                (repo / ".atrex_long_horizon/episodes/e0001/telemetry.brief.md").is_file()
+            )
+
+    def test_telemetry_failure_does_not_block_candidate_promotion(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            repo = root / "campaign"
+            init_repo(repo)
+            patches = self._patches()
+            with (
+                patches[0],
+                patches[1],
+                patches[2],
+                patches[3],
+                patches[4],
+                mock.patch(
+                    "long_horizon.store.CampaignStore.archive_telemetry",
+                    side_effect=OSError("telemetry disk unavailable"),
+                ),
+            ):
+                reason = LongHorizonCampaign(
+                    base_campaign=fake_base(repo),
+                    max_episodes=1,
+                    verifier=FixedVerifier(True),
+                    session_runner=CandidateRunner(5),
+                    worktree_root=root / "worktrees",
+                ).run()
+
+            self.assertEqual(reason, "max-episodes")
+            self.assertEqual((repo / "kernel.py").read_text(encoding="utf-8"), "VALUE = 5\n")
+            state = json.loads((repo / ".atrex_long_horizon/state.json").read_text())
+            self.assertEqual(state["accepted"], 1)
+            self.assertEqual(
+                state["attempts"][0]["telemetry"]["measurement"], "unavailable"
+            )
+            self.assertEqual(
+                state["attempts"][0]["telemetry"]["reason_codes"],
+                ["telemetry_finalize_failed:OSError"],
+            )
 
     def test_regressing_candidate_never_moves_incumbent(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/long_horizon/tests/test_main_adapter.py
+++ b/long_horizon/tests/test_main_adapter.py
@@ -5,6 +5,7 @@ import unittest
 from unittest import mock
 
 from long_horizon import main_adapter
+from orchestrator.agent_runtime.model import AgentRuntimeCapabilities
 
 
 class SessionAdapterTests(unittest.TestCase):
@@ -38,6 +39,26 @@ class SessionAdapterTests(unittest.TestCase):
             command[command.index("--session-id") + 1], "pi-session-id"
         )
         self.assertFalse(main_adapter.supports_same_session_resume("pi"))
+
+    def test_stream_normalization_failure_preserves_terminal_total(self) -> None:
+        adapter = mock.Mock()
+        adapter.capabilities = AgentRuntimeCapabilities(True, True, True)
+        adapter.normalize_stream.side_effect = ValueError("malformed stream")
+        stdout = json.dumps(
+            {"type": "turn.completed", "usage": {"input_tokens": 7, "output_tokens": 2}}
+        )
+
+        with mock.patch.object(
+            main_adapter.DEFAULT_BACKEND_REGISTRY, "create", return_value=adapter
+        ):
+            events, terminal, capabilities, errors = main_adapter.normalize_stream(
+                "codex", stdout
+            )
+
+        self.assertEqual(events, ())
+        self.assertEqual(terminal.total_tokens, 9)
+        self.assertFalse(capabilities.usage_delta_observed)
+        self.assertEqual(errors, ("stream_normalization_failed:ValueError",))
 
     def test_codex_thread_id_is_read_from_jsonl(self) -> None:
         thread_id = "019c1234-5678-7abc-8def-0123456789ab"

--- a/long_horizon/tests/test_session.py
+++ b/long_horizon/tests/test_session.py
@@ -264,6 +264,84 @@ class SessionRecoveryTests(unittest.TestCase):
             self.assertEqual(result.handoff.status, "pivot")
             self.assertIn(thread_id, commands[1])
 
+    def test_single_invocation_captures_structured_usage_and_marker_events(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            workspace = Path(temp)
+            handoff = workspace / "handoff.json"
+            observed_environment: dict[str, str] = {}
+            receipt = (
+                'ATREX_TRACE_EVENT={"schema":"atrex.iteration_trace.v1",'
+                '"kind":"phase_marker","action":"start","phase":"research",'
+                '"marker_id":"marker-1"}'
+            )
+            stdout = "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "type": "message_end",
+                            "message": {
+                                "role": "assistant",
+                                "usage": {
+                                    "input": 2,
+                                    "output": 3,
+                                    "cacheRead": 5,
+                                    "cacheWrite": 0,
+                                    "totalTokens": 10,
+                                },
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "message_end",
+                            "message": {
+                                "role": "toolResult",
+                                "content": [{"type": "text", "text": receipt}],
+                                "usage": {
+                                    "input": 1,
+                                    "output": 1,
+                                    "cacheRead": 3,
+                                    "cacheWrite": 0,
+                                    "totalTokens": 5,
+                                },
+                            },
+                        }
+                    ),
+                    json.dumps({"type": "agent_settled"}),
+                ]
+            )
+
+            def execute(command, cwd, timeout, environment):
+                observed_environment.update(environment)
+                atomic_write_json(handoff, {"status": "pivot"})
+                return stdout, "", 0, False
+
+            with mock.patch(
+                "long_horizon.main_adapter.session_environment", return_value={}
+            ):
+                result = LongSessionRunner(executor=execute, agent_cli="pi").run(
+                    workspace,
+                    "work",
+                    timeout=60,
+                    handoff_path=handoff,
+                    handoff_resumes=0,
+                    completion_check=lambda value: "",
+                    telemetry_environment={"ATREX_TELEMETRY_TRACE": "/tmp/trace.jsonl"},
+                )
+
+            self.assertEqual(result.tokens, 15)
+            self.assertEqual(len(result.invocations), 1)
+            observation = result.invocations[0]
+            self.assertEqual(observation.terminal_usage.total_tokens, 15)
+            self.assertEqual(
+                [event.kind for event in observation.events],
+                ["usage_delta", "usage_delta", "phase_marker", "terminal_usage"],
+            )
+            self.assertTrue(observation.capabilities.usage_delta_observed)
+            self.assertEqual(
+                observed_environment["ATREX_TELEMETRY_TRACE"], "/tmp/trace.jsonl"
+            )
+
     def test_dependency_policy_sigterm_does_not_resume(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             workspace = Path(temp)

--- a/long_horizon/tests/test_session.py
+++ b/long_horizon/tests/test_session.py
@@ -30,9 +30,11 @@ class SessionRecoveryTests(unittest.TestCase):
             workspace = Path(temp)
             handoff = workspace / "handoff.json"
             commands: list[list[str]] = []
+            attempt_ids: list[str | None] = []
 
             def execute(command, cwd, timeout, environment):
                 commands.append(command)
+                attempt_ids.append(environment.get("ATREX_TELEMETRY_ATTEMPT_ID"))
                 if len(commands) == 2:
                     atomic_write_json(handoff, {"status": "pivot"})
                 return "", "", 0, False
@@ -51,11 +53,15 @@ class SessionRecoveryTests(unittest.TestCase):
                     handoff_path=handoff,
                     handoff_resumes=2,
                     completion_check=lambda value: "",
+                    telemetry_environment={
+                        "ATREX_TELEMETRY_ATTEMPT_ID": "invocation"
+                    },
                 )
             self.assertEqual(result.resume_count, 1)
             self.assertEqual(result.handoff.status, "pivot")
             self.assertEqual(commands[0][2], commands[1][2])
             self.assertEqual(commands[1][1], "--resume")
+            self.assertEqual(attempt_ids, ["invocation-1", "invocation-2"])
 
     def test_nonzero_exit_does_not_resume(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/long_horizon/tests/test_session.py
+++ b/long_horizon/tests/test_session.py
@@ -278,6 +278,21 @@ class SessionRecoveryTests(unittest.TestCase):
                 [
                     json.dumps(
                         {
+                            "type": "message_update",
+                            "message": {
+                                "role": "assistant",
+                                "usage": {
+                                    "input": 2,
+                                    "output": 3,
+                                    "cacheRead": 5,
+                                    "cacheWrite": 0,
+                                    "totalTokens": 10,
+                                },
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
                             "type": "message_end",
                             "message": {
                                 "role": "assistant",

--- a/long_horizon/tests/test_telemetry.py
+++ b/long_horizon/tests/test_telemetry.py
@@ -134,7 +134,7 @@ class EpisodeTelemetryTests(unittest.TestCase):
         )
         observation = InvocationObservation(
             terminal_usage=usage(500),
-            events=(NormalizedAgentEvent(0, "terminal_usage", usage=usage(500)),),
+            events=(),
             capabilities=terminal_only,
         )
 

--- a/long_horizon/tests/test_telemetry.py
+++ b/long_horizon/tests/test_telemetry.py
@@ -70,7 +70,16 @@ class EpisodeTelemetryTests(unittest.TestCase):
         self.assertEqual(
             tokens["phases"]["implementation"]["usage"]["total_tokens"], 10
         )
-        self.assertEqual(tokens["phases"]["implementation"]["interval_count"], 2)
+        implementation = tokens["phases"]["implementation"]
+        self.assertEqual(implementation["interval_count"], 2)
+        self.assertEqual(
+            [value["usage"]["total_tokens"] for value in implementation["intervals"]],
+            [4, 6],
+        )
+        self.assertEqual(
+            [value["invocation"] for value in implementation["intervals"]],
+            [1, 1],
+        )
         self.assertEqual(tokens["orchestration"]["total_tokens"], 10)
         self.assertEqual(tokens["unattributed"]["total_tokens"], 0)
         self.assertEqual(tokens["accounted_coverage"], 1.0)
@@ -81,6 +90,7 @@ class EpisodeTelemetryTests(unittest.TestCase):
         brief = render_episode_brief(summary)
         self.assertIn("Episode 3", brief)
         self.assertIn("implementation", brief)
+        self.assertIn("| implementation | 1 | 2 |", brief)
         self.assertIn("30", brief)
 
     def test_resumed_episode_is_attempt_first_and_marked_unqualified(self) -> None:

--- a/long_horizon/tests/test_telemetry.py
+++ b/long_horizon/tests/test_telemetry.py
@@ -72,12 +72,13 @@ class EpisodeTelemetryTests(unittest.TestCase):
         )
         implementation = tokens["phases"]["implementation"]
         self.assertEqual(implementation["interval_count"], 2)
+        implementation_intervals = summary["phase_intervals"]["implementation"]
         self.assertEqual(
-            [value["usage"]["total_tokens"] for value in implementation["intervals"]],
+            [value["usage"]["total_tokens"] for value in implementation_intervals],
             [4, 6],
         )
         self.assertEqual(
-            [value["invocation"] for value in implementation["intervals"]],
+            [value["invocation"] for value in implementation_intervals],
             [1, 1],
         )
         self.assertEqual(tokens["orchestration"]["total_tokens"], 10)
@@ -118,11 +119,65 @@ class EpisodeTelemetryTests(unittest.TestCase):
         self.assertEqual(summary["invocation_count"], 2)
         self.assertEqual(summary["phase_tokens"]["terminal_usage"]["total_tokens"], 30)
         self.assertEqual(summary["phase_tokens"]["accounted_coverage"], 1.0)
-        self.assertEqual(summary["measurement"], "partial")
+        self.assertEqual(summary["measurement"], "unavailable")
         self.assertIn(
             "same_session_resume_usage_semantics_unqualified",
             summary["reason_codes"],
         )
+
+    def test_terminal_only_backend_keeps_episode_measurement_unavailable(self) -> None:
+        terminal_only = AgentRuntimeCapabilities(
+            terminal_usage=True,
+            usage_delta=False,
+            phase_marker_receipt=True,
+            usage_delta_observed=False,
+        )
+        observation = InvocationObservation(
+            terminal_usage=usage(500),
+            events=(NormalizedAgentEvent(0, "terminal_usage", usage=usage(500)),),
+            capabilities=terminal_only,
+        )
+
+        summary = summarize_episode(
+            episode=1,
+            version=1,
+            status="pivot",
+            accepted=False,
+            control_tokens=500,
+            resume_count=0,
+            invocations=(observation,),
+        )
+
+        self.assertEqual(summary["measurement"], "unavailable")
+        self.assertEqual(summary["phase_tokens"]["measurement"], "unavailable")
+        self.assertEqual(summary["phase_tokens"]["unattributed"]["total_tokens"], 500)
+        self.assertIn("backend_has_no_usage_delta", summary["reason_codes"])
+
+    def test_unavailable_interval_is_not_exposed_as_phase_detail(self) -> None:
+        observation = InvocationObservation(
+            terminal_usage=usage(10),
+            events=(
+                marker(0, "planning", "start"),
+                NormalizedAgentEvent(1, "usage_delta", usage=TokenUsage.unavailable()),
+                marker(2, "planning", "end"),
+            ),
+            capabilities=CAPABILITIES,
+        )
+
+        summary = summarize_episode(
+            episode=1,
+            version=1,
+            status="pivot",
+            accepted=False,
+            control_tokens=10,
+            resume_count=0,
+            invocations=(observation,),
+        )
+
+        planning = summary["phase_tokens"]["phases"]["planning"]
+        self.assertIsNone(planning["usage"])
+        self.assertEqual(planning["interval_count"], 0)
+        self.assertEqual(summary["phase_intervals"]["planning"], [])
 
     def test_missing_structured_observation_preserves_control_total_as_unattributed(self) -> None:
         summary = summarize_episode(

--- a/long_horizon/tests/test_telemetry.py
+++ b/long_horizon/tests/test_telemetry.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import unittest
+
+from long_horizon.models import InvocationObservation
+from long_horizon.telemetry import render_episode_brief, summarize_episode
+from orchestrator.agent_runtime.model import (
+    AgentRuntimeCapabilities,
+    NormalizedAgentEvent,
+    TokenUsage,
+)
+
+
+CAPABILITIES = AgentRuntimeCapabilities(
+    terminal_usage=True,
+    usage_delta=True,
+    phase_marker_receipt=True,
+    usage_delta_observed=True,
+)
+
+
+def usage(total: int) -> TokenUsage:
+    return TokenUsage(total, 0, 0, 0, total, "exact")
+
+
+def marker(sequence: int, phase: str, action: str) -> NormalizedAgentEvent:
+    return NormalizedAgentEvent(
+        sequence,
+        "phase_marker",
+        phase=phase,
+        action=action,
+        marker_id=f"{phase}-{action}-{sequence}",
+    )
+
+
+class EpisodeTelemetryTests(unittest.TestCase):
+    def test_single_invocation_reuses_explicit_repeated_phase_accounting(self) -> None:
+        observation = InvocationObservation(
+            terminal_usage=usage(30),
+            events=(
+                NormalizedAgentEvent(0, "usage_delta", usage=usage(2)),
+                marker(1, "research", "start"),
+                NormalizedAgentEvent(2, "usage_delta", usage=usage(8)),
+                marker(3, "research", "end"),
+                marker(4, "implementation", "start"),
+                NormalizedAgentEvent(5, "usage_delta", usage=usage(4)),
+                marker(6, "implementation", "end"),
+                marker(7, "implementation", "start"),
+                NormalizedAgentEvent(8, "usage_delta", usage=usage(6)),
+                marker(9, "implementation", "end"),
+                NormalizedAgentEvent(10, "usage_delta", usage=usage(10)),
+                NormalizedAgentEvent(11, "terminal_usage", usage=usage(30)),
+            ),
+            capabilities=CAPABILITIES,
+        )
+
+        summary = summarize_episode(
+            episode=3,
+            version=5,
+            status="candidate_ready",
+            accepted=True,
+            control_tokens=30,
+            resume_count=0,
+            invocations=(observation,),
+        )
+
+        tokens = summary["phase_tokens"]
+        self.assertEqual(tokens["terminal_usage"]["total_tokens"], 30)
+        self.assertEqual(tokens["phases"]["research"]["usage"]["total_tokens"], 10)
+        self.assertEqual(
+            tokens["phases"]["implementation"]["usage"]["total_tokens"], 10
+        )
+        self.assertEqual(tokens["phases"]["implementation"]["interval_count"], 2)
+        self.assertEqual(tokens["orchestration"]["total_tokens"], 10)
+        self.assertEqual(tokens["unattributed"]["total_tokens"], 0)
+        self.assertEqual(tokens["accounted_coverage"], 1.0)
+        self.assertEqual(summary["measurement"], "partial")
+        self.assertEqual(summary["reason_codes"], [])
+        self.assertNotIn("events", summary)
+
+        brief = render_episode_brief(summary)
+        self.assertIn("Episode 3", brief)
+        self.assertIn("implementation", brief)
+        self.assertIn("30", brief)
+
+    def test_resumed_episode_is_attempt_first_and_marked_unqualified(self) -> None:
+        first = InvocationObservation(
+            terminal_usage=usage(10),
+            events=(NormalizedAgentEvent(0, "usage_delta", usage=usage(10)),),
+            capabilities=CAPABILITIES,
+        )
+        second = InvocationObservation(
+            terminal_usage=usage(20),
+            events=(NormalizedAgentEvent(0, "usage_delta", usage=usage(20)),),
+            capabilities=CAPABILITIES,
+        )
+
+        summary = summarize_episode(
+            episode=1,
+            version=1,
+            status="pivot",
+            accepted=False,
+            control_tokens=30,
+            resume_count=1,
+            invocations=(first, second),
+        )
+
+        self.assertEqual(summary["invocation_count"], 2)
+        self.assertEqual(summary["phase_tokens"]["terminal_usage"]["total_tokens"], 30)
+        self.assertEqual(summary["phase_tokens"]["accounted_coverage"], 1.0)
+        self.assertEqual(summary["measurement"], "partial")
+        self.assertIn(
+            "same_session_resume_usage_semantics_unqualified",
+            summary["reason_codes"],
+        )
+
+    def test_missing_structured_observation_preserves_control_total_as_unattributed(self) -> None:
+        summary = summarize_episode(
+            episode=1,
+            version=1,
+            status="invalid_handoff",
+            accepted=False,
+            control_tokens=42,
+            resume_count=0,
+            invocations=(),
+        )
+
+        tokens = summary["phase_tokens"]
+        self.assertEqual(tokens["terminal_usage"]["total_tokens"], 42)
+        self.assertEqual(tokens["unattributed"]["total_tokens"], 42)
+        self.assertEqual(tokens["accounted_coverage"], 0.0)
+        self.assertEqual(summary["measurement"], "unavailable")
+        self.assertIn("structured_usage_unavailable", summary["reason_codes"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orchestrator/agent_runtime/adapter.py
+++ b/orchestrator/agent_runtime/adapter.py
@@ -295,6 +295,7 @@ class ClaudeLikeAdapter(AgentBackendAdapter):
         normalized: list[NormalizedAgentEvent] = []
         terminal = TokenUsage.unavailable()
         sequence = 0
+        seen_usage_message_ids: set[str] = set()
         for event in _json_events(stdout):
             event_type = event.get("type")
             if event_type == "result":
@@ -316,7 +317,16 @@ class ClaudeLikeAdapter(AgentBackendAdapter):
             if usage is None and isinstance(message, Mapping):
                 usage = message.get("usage")
             parsed = token_usage_from_mapping(usage)
-            if parsed.total_tokens is not None:
+            message_id = (
+                message.get("id")
+                if isinstance(message, Mapping)
+                and isinstance(message.get("id"), str)
+                else None
+            )
+            duplicate_usage = bool(
+                message_id and message_id in seen_usage_message_ids
+            )
+            if parsed.total_tokens is not None and not duplicate_usage:
                 normalized.append(
                     NormalizedAgentEvent(
                         sequence=sequence,
@@ -325,6 +335,8 @@ class ClaudeLikeAdapter(AgentBackendAdapter):
                     )
                 )
                 sequence += 1
+                if message_id:
+                    seen_usage_message_ids.add(message_id)
             for action, phase, marker_id in _phase_marker_receipts(event):
                 normalized.append(
                     NormalizedAgentEvent(
@@ -392,6 +404,23 @@ class QoderAdapter(ClaudeLikeAdapter):
 
     def __init__(self, humanize_dir: Path) -> None:
         del humanize_dir
+
+    def normalize_stream(
+        self, stdout: str
+    ) -> tuple[tuple[NormalizedAgentEvent, ...], TokenUsage]:
+        events, terminal = super().normalize_stream(stdout)
+        usage_events = [event for event in events if event.usage is not None]
+        if (
+            terminal.total_tokens == 0
+            and usage_events
+            and all(event.usage.total_tokens == 0 for event in usage_events if event.usage)
+        ):
+            markers = [event for event in events if event.kind == "phase_marker"]
+            return (
+                tuple(replace(event, sequence=index) for index, event in enumerate(markers)),
+                TokenUsage.unavailable(),
+            )
+        return events, terminal
 
     def build_command(
         self,

--- a/orchestrator/telemetry/phase_tokens.py
+++ b/orchestrator/telemetry/phase_tokens.py
@@ -81,7 +81,6 @@ def summarize_phase_tokens(
                     "interval_count": 0,
                     "measurement": "unavailable",
                     "reason": "phase_not_observed",
-                    "intervals": [],
                 }
                 for phase in PHASES
             },
@@ -184,7 +183,6 @@ def summarize_phase_tokens(
                 "interval_count": 0,
                 "measurement": "unavailable",
                 "reason": "phase_not_observed",
-                "intervals": [],
             }
             continue
         interval_usages = [_sum_phase_usages(interval) for interval in intervals]
@@ -350,7 +348,6 @@ def aggregate_attempt_tokens(attempts: Sequence[Mapping[str, Any]]) -> dict[str,
                 "interval_count": 0,
                 "measurement": "unavailable",
                 "reason": "phase_not_observed",
-                "intervals": [],
             }
             continue
         aggregate = _sum_phase_usages(usages)
@@ -369,7 +366,6 @@ def aggregate_attempt_tokens(attempts: Sequence[Mapping[str, Any]]) -> dict[str,
             "interval_count": interval_count,
             "measurement": aggregate.measurement,
             "reason": None,
-            "intervals": [],
         }
 
     displayed_attributed = _sum_phase_usages(phase_aggregates)

--- a/orchestrator/telemetry/phase_tokens.py
+++ b/orchestrator/telemetry/phase_tokens.py
@@ -81,6 +81,7 @@ def summarize_phase_tokens(
                     "interval_count": 0,
                     "measurement": "unavailable",
                     "reason": "phase_not_observed",
+                    "intervals": [],
                 }
                 for phase in PHASES
             },
@@ -183,6 +184,7 @@ def summarize_phase_tokens(
                 "interval_count": 0,
                 "measurement": "unavailable",
                 "reason": "phase_not_observed",
+                "intervals": [],
             }
             continue
         interval_usages = [_sum_phase_usages(interval) for interval in intervals]
@@ -193,6 +195,10 @@ def summarize_phase_tokens(
             "interval_count": len(intervals),
             "measurement": phase_usage.measurement,
             "reason": None,
+            "intervals": [
+                {"index": index, "usage": usage_dict(interval_usage)}
+                for index, interval_usage in enumerate(interval_usages, start=1)
+            ],
         }
 
     attributed = _sum_phase_usages(attributed_usages)
@@ -344,6 +350,7 @@ def aggregate_attempt_tokens(attempts: Sequence[Mapping[str, Any]]) -> dict[str,
                 "interval_count": 0,
                 "measurement": "unavailable",
                 "reason": "phase_not_observed",
+                "intervals": [],
             }
             continue
         aggregate = _sum_phase_usages(usages)
@@ -362,6 +369,7 @@ def aggregate_attempt_tokens(attempts: Sequence[Mapping[str, Any]]) -> dict[str,
             "interval_count": interval_count,
             "measurement": aggregate.measurement,
             "reason": None,
+            "intervals": [],
         }
 
     displayed_attributed = _sum_phase_usages(phase_aggregates)

--- a/tests/test_agent_backend_adapters.py
+++ b/tests/test_agent_backend_adapters.py
@@ -79,6 +79,20 @@ class BackendFixtureTest(unittest.TestCase):
         self.assertEqual(events[1].action, "start")
         self.assertEqual(terminal.total_tokens, 214)
 
+    def test_claude_duplicate_message_usage_is_counted_once(self) -> None:
+        stdout = "\n".join(
+            [
+                '{"type":"assistant","message":{"id":"msg-1","usage":{"input_tokens":2,"output_tokens":3}}}',
+                '{"type":"assistant","message":{"id":"msg-1","usage":{"input_tokens":2,"output_tokens":3}}}',
+                '{"type":"result","usage":{"input_tokens":2,"output_tokens":3}}',
+            ]
+        )
+
+        events, terminal = ClaudeAdapter(Path("missing")).normalize_stream(stdout)
+
+        self.assertEqual([event.kind for event in events], ["usage_delta", "terminal_usage"])
+        self.assertEqual(terminal.total_tokens, 5)
+
     def test_qoder_fixture_supports_camel_case_usage(self) -> None:
         events, terminal = QoderAdapter(Path("missing")).normalize_stream(
             (FIXTURES / "qoder_usage.jsonl").read_text()
@@ -87,6 +101,20 @@ class BackendFixtureTest(unittest.TestCase):
         self.assertEqual([event.kind for event in events].count("usage_delta"), 2)
         self.assertEqual([event.kind for event in events].count("phase_marker"), 2)
         self.assertEqual(terminal.total_tokens, 15)
+
+    def test_qoder_zero_only_usage_is_unavailable(self) -> None:
+        stdout = "\n".join(
+            [
+                '{"type":"assistant","message":{"usage":{"inputTokens":0,"outputTokens":0}}}',
+                '{"type":"result","usage":{"inputTokens":0,"outputTokens":0}}',
+            ]
+        )
+
+        events, terminal = QoderAdapter(Path("missing")).normalize_stream(stdout)
+
+        self.assertEqual(events, ())
+        self.assertIsNone(terminal.total_tokens)
+        self.assertEqual(terminal.measurement, "unavailable")
 
     def test_pi_fixture_yields_deltas_receipts_and_derived_terminal_usage(self) -> None:
         adapter = PiAdapter(Path("missing"))


### PR DESCRIPTION
## Summary

- enable local-only token telemetry by default for long-horizon episodes
- normalize each initial/resumed Agent invocation through the existing backend adapters
- preserve structured input/output/cache-read/cache-write usage and explicit phase-marker receipts
- reuse ordinary-iteration phase accounting for repeated profile/research/planning/implementation/correctness/benchmark/recording intervals
- retain per-invocation, per-phase-interval usage in JSON and the human-readable brief
- aggregate invocation-first and episode-second while preserving orchestration, unattributed usage, coverage, and reconciliation
- keep telemetry observational: summary failures degrade to unavailable without changing handoff, verification, promotion, memory, Git, stall, or retry authority
- use backend-normalized terminal usage for long-session token budgets, avoiding duplicate counting of streaming update and terminal events

## Output

Each episode writes ignored local state below `.atrex_long_horizon/episodes/eNNNN/`:

- `telemetry.summary.json`
- `telemetry.brief.md`
- the existing metadata-only episode runtime trace

No raw Agent stream, file contents, credentials, or private endpoint data is persisted.

## Token-budget behavior change

Long-horizon `result.tokens` now uses the backend-normalized terminal total and falls back to the legacy generic parser only when structured terminal usage is unavailable. This fixes duplicate counting observed in streaming backends, but it is an intentional control-unit change: a campaign with the same `--token-budget` may run longer than it did under the inflated legacy total. Existing long-horizon budgets calibrated against the old parser should be recalibrated from normalized terminal usage. The accounting fix remains isolated in its own commit (`f0a2c62`).

## Resume semantics

- every initial/resume invocation is normalized independently
- single-invocation episodes can be exact when the backend exposes deltas and terminal usage
- multi-invocation same-session totals are aggregated attempt-first and explicitly marked partial with `same_session_resume_usage_semantics_unqualified` until cumulative-vs-delta resume behavior is qualified per backend
- unavailable structured usage preserves the existing control-token total as unattributed rather than guessing phase ownership

## Validation

- 56 long-horizon tests passed
- 117 Runtime/Telemetry/orchestrator tests passed, 1 skipped
- modified Python modules pass `py_compile` and the branch passes `git diff --check`
- a real Pi repeated-planning smoke produced two separately retained planning intervals (28,341 and 29,071 tokens), exact control/terminal reconciliation, 100% accounted coverage, and zero unattributed tokens
- two complete long-horizon optimization episodes against a remote GPU evaluator reconciled 2,124,345 and 2,287,037 terminal tokens respectively, with 95.97% and 97.17% semantic phase coverage, 100% accounted coverage, zero unattributed tokens, and no reason codes
- the second episode exercised two planning, implementation, correctness, and benchmark intervals and independently verified that final promotion authority remains outside telemetry


## Cross-backend qualification

The same local-only marker workflow was executed in ordinary and long-horizon modes with Claude, Codex, and QoderCLI:

- Claude initially exposed duplicate stream events for one message ID; the adapter now deduplicates message usage. Both modes subsequently reconciled exactly with 100% accounted coverage and zero unattributed tokens.
- Codex exposed terminal usage and marker receipts but no usage deltas. Both modes correctly degrade phase attribution to unavailable while retaining the complete terminal total as unattributed.
- QoderCLI emitted zero-only usage for real non-empty sessions. Zero-only reports now degrade to unavailable instead of claiming exact zero-token coverage.
- regression fixtures cover Claude duplicate-message usage and Qoder zero-only usage.

