### PR TITLE
fix: preserve Codex usage on interrupted streams

### DIFF
--- a/long_horizon/main_adapter.py
+++ b/long_horizon/main_adapter.py
@@ -8,7 +8,7 @@ from orchestrator.agent_runtime.adapter import DEFAULT_BACKEND_REGISTRY
 from orchestrator.agent_runtime.codex_ledger import (
     CodexSessionLedgerObserver,
     codex_thread_id_from_stream,
-    normalized_codex_ledger,
+    observe_codex_usage,
 )
 from orchestrator.agent_runtime.model import (
     AgentRuntimeCapabilities,
@@ -184,9 +184,15 @@ def normalize_stream(
     )
     if agent_cli == "codex" and codex_observer is not None and session_id:
         try:
-            events, terminal_usage, capabilities = normalized_codex_ledger(
+            (
+                events,
+                terminal_usage,
+                capabilities,
+                ledger_errors,
+            ) = observe_codex_usage(
                 codex_observer, session_id, terminal_usage
             )
+            observation_errors += ledger_errors
         except Exception as exc:
             observation_errors += (
                 f"codex_ledger_unavailable:{type(exc).__name__}",

--- a/long_horizon/session.py
+++ b/long_horizon/session.py
@@ -252,12 +252,19 @@ class LongSessionRunner:
             )
             if ledger_failed:
                 codex_ledger_usable = False
-            resume_usage_qualified = bool(
+            ledger_usage_observed = bool(
                 is_codex
                 and capabilities.usage_delta_observed
                 and not ledger_failed
             )
-            if is_codex and not resume_usage_qualified:
+            resume_usage_qualified = bool(
+                ledger_usage_observed
+                and not any(
+                    value.startswith("codex_")
+                    for value in observation_errors
+                )
+            )
+            if is_codex and not ledger_usage_observed:
                 fallback_usage = _codex_invocation_usage(
                     stream_session_usage or TokenUsage.unavailable(),
                     codex_stdout_session_usage,

--- a/orchestrator/agent_runtime/codex_ledger.py
+++ b/orchestrator/agent_runtime/codex_ledger.py
@@ -6,7 +6,7 @@ import re
 import tempfile
 import time
 from collections.abc import Iterator, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -96,7 +96,7 @@ CODEX_LEDGER_CAPABILITIES = AgentRuntimeCapabilities(
 )
 
 
-def normalized_codex_ledger(
+def observe_codex_usage(
     observer: "CodexSessionLedgerObserver",
     thread_id: str,
     stream_terminal: TokenUsage,
@@ -104,12 +104,34 @@ def normalized_codex_ledger(
     tuple[NormalizedAgentEvent, ...],
     TokenUsage,
     AgentRuntimeCapabilities,
+    tuple[str, ...],
 ]:
-    observation = observer.observe_reconciled(thread_id, stream_terminal)
+    if stream_terminal.total_tokens is not None:
+        observation = observer.observe_reconciled(thread_id, stream_terminal)
+        return (
+            observation.events,
+            observation.terminal_usage,
+            CODEX_LEDGER_CAPABILITIES,
+            (),
+        )
+    observation = observer.observe(thread_id)
+    terminal = replace(observation.terminal_usage, measurement="partial")
+    events = tuple(
+        replace(
+            event,
+            usage=(
+                replace(event.usage, measurement="partial")
+                if event.usage is not None
+                else None
+            ),
+        )
+        for event in observation.events
+    )
     return (
-        observation.events,
-        observation.terminal_usage,
+        events,
+        terminal,
         CODEX_LEDGER_CAPABILITIES,
+        ("codex_stdout_terminal_unavailable",),
     )
 
 

--- a/orchestrator/agent_runtime/runtime.py
+++ b/orchestrator/agent_runtime/runtime.py
@@ -25,7 +25,7 @@ from .codex_ledger import (
     CodexTemporaryHome,
     codex_home,
     codex_thread_id_from_stream,
-    normalized_codex_ledger,
+    observe_codex_usage,
 )
 from .model import (
     AgentRunRequest,
@@ -235,9 +235,15 @@ class CliAgentRuntime:
                         request.workspace
                     )
                 session_id = observed_session_id
-                events, terminal_usage, capabilities = normalized_codex_ledger(
+                (
+                    events,
+                    terminal_usage,
+                    capabilities,
+                    ledger_errors,
+                ) = observe_codex_usage(
                     codex_observer, observed_session_id, terminal_usage
                 )
+                observation_errors += ledger_errors
             except Exception as exc:
                 observation_errors += (
                     f"codex_ledger_unavailable:{type(exc).__name__}",

--- a/orchestrator/prompts/episode.md
+++ b/orchestrator/prompts/episode.md
@@ -80,9 +80,9 @@ Telemetry is best-effort and must not block engineering work. Mark phase boundar
 commands and keep at most one phase active:
 
 ```bash
-python tools/iteration_trace.py phase-start <profile|research|planning|implementation|correctness|benchmark|recording>
-python tools/iteration_trace.py phase-end <profile|research|planning|implementation|correctness|benchmark|recording>
-python tools/iteration_trace.py source-read <gpu_wiki|reference_projects|workspace|public_web> <safe-relative-reference>
+python3 tools/iteration_trace.py phase-start <profile|research|planning|implementation|correctness|benchmark|recording>
+python3 tools/iteration_trace.py phase-end <profile|research|planning|implementation|correctness|benchmark|recording>
+python3 tools/iteration_trace.py source-read <gpu_wiki|reference_projects|workspace|public_web> <safe-relative-reference>
 ```
 
 Never put credentials, private URL parameters, absolute user paths, raw tool output, or transcript


### PR DESCRIPTION
## Summary

- retain authoritative Codex rollout deltas as `partial` when the service disconnects before emitting stdout `turn.completed`
- keep usage-delta and marker events available for phase attribution while recording `codex_stdout_terminal_unavailable`
- use `python3` for telemetry marker commands so the unified episode shell does not depend on a `python` alias
- preserve exact double reconciliation whenever stdout terminal usage is available

## Failure semantics

A missing stdout terminal no longer discards already-recorded rollout usage. Ledger totals remain component-validated and cumulative; their measurement is downgraded to `partial`, and control/telemetry continue without pretending the secondary stdout check succeeded.

## Main-branch consolidation

The branch is rebased onto the long-horizon consolidation in #49. The deleted ordinary iteration prompt and legacy test suite were not resurrected. The marker-command change was migrated to the new canonical `orchestrator/prompts/episode.md`; Codex accounting remains in the retained unified Long Horizon runtime.

## Validation

Before #49 consolidation, the same code path passed 61 long-horizon tests and 133 Runtime/Telemetry/orchestrator/Codex-ledger tests (1 skipped). After rebasing onto #49, the reduced tree passes:

- `py_compile` for all retained orchestrator, agent-runtime, and long-horizon Python modules
- `orchestrator/optimize.py --help` import/CLI smoke
- a focused partial-ledger fallback probe verifying 10 ledger tokens become `partial`, usage deltas remain observed, and `codex_stdout_terminal_unavailable` is recorded
- `git diff --check`

A fresh ordinary 29-workload GEMM optimization passed every workload with zero error and reconciled 714,956 terminal tokens, 95.48% semantic coverage, 100% accounted coverage, and zero unattributed tokens. A fresh long-horizon optimization produced and committed a 29/29-passing candidate before the Codex service disconnected during final shutdown; ledger fallback retained and reconciled 1,407,029 partial tokens with zero unattributed tokens.