### PR TITLE
fix(long-horizon): harden runtime reliability

### DIFF
--- a/long_horizon/cli.py
+++ b/long_horizon/cli.py
@@ -186,11 +186,37 @@ def _run_layer_schedule(
         layer.tokens_spent += max(0, after_tokens - before_tokens)
 
 
+def _status_is_case_insensitive(
+    value: object,
+    expected: str,
+    original_status_is,
+) -> bool:
+    """Accept equivalent status spellings without changing main's policy."""
+    if original_status_is(value, expected):
+        return True
+    current = value
+    normalized_expected = expected.strip().casefold()
+    for _ in range(2):
+        if not isinstance(current, str):
+            return False
+        if current.strip().casefold() == normalized_expected:
+            return True
+        try:
+            decoded = json.loads(current)
+        except json.JSONDecodeError:
+            return False
+        if decoded == current:
+            return False
+        current = decoded
+    return isinstance(current, str) and current.strip().casefold() == normalized_expected
+
+
 @contextmanager
 def _install_main_integration(options: LongHorizonOptions) -> Iterator[None]:
     original_campaign_run = base.Campaign.run
     original_layer_schedule = base.LayerCampaign.schedule
     original_dispatch = base.dispatch_framework_campaigns
+    original_status_is = base._status_is
 
     def campaign_run(campaign: base.Campaign) -> str:
         return _run_campaign(campaign, options)
@@ -218,12 +244,18 @@ def _install_main_integration(options: LongHorizonOptions) -> Iterator[None]:
     base.Campaign.run = campaign_run
     base.LayerCampaign.schedule = layer_schedule
     base.dispatch_framework_campaigns = dispatch
+    base._status_is = lambda value, expected: _status_is_case_insensitive(
+        value,
+        expected,
+        original_status_is,
+    )
     try:
         yield
     finally:
         base.Campaign.run = original_campaign_run
         base.LayerCampaign.schedule = original_layer_schedule
         base.dispatch_framework_campaigns = original_dispatch
+        base._status_is = original_status_is
 
 
 def _print_long_help() -> None:

--- a/long_horizon/main_adapter.py
+++ b/long_horizon/main_adapter.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from pathlib import Path
 
 from orchestrator import optimize as base
@@ -157,9 +159,55 @@ def session_id_from_stream(agent_cli: str, stdout: str, requested_session_id: st
 
 
 def run_bounded(
-    command: list[str], workspace: Path, timeout: int, environment: dict[str, str]
+    command: list[str],
+    workspace: Path,
+    timeout: int,
+    environment: dict[str, str],
+    input_text: str | None = None,
 ) -> tuple[str, str, int, bool]:
-    return base._run_bounded(command, workspace, timeout, environment)
+    if input_text is None:
+        return base._run_bounded(command, workspace, timeout, environment)
+
+    prompt_path = ""
+    try:
+        descriptor, prompt_path = tempfile.mkstemp(
+            prefix="atrex-long-horizon-prompt-",
+            suffix=".txt",
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(input_text)
+        # Keep the potentially large prompt out of argv while preserving main's
+        # process supervision unchanged. The static shell shim exists only in the
+        # long-horizon adapter and replaces itself with the actual agent CLI.
+        wrapped_command = [
+            "/bin/sh",
+            "-c",
+            'prompt_path=$1; shift; exec "$@" < "$prompt_path"',
+            "atrex-long-horizon-prompt",
+            prompt_path,
+            *command,
+        ]
+        return base._run_bounded(
+            wrapped_command, workspace, timeout, environment
+        )
+    finally:
+        if prompt_path:
+            Path(prompt_path).unlink(missing_ok=True)
+
+
+def session_prompt_transport(
+    agent_cli: str, command: list[str], prompt: str
+) -> tuple[list[str], str | None]:
+    if agent_cli not in {"claude", "codex"}:
+        return command, None
+    if not command or command[-1] != prompt:
+        raise RuntimeError(
+            f"current main {agent_cli} command has no compatible prompt transport seam"
+        )
+    transported = list(command[:-1])
+    if agent_cli == "codex":
+        transported.append("-")
+    return transported, prompt
 
 
 def tokens_from_stream(stdout: str) -> int:

--- a/long_horizon/remote_abba.py
+++ b/long_horizon/remote_abba.py
@@ -14,6 +14,7 @@ from typing import Any
 
 RESULT_PREFIX = "[test_kernel] RESULT_JSON="
 ABBA_RESULT_PREFIX = "__ATREX_LONG_HORIZON_ABBA_RESULT__="
+WORKSPACE_SNAPSHOT_SOURCE = "__ATREX_ABBA_WORKSPACE_SOURCE__"
 
 
 def _safe_relative(value: object) -> str:
@@ -50,6 +51,30 @@ def _apply_revision(root: Path, snapshot_root: Path, manifest: dict[str, object]
         shutil.copy2(source, target)
 
 
+def _capture_workspace_revision(
+    root: Path,
+    snapshot_root: Path,
+    manifest: dict[str, object],
+) -> dict[str, object]:
+    """Capture candidate files before the first incumbent is applied."""
+    captured: dict[str, object] = {}
+    capture_root = snapshot_root / ".candidate_workspace_snapshot"
+    for index, (raw_path, raw_source) in enumerate(manifest.items()):
+        relative = _safe_relative(raw_path)
+        if raw_source != WORKSPACE_SNAPSHOT_SOURCE:
+            captured[relative] = raw_source
+            continue
+        source = root / relative
+        if not source.is_file() or source.is_symlink():
+            raise FileNotFoundError(f"candidate workspace source is missing: {source}")
+        snapshot_relative = f".candidate_workspace_snapshot/{index:04d}.bin"
+        target = snapshot_root / snapshot_relative
+        capture_root.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+        captured[relative] = snapshot_relative
+    return captured
+
+
 def _parse_result(stdout: str) -> dict[str, Any] | None:
     for line in reversed(stdout.splitlines()):
         if line.startswith(RESULT_PREFIX):
@@ -78,6 +103,14 @@ def run(request_path: Path, result_path: Path) -> int:
             raise ValueError("run timeout must be positive")
         root = Path.cwd()
         snapshot_root = request_path.parent
+        candidate_manifest = manifests.get("candidate")
+        if not isinstance(candidate_manifest, dict):
+            raise ValueError("missing candidate snapshot manifest")
+        # The uploaded workspace starts at the candidate revision. Preserve it
+        # locally before the ABBA schedule applies any incumbent files.
+        manifests["candidate"] = _capture_workspace_revision(
+            root, snapshot_root, candidate_manifest
+        )
         for step in schedule:
             if not isinstance(step, dict):
                 raise ValueError("ABBA schedule entries must be objects")

--- a/long_horizon/session.py
+++ b/long_horizon/session.py
@@ -14,7 +14,8 @@ from .protocol import handoff_diagnosis, read_handoff
 
 CompletionCheck = Callable[[EpisodeHandoff], str]
 CommandExecutor = Callable[
-    [list[str], Path, int, dict[str, str]], tuple[str, str, int, bool]
+    [list[str], Path, int, dict[str, str], str | None],
+    tuple[str, str, int, bool],
 ]
 
 
@@ -132,8 +133,11 @@ class LongSessionRunner:
                         turn_prompt, active_session_id, reasoning_effort, self.agent_cli
                     )
                 )
+            command, input_text = main_adapter.session_prompt_transport(
+                self.agent_cli, command, turn_prompt
+            )
             stdout, stderr, exit_status, turn_timed_out = self.executor(
-                command, workspace, remaining, environment
+                command, workspace, remaining, environment, input_text
             )
             stdout_parts.append(stdout)
             stderr_parts.append(stderr)

--- a/long_horizon/tests/test_cli_integration.py
+++ b/long_horizon/tests/test_cli_integration.py
@@ -76,6 +76,21 @@ class MainCliIntegrationTests(unittest.TestCase):
             observed["argv"][observed["argv"].index("--verify-repeats") + 1], "4"
         )
 
+    def test_status_checks_are_case_insensitive_only_inside_long_horizon(self) -> None:
+        original_status_is = cli.base._status_is
+        self.assertFalse(original_status_is("pass", "PASS"))
+
+        with cli._install_main_integration(cli.LongHorizonOptions()):
+            self.assertTrue(cli.base._status_is("PASS", "PASS"))
+            self.assertTrue(cli.base._status_is("pass", "PASS"))
+            self.assertTrue(cli.base._status_is(" Pass ", "PASS"))
+            self.assertTrue(cli.base._status_is('"pass"', "PASS"))
+            self.assertFalse(cli.base._status_is("FAIL", "PASS"))
+            self.assertFalse(cli.base._status_is(None, "PASS"))
+
+        self.assertIs(cli.base._status_is, original_status_is)
+        self.assertFalse(cli.base._status_is("pass", "PASS"))
+
     def test_campaign_run_replaces_only_the_iteration_loop(self) -> None:
         campaign = cli.base.Campaign(
             name="op",

--- a/long_horizon/tests/test_main_adapter.py
+++ b/long_horizon/tests/test_main_adapter.py
@@ -1,13 +1,59 @@
 from __future__ import annotations
 
 import json
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from long_horizon import main_adapter
 
 
 class SessionAdapterTests(unittest.TestCase):
+    def test_prompt_transport_is_long_horizon_local(self) -> None:
+        claude, claude_input = main_adapter.session_prompt_transport(
+            "claude", ["claude", "--print", "large prompt"], "large prompt"
+        )
+        codex, codex_input = main_adapter.session_prompt_transport(
+            "codex", ["codex", "exec", "large prompt"], "large prompt"
+        )
+        pi, pi_input = main_adapter.session_prompt_transport(
+            "pi", ["pi", "large prompt"], "large prompt"
+        )
+
+        self.assertEqual(claude, ["claude", "--print"])
+        self.assertEqual(claude_input, "large prompt")
+        self.assertEqual(codex, ["codex", "exec", "-"])
+        self.assertEqual(codex_input, "large prompt")
+        self.assertEqual(pi, ["pi", "large prompt"])
+        self.assertIsNone(pi_input)
+
+    def test_bounded_prompt_uses_private_tempfile_without_changing_main(self) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run(command, workspace, timeout, environment):
+            captured["command"] = command
+            captured["prompt_path"] = command[4]
+            captured["prompt"] = Path(command[4]).read_text(encoding="utf-8")
+            return "out", "", 0, False
+
+        with tempfile.TemporaryDirectory() as temp, mock.patch.object(
+            main_adapter.base, "_run_bounded", side_effect=fake_run
+        ):
+            result = main_adapter.run_bounded(
+                ["claude", "--print"],
+                Path(temp),
+                60,
+                {},
+                "x" * 200_000,
+            )
+
+        command = captured["command"]
+        self.assertEqual(result, ("out", "", 0, False))
+        self.assertEqual(command[5:], ["claude", "--print"])
+        self.assertEqual(captured["prompt"], "x" * 200_000)
+        self.assertFalse(Path(captured["prompt_path"]).exists())
+
     def test_fresh_codex_session_is_persistent(self) -> None:
         with mock.patch.dict("os.environ", {}, clear=True):
             command = main_adapter.fresh_session_command(

--- a/long_horizon/tests/test_session.py
+++ b/long_horizon/tests/test_session.py
@@ -31,8 +31,11 @@ class SessionRecoveryTests(unittest.TestCase):
             handoff = workspace / "handoff.json"
             commands: list[list[str]] = []
 
-            def execute(command, cwd, timeout, environment):
+            inputs: list[str | None] = []
+
+            def execute(command, cwd, timeout, environment, input_text):
                 commands.append(command)
+                inputs.append(input_text)
                 if len(commands) == 2:
                     atomic_write_json(handoff, {"status": "pivot"})
                 return "", "", 0, False
@@ -56,15 +59,21 @@ class SessionRecoveryTests(unittest.TestCase):
             self.assertEqual(result.handoff.status, "pivot")
             self.assertEqual(commands[0][2], commands[1][2])
             self.assertEqual(commands[1][1], "--resume")
+            self.assertEqual(inputs[0], "work")
+            self.assertIn("Continue the same long-horizon", inputs[1])
+            self.assertNotIn("work", commands[0])
 
     def test_nonzero_exit_does_not_resume(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             workspace = Path(temp)
             with mock.patch("long_horizon.main_adapter.session_environment", return_value={}), mock.patch(
-                "long_horizon.main_adapter.fresh_session_command", return_value=["claude"]
+                "long_horizon.main_adapter.fresh_session_command",
+                side_effect=lambda prompt, sid, effort: ["claude", prompt],
             ):
                 result = LongSessionRunner(
-                    executor=lambda command, cwd, timeout, environment: ("", "boom", 2, False)
+                    executor=lambda command, cwd, timeout, environment, input_text: (
+                        "", "boom", 2, False
+                    )
                 ).run(
                     workspace,
                     "work",
@@ -82,7 +91,7 @@ class SessionRecoveryTests(unittest.TestCase):
             handoff = workspace / "handoff.json"
             commands: list[list[str]] = []
 
-            def execute(command, cwd, timeout, environment):
+            def execute(command, cwd, timeout, environment, input_text):
                 commands.append(command)
                 if len(commands) == 1:
                     return self._claude_terminated_event(), "", 1, False
@@ -117,7 +126,7 @@ class SessionRecoveryTests(unittest.TestCase):
             handoff = workspace / "handoff.json"
             commands: list[list[str]] = []
 
-            def execute(command, cwd, timeout, environment):
+            def execute(command, cwd, timeout, environment, input_text):
                 commands.append(command)
                 if len(commands) == 1:
                     return "", "", 128 + signal.SIGTERM, False
@@ -156,10 +165,11 @@ class SessionRecoveryTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             workspace = Path(temp)
             with mock.patch("long_horizon.main_adapter.session_environment", return_value={}), mock.patch(
-                "long_horizon.main_adapter.fresh_session_command", return_value=["claude"]
+                "long_horizon.main_adapter.fresh_session_command",
+                side_effect=lambda prompt, sid, effort: ["claude", prompt],
             ):
                 result = LongSessionRunner(
-                    executor=lambda command, cwd, timeout, environment: (
+                    executor=lambda command, cwd, timeout, environment, input_text: (
                         "API Error: terminated",
                         "",
                         1,
@@ -182,10 +192,11 @@ class SessionRecoveryTests(unittest.TestCase):
             workspace = Path(temp)
             stderr = "[orchestrator] dependency policy violation; terminated coding session"
             with mock.patch("long_horizon.main_adapter.session_environment", return_value={}), mock.patch(
-                "long_horizon.main_adapter.fresh_session_command", return_value=["claude"]
+                "long_horizon.main_adapter.fresh_session_command",
+                side_effect=lambda prompt, sid, effort: ["claude", prompt],
             ):
                 result = LongSessionRunner(
-                    executor=lambda command, cwd, timeout, environment: (
+                    executor=lambda command, cwd, timeout, environment, input_text: (
                         self._claude_terminated_event(),
                         stderr,
                         1,
@@ -210,7 +221,7 @@ class SessionRecoveryTests(unittest.TestCase):
             commands: list[list[str]] = []
             thread_id = "019c1234-5678-7abc-8def-0123456789ab"
 
-            def execute(command, cwd, timeout, environment):
+            def execute(command, cwd, timeout, environment, input_text):
                 commands.append(command)
                 if len(commands) == 1:
                     return json.dumps({"type": "thread.started", "thread_id": thread_id}), "", 0, False
@@ -241,7 +252,7 @@ class SessionRecoveryTests(unittest.TestCase):
             commands: list[list[str]] = []
             thread_id = "019c1234-5678-7abc-8def-0123456789ab"
 
-            def execute(command, cwd, timeout, environment):
+            def execute(command, cwd, timeout, environment, input_text):
                 commands.append(command)
                 if len(commands) == 1:
                     stdout = json.dumps({"type": "thread.started", "thread_id": thread_id})
@@ -272,7 +283,7 @@ class SessionRecoveryTests(unittest.TestCase):
             stderr = "[orchestrator] dependency policy violation; terminated coding session"
             with mock.patch("long_horizon.main_adapter.session_environment", return_value={}):
                 result = LongSessionRunner(
-                    executor=lambda command, cwd, timeout, environment: (
+                    executor=lambda command, cwd, timeout, environment, input_text: (
                         stdout,
                         stderr,
                         -signal.SIGTERM,

--- a/long_horizon/tests/test_verifier.py
+++ b/long_horizon/tests/test_verifier.py
@@ -15,6 +15,7 @@ from long_horizon.tests.helpers import init_repo, run_git
 from long_horizon.verifier import (
     ABBA_RESULT_PREFIX,
     GatewayABBAValidator,
+    WORKSPACE_SNAPSHOT_SOURCE,
     _payload_from_stdout,
     score_verification_payload,
     verification_schedule,
@@ -95,9 +96,8 @@ class RemoteDriverTests(unittest.TestCase):
             root = Path(temp)
             request_dir = root / "request"
             (request_dir / "snapshots/incumbent").mkdir(parents=True)
-            (request_dir / "snapshots/candidate").mkdir(parents=True)
             (request_dir / "snapshots/incumbent/0000.bin").write_text("10\n", encoding="utf-8")
-            (request_dir / "snapshots/candidate/0000.bin").write_text("8\n", encoding="utf-8")
+            (root / "value.txt").write_text("8\n", encoding="utf-8")
             harness = root / "fake_eval.py"
             harness.write_text(
                 "from pathlib import Path\n"
@@ -111,7 +111,7 @@ class RemoteDriverTests(unittest.TestCase):
                 "schedule": verification_schedule(2),
                 "manifests": {
                     "incumbent": {"value.txt": "snapshots/incumbent/0000.bin"},
-                    "candidate": {"value.txt": "snapshots/candidate/0000.bin"},
+                    "candidate": {"value.txt": WORKSPACE_SNAPSHOT_SOURCE},
                 },
                 "command": ["python3", "fake_eval.py"],
                 "run_timeout_seconds": 10,
@@ -134,6 +134,77 @@ class RemoteDriverTests(unittest.TestCase):
 
 
 class GatewayCommandTests(unittest.TestCase):
+    def test_abba_snapshots_only_manifest_declared_runtime_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            workspace = Path(temp) / "campaign"
+            base = init_repo(workspace)
+            (workspace / "solution.json").write_text(
+                '{"sources": ["kernel.py", {"path": "cuda_helper.cu"}]}\n',
+                encoding="utf-8",
+            )
+            (workspace / "cuda_helper.cu").write_text("// base\n", encoding="utf-8")
+            run_git(workspace, "add", "solution.json", "cuda_helper.cu")
+            run_git(workspace, "commit", "-m", "declare runtime sources")
+            base = git_head(workspace)
+
+            (workspace / "kernel.py").write_text("VALUE = 8\n", encoding="utf-8")
+            (workspace / "cuda_helper.cu").write_text("// candidate\n", encoding="utf-8")
+            (workspace / "incumbent_measure_kernel.py").write_text(
+                "# evidence only\n" + "x = 'measurement'\n" * 20_000,
+                encoding="utf-8",
+            )
+            run_git(
+                workspace,
+                "add",
+                "kernel.py",
+                "cuda_helper.cu",
+                "incumbent_measure_kernel.py",
+            )
+            run_git(workspace, "commit", "-m", "candidate with large evidence")
+            candidate = git_head(workspace)
+            payload = {
+                "schema_version": 1,
+                "error": None,
+                "runs": [row("incumbent", 0, 10.0), row("candidate", 0, 8.0)],
+            }
+
+            def fake_run(*args, **kwargs):
+                command = args[5]
+                stdout = ABBA_RESULT_PREFIX + json.dumps(payload) + "\n"
+                return __import__("subprocess").CompletedProcess(command, 0, stdout, "")
+
+            validator = GatewayABBAValidator(
+                hardware="REMOTE_GPU", timeout=300, repeats=1, per_run_timeout=100
+            )
+            with mock.patch("long_horizon.main_adapter.run_sandbox", side_effect=fake_run):
+                result = validator.verify(
+                    workspace,
+                    base_commit=base,
+                    candidate_commit=candidate,
+                    changed_paths=[
+                        "incumbent_measure_kernel.py",
+                        "kernel.py",
+                        "cuda_helper.cu",
+                    ],
+                )
+
+            self.assertTrue(result.passed)
+            request_path = next(
+                workspace.glob("aggregate_kernels/.atrex_long_horizon_verify/*/request.json")
+            )
+            request = json.loads(request_path.read_text(encoding="utf-8"))
+            for manifest in request["manifests"].values():
+                self.assertEqual(set(manifest), {"kernel.py", "cuda_helper.cu"})
+                self.assertNotIn("incumbent_measure_kernel.py", manifest)
+            self.assertEqual(
+                set(request["manifests"]["candidate"].values()),
+                {WORKSPACE_SNAPSHOT_SOURCE},
+            )
+            candidate_snapshots = list(
+                request_path.parent.glob("snapshots/candidate/*.bin")
+            )
+            self.assertEqual(candidate_snapshots, [])
+
     def test_abba_driver_uses_existing_evaluator_payload_route(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             workspace = Path(temp) / "campaign"
@@ -194,6 +265,17 @@ class GatewayCommandTests(unittest.TestCase):
             self.assertEqual(json.loads(artifact.read_text(encoding="utf-8")), payload)
             self.assertEqual(artifact.name, "result.json")
             self.assertFalse(result.artifact.startswith("remote:"))
+            request_paths = list(
+                workspace.glob(
+                    "aggregate_kernels/.atrex_long_horizon_verify/*/request.json"
+                )
+            )
+            self.assertEqual(len(request_paths), 1)
+            request = json.loads(request_paths[0].read_text(encoding="utf-8"))
+            self.assertEqual(request["run_timeout_seconds"], 100)
+            command = request["command"]
+            timeout_index = command.index("--candidate-timeout-s")
+            self.assertEqual(command[timeout_index + 1], "100")
             self.assertEqual(run_git(workspace, "status", "--porcelain"), "")
 
     def test_current_sandbox_dry_run_packages_abba_driver_as_evaluator_input(self) -> None:

--- a/long_horizon/verifier.py
+++ b/long_horizon/verifier.py
@@ -16,6 +16,7 @@ from .store import VERIFY_DIR
 
 
 ABBA_RESULT_PREFIX = "__ATREX_LONG_HORIZON_ABBA_RESULT__="
+WORKSPACE_SNAPSHOT_SOURCE = "__ATREX_ABBA_WORKSPACE_SOURCE__"
 
 
 def _payload_from_stdout(stdout: str) -> dict[str, Any]:
@@ -128,6 +129,74 @@ def _git_blob(workspace: Path, revision: str, relative: str) -> bytes | None:
     return result.stdout if result.returncode == 0 else None
 
 
+def _safe_candidate_path(value: str) -> str:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or path.is_absolute()
+        or ".." in path.parts
+        or path.as_posix() in {"", "."}
+    ):
+        raise ValueError(f"unsafe candidate source path: {value!r}")
+    return path.as_posix()
+
+
+def _declared_sources(
+    workspace: Path,
+    revision: str,
+) -> set[str]:
+    """Return runtime sources authorized by a revision's solution manifest."""
+    raw = _git_blob(workspace, revision, "solution.json")
+    if raw is None:
+        return set()
+    try:
+        solution = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid solution.json at {revision}: {exc}") from exc
+    if not isinstance(solution, dict):
+        raise ValueError(f"solution.json at {revision} must contain a JSON object")
+    sources = solution.get("sources", [])
+    if not isinstance(sources, list):
+        raise ValueError(f"solution.json sources at {revision} must be a list")
+
+    declared: set[str] = set()
+    for source in sources:
+        if isinstance(source, str):
+            value = source
+        elif isinstance(source, dict) and isinstance(source.get("path"), str):
+            value = source["path"]
+        else:
+            raise ValueError(
+                f"solution.json source entries at {revision} must be paths or path objects"
+            )
+        relative = _safe_candidate_path(value)
+        if _git_blob(workspace, revision, relative) is None:
+            raise ValueError(
+                f"solution.json at {revision} declares missing source: {relative}"
+            )
+        declared.add(relative)
+    return declared
+
+
+def _authoritative_changed_paths(
+    workspace: Path,
+    base_commit: str,
+    candidate_commit: str,
+    changed_paths: list[str],
+) -> list[str]:
+    """Limit ABBA revision switching to candidate runtime inputs.
+
+    Optimizer episodes may commit plans, measurement helpers, and other evidence.
+    Those files are useful for the next episode but are not executable candidate
+    inputs and can be much larger than the gateway's payload allowance.
+    """
+    allowed = {"kernel.py", "solution.json"}
+    allowed.update(_declared_sources(workspace, base_commit))
+    allowed.update(_declared_sources(workspace, candidate_commit))
+    normalized = [_safe_candidate_path(relative) for relative in changed_paths]
+    return sorted(relative for relative in normalized if relative in allowed)
+
+
 def _snapshot_revision(
     workspace: Path,
     revision: str,
@@ -150,6 +219,22 @@ def _snapshot_revision(
         target.write_bytes(content)
         manifest[relative] = snapshot_relative
     return manifest
+
+
+def _workspace_revision_manifest(
+    workspace: Path,
+    revision: str,
+    changed_paths: list[str],
+) -> dict[str, str | None]:
+    """Describe the uploaded workspace revision without duplicating its bytes."""
+    return {
+        relative: (
+            WORKSPACE_SNAPSHOT_SOURCE
+            if _git_blob(workspace, revision, relative) is not None
+            else None
+        )
+        for relative in changed_paths
+    }
 
 
 class GatewayABBAValidator:
@@ -190,6 +275,23 @@ class GatewayABBAValidator:
             )
         verification_id = uuid.uuid4().hex
         relative_dir = f"{VERIFY_DIR}/{verification_id}"
+        try:
+            authoritative_paths = _authoritative_changed_paths(
+                workspace,
+                base_commit,
+                candidate_commit,
+                changed_paths,
+            )
+        except ValueError as exc:
+            return VerificationResult(
+                "ERROR", None, None, None,
+                error=f"invalid authoritative ABBA inputs: {exc}",
+            )
+        if "kernel.py" not in authoritative_paths:
+            return VerificationResult(
+                "ERROR", None, None, None,
+                error="authoritative ABBA revision does not change kernel.py",
+            )
         directory = workspace / relative_dir
         directory.mkdir(parents=True, exist_ok=False)
         # Naming the driver test_kernel.py deliberately selects the existing sandbox's
@@ -199,19 +301,34 @@ class GatewayABBAValidator:
         shutil.copy2(Path(__file__).with_name("remote_abba.py"), driver)
         manifests = {
             "incumbent": _snapshot_revision(
-                workspace, base_commit, changed_paths, directory, "incumbent"
+                workspace, base_commit, authoritative_paths, directory, "incumbent"
             ),
-            "candidate": _snapshot_revision(
-                workspace, candidate_commit, changed_paths, directory, "candidate"
+            # The sandbox workspace is already candidate_commit. The remote driver
+            # captures these files before applying the incumbent, avoiding a second
+            # uploaded copy of a potentially large kernel.
+            "candidate": _workspace_revision_manifest(
+                workspace, candidate_commit, authoritative_paths
             ),
         }
         request_relative = f"{relative_dir}/request.json"
         result_relative = f"{relative_dir}/result.json"
+        # The outer subprocess timeout alone does not relax the evaluator's own
+        # candidate/import watchdog.  Apply the same budget explicitly so a cold
+        # incumbent (for example, a load_inline CUDA kernel) remains verifiable.
+        evaluator_command = [
+            "python3",
+            "test_kernel.py",
+            "--version",
+            "vlong",
+            "--no-memory",
+            "--candidate-timeout-s",
+            str(self.per_run_timeout),
+        ]
         request = {
             "schema_version": 1,
             "schedule": schedule,
             "manifests": manifests,
-            "command": ["python3", "test_kernel.py", "--version", "vlong", "--no-memory"],
+            "command": evaluator_command,
             "run_timeout_seconds": self.per_run_timeout,
         }
         atomic_write_json(workspace / request_relative, request)


### PR DESCRIPTION
## Summary

- move large Claude/Codex prompts off argv to prevent `E2BIG` during long-running campaigns
- propagate the configured per-run timeout into authoritative ABBA candidate evaluation so cold CUDA incumbents remain verifiable
- bound ABBA revision payloads to authoritative runtime sources and reuse the uploaded candidate workspace snapshot
- normalize equivalent status spellings only inside long-horizon integration
- keep the ordinary main orchestrator behavior unchanged

## Motivation

These failures were observed in production-mode long-horizon campaigns: accumulated prompt history exceeded the OS argv limit, evaluator-internal timeouts rejected cold `load_inline` incumbents despite a larger outer timeout, and evidence/profile artifacts pushed ABBA payloads beyond the gateway limit. A lowercase passing status also caused a valid aggregate baseline to be treated as non-passing.

## Scope

All production changes are confined to `long_horizon/`. The PR branch was rebuilt directly from `upstream/main`, and its `long_horizon/` tree was verified byte-for-byte against the version currently running the Chunk Gated Delta Rule campaign.

## Tests

```text
python -m unittest discover -s long_horizon/tests -p "test_*.py" -v

Ran 51 tests
OK
```