### PR TITLE
feat(gpu-wiki): enhance retrieval and trace mining

### DIFF
--- a/gpu-wiki/AGENTS.md
+++ b/gpu-wiki/AGENTS.md
@@ -4,10 +4,11 @@ Read `README.md` first. This wiki is **two independent JSON record stores**, and
 which one to ask depends on whether a benchmark could prove the answer wrong.
 
 **Default door — describe your situation, do not compose a query.**
-`python3 gpu-wiki/tools/query_nl.py "<prose>"` spawns `query_bridge_agent` for one
-store-blind intent extraction. Deterministic code then normalizes, queries, safely
-widens, and returns verbatim payloads keyed by stable record id. The bridge cannot
-invoke either query tool or carry a record.
+`python3 gpu-wiki/tools/query_nl.py "<prose>"` parses AKA's standard request
+format deterministically; other prose gets one store-blind intent extraction by
+`query_bridge_agent`. Deterministic code then resolves operator aliases and
+components, queries isolated lanes, safely widens, and returns payloads keyed by
+stable record id. The bridge cannot invoke either query tool or carry a record.
 
 Every call independently attempts both `gpu_wiki` and `internal_gpu_wiki`. A missing
 directory, the tracked `SOURCE.txt` placeholder alone, an incomplete interface, or a

--- a/gpu-wiki/README.md
+++ b/gpu-wiki/README.md
@@ -49,7 +49,7 @@ The Skills Workshop in the diagram represents three distinct responsibilities:
 
 | Skill | Input | Output |
 |---|---|---|
-| [`opt-trace-mining`](skills/opt-trace-mining/) | Git history of successive kernel versions | Candidate optimization experience |
+| [`opt-trace-mining`](skills/opt-trace-mining/) | Legacy version ladders or long-horizon Git/journal traces | Candidate optimization experience with commit-resolved provenance |
 | [`session-trace-mining`](skills/session-trace-mining/) | AI coding-agent session transcripts | Candidate agent-discovered knowledge |
 | [`wiki-gate`](skills/wiki-gate/) | One candidate record | Insert, confirm, conflict, or reject decision |
 
@@ -126,15 +126,17 @@ cannot query either Wiki store, read records, rank results, or write files.
 After the bridge returns plain JSON, deterministic code owns the rest:
 
 1. strictly validate the intent;
-2. normalize product, architecture, DSL, operator, and symptom vocabulary;
-3. construct isolated kernel and hardware lookups;
+2. normalize product, architecture, DSL, operator aliases, components, and symptoms;
+3. construct isolated operator/component lanes plus hardware lookups;
 4. widen safely without dropping the architecture boundary;
 5. execute the store-specific query tools;
 6. deduplicate, project, budget, and return the records.
 
-The Claude success path uses one tool-free bridge call. Invalid bridge JSON gets
-at most one fresh repair attempt. `claude` is the default agent CLI; `codex` and
-`qodercli` are also supported.
+AKA's standard optimizer request format is parsed deterministically and launches
+no bridge model. Other prose uses one low-effort, tool-free JSON call, with at
+most one fresh repair attempt after strict local validation. `claude` is the
+default agent CLI and `qodercli` is also supported; a CLI without a verified
+no-tools protocol is rejected.
 
 The consuming agent receives only two top-level fields:
 

--- a/gpu-wiki/skills/opt-trace-mining/SKILL.md
+++ b/gpu-wiki/skills/opt-trace-mining/SKILL.md
@@ -20,15 +20,17 @@ checked against the trace.
 
 What makes this corpus different from the sibling's: **the trace is a git
 repository, so every claim can be re-resolved.** Provenance is the trace label
-plus the commit, the code is a real diff, and the kept/reverted verdict is in the
-commit subject rather than in prose. There is no markdown page anywhere in this
+plus the commit, and the code is a real diff. The canonical version event is the
+commit that first adds `memory/v<N>.json`; this supports both legacy `v<N>:`
+commits and long-horizon promotion commits. A later metadata-only commit cannot
+replace that code-bearing event. There is no markdown page anywhere in this
 repository, so a record cites the trace and the commit and nothing else — records
 are the only source of truth here.
 
 ## What one trace looks like
 
 ```
-<trace>/.git                     commit subjects: `v<N>: ...`, and the verdict
+<trace>/.git                     canonical version events and code history
 <trace>/kernel.py                the kernel at that commit
 <trace>/memory/v<N>.json         per-version measurements       (optional)
 <trace>/profiles/v<N>*/          profiler captures              (optional)
@@ -42,7 +44,8 @@ Only `.git` is required, and each missing piece removes exactly one capability:
 no `memory/` means no numbers, hence no `strategy` records; no `profiles/` means
 no record may ever claim a profiler-backed bottleneck. The three sources
 disagree, so each is read only for what it is authoritative about — commits for
-the verdict, step records for the measurements, captures for the bottleneck.
+the code/version event, step records for measurements and terminal outcome,
+captures for the bottleneck.
 
 ## Setup
 
@@ -52,7 +55,8 @@ Nothing to configure for a trace that states its own hardware:
 export RTM_TRACE=/path/to/your/trace/kernel_opt_001_your_operator
 ```
 
-- **scratch** — `/tmp/opt-trace-mining/<slug>/`: parsed jsonl, packets. All
+- **scratch** — the platform temporary directory under
+  `opt-trace-mining/<slug>/`: parsed jsonl, packets. All
   reproducible from the trace, so none of it is committed. Override with
   `RTM_WORKSPACE`.
 - **staging** — `kernel_wiki/staging/`: records plus `reports/<slug>/`. Reviewed,
@@ -89,10 +93,11 @@ export RTM_TRACE=/path/to/trace
 python3 $S/make_schema.py --check     # the profile matches its patch list
 python3 $S/ingest.py                  # trace  -> work/versions.jsonl, profiles.jsonl, meta.json
 python3 $S/recon.py                   #        -> reports/<slug>/recon.md   READ THIS FIRST
+python3 $S/long_horizon_recon.py      #        -> reports/<slug>/long-horizon.md when present
 python3 $S/partition.py               #        -> work/segments.jsonl, reports/<slug>/partition.md
 python3 $S/build_packets.py           #        -> packets/<seg>.{json,diff,py}
 # distil (see below), then:
-python3 $S/validate_store.py --verbose        # 9 store gates + 7 trace gates
+python3 $S/validate_store.py --verbose        # 9 store gates + 8 trace gates
 python3 $S/validate_store.py --injection-tests
 python3 $S/score_records.py           # worth.rank + records/index.json
 python3 $S/make_readme.py             #        -> <staging>/README.md
@@ -110,10 +115,11 @@ Re-run the last three after every distillation batch.
 | `make_schema.py` | `assets/schema/opt-trace-1.0.schema.json`, this corpus's narrowing of `clean-1.3`, from a declared patch list | invent a dialect: every patch only narrows, so passing the profile implies passing the store's schema |
 | `ingest.py` | one row per version: verdict, geomean, per-shape latency, correctness, DSL per commit, which captures are usable | guess hardware, or believe the version's self-reported commit hash |
 | `recon.py` | the evidence-density report: citable-number share, usable-capture share, what the live store already holds for this operator | decide anything; it exists so a human decides whether the trace is worth distilling |
+| `long_horizon_recon.py` | structured attempts, candidate lineages, and exact journal/commit attribution when long-horizon evidence exists | split one episode-level gain across experiments that lack their own measurement |
 | `partition.py` | one segment per record-to-be, with ids allocated above the store's existing maxima | judge whether a dead-end is a fact — it flags, the agent decides, the gate enforces |
 | `build_packets.py` | a scrubbed, self-contained packet per segment, plus the diff as a sibling file | let a raw identifier reach the layer the agent reads |
 | *(the agent)* | one record per packet | write code, invent numbers, or fill a field the packet does not support |
-| `validate_store.py` | 16 gates and their injection tests | pass a record it cannot check against the trace |
+| `validate_store.py` | 17 gates and their injection tests | pass a record it cannot check against the trace |
 | `score_records.py` | `worth.rank` and the staging `index.json`, using the store's own `wiki_score` | let an agent score its own record |
 | `make_readme.py` | the reviewer's summary of the staging store | claim the records are in the store |
 
@@ -133,28 +139,47 @@ claim onto every record.
 | curated pitfall | `anti-strategy` | mostly hangs off *kept* versions: the run shipped the change and separately wrote down what had not worked. The reverted path cannot see this knowledge |
 | final kernel, mega snapshots | `reference-kernel` | the whole implementation, for reading rather than for a delta |
 
+The terminal reference is the newest code-bearing, non-reverted version with a
+positive complete measurement and explicit `PASS` correctness and quality-gate
+results. A newer unmeasured, failed, or reverted commit cannot displace it.
+
 A trace cannot produce a `technique-card` (a cross-corpus aggregate) or a `doc`
 (no measurement), and cannot produce a `generic`-level record: one kernel's
 measurement is not evidence for every architecture. The profile enforces all
 three.
 
+### Long-horizon deep pass
+
+When `.atrex_long_horizon/` or `memory/long_horizon_e*.json` exists, run
+`long_horizon_recon.py` after `recon.py` and read both reports before distilling.
+The deep pass may produce one granular strategy only when a structured attempt
+binds its own retained code commit, measurement, and correctness result. It may
+produce a granular anti-strategy only when a rejected or null experiment clears
+the established-fact bar. Research, planning, diagnostics without a conclusion,
+and policy-rejected candidates must not be presented as successful strategies.
+
+Granular records carry `evidence.raw.evidence_extra` with the journal path,
+experiment ids, and a resolvable canonical or revalidation commit. Local or
+archived A/B measurements remain provisional unless supervisor verification
+explicitly marks the candidate measurement authoritative. Legacy free-form
+journals require semantic review; never assign an episode-level gain to every
+probe or commit.
+
 ### Why only a ratchet
 
-A trace's latency series is not a progress curve — improvements and regressions
-come in roughly equal numbers, and the large excursions are usually the
-measurement environment, which the run itself often says so in prose. So a
-per-step delta is meaningless and `ladder.py` selects only versions that set a new
-best-so-far, with two guards: a jump beyond `REBASELINE_FACTOR` in either
-direction is the harness re-baselining, and a version whose own text says it
-changed nothing may take the new floor but may not claim it. `python3 ladder.py`
-runs the self-test that pins this on a synthetic non-monotonic series.
+A legacy trace's latency series is not a progress curve, so `ladder.py` selects
+only versions that set a new best-so-far. A long-horizon record may instead carry
+an authoritative candidate improvement from same-allocation supervisor
+verification; that explicit value takes precedence over cross-episode geomeans.
+A metadata-only version may update the observed floor but cannot own a strategy.
+`python3 ladder.py` pins the ratchet on a synthetic non-monotonic series.
 
-## The sixteen gates
+## The seventeen gates
 
 `validate_store.py` runs this repository's own `tools/check_kernel_wiki.py`
 against the staging root, so all nine of its gates apply —
 `schema` · `ids` · `anonymization` · `raw-isolation` · `relations` · `index` ·
-`self-contained` · `no-cross-reference` · `established-fact` — and then seven that
+`self-contained` · `no-cross-reference` · `established-fact` — and then eight that
 only this pipeline can run, because only it has the trace and the packets:
 
 - **profile** — the record satisfies `opt-trace-1.0`, which additionally requires
@@ -181,6 +206,12 @@ only this pipeline can run, because only it has the trace and the packets:
   `wiki-gate --commit insert` refuses a duplicate and renumbering after a batch is
   the expensive part. An `episode_key` that already exists is reported, not
   failed: whether it is a rediscovery to `confirm` is the agent's judgement.
+- **journal-provenance** — a granular long-horizon record must cite an existing
+  journal or archived evidence file, every declared experiment id must occur in
+  it, and its canonical promotion or revalidation commit must resolve. Evidence
+  paths must be relative to the trace root; absolute paths, traversal, symlink
+  escapes, files above 8 MiB, and aggregate evidence above 32 MiB are rejected
+  before content is read.
 
 **Never weaken a gate to make records pass, and never let a distilling agent edit
 `scripts/`.** When a gate looks wrong, prove it fires:
@@ -253,10 +284,10 @@ Everything is trace-agnostic except three places:
   layout means adapting `read_commits` / `read_memory` / `read_profiles`;
   everything downstream sees version rows and never a raw file.
 
-Two things to check on a new archive before trusting the output: whether the
-commit-subject grammar carries the verdict at all (if not, nothing can supply the
-kept/reverted split), and what fraction of profiler captures measured the kernel
-under test — `recon.py` prints both.
+Two things to check on a new archive before trusting the output: whether every
+canonical `memory/v<N>.json` addition can be paired with the intended kernel
+state (legacy subject-only traces use `v<N>:` as fallback), and what fraction of
+profiler captures measured the kernel under test — `recon.py` prints both.
 
 ## Resources
 
@@ -268,4 +299,5 @@ under test — `recon.py` prints both.
   admission bar for negative knowledge; `partition.py` imports the same regexes
   the store's gate uses, so triage and enforcement cannot disagree.
 - Self-tests worth running after any edit: `python3 families.py`,
-  `python3 ladder.py`, `python3 anonymize.py`.
+  `python3 ladder.py`, `python3 anonymize.py`, plus the repository's existing
+  query and Wiki validation suites.

--- a/gpu-wiki/skills/opt-trace-mining/assets/schema/opt-trace-1.0.schema.json
+++ b/gpu-wiki/skills/opt-trace-mining/assets/schema/opt-trace-1.0.schema.json
@@ -1710,7 +1710,7 @@
  "x-profile-of": {
   "base": "clean-1.3",
   "base_file": "schema/kernel/schema.json",
-  "base_sha256": "bcd12224eb00f56d72a31b1503e07f382e0f4d3868f1c40a509edbc3eb057786",
+  "base_sha256": "0d2bc66301a8ffd7b9dc1061cbad6f49c3e64bc6653f0995c940b910a481d972",
   "n_patches": 7,
   "generated_by": "skills/opt-trace-mining/scripts/make_schema.py"
  }

--- a/gpu-wiki/skills/opt-trace-mining/references/distill-brief.md
+++ b/gpu-wiki/skills/opt-trace-mining/references/distill-brief.md
@@ -29,8 +29,8 @@ directory. Read the code from there.
 ## Hard rules — all mechanically checked; a record that breaks one is waste
 
 1. **No dangling reference.** Never write a version id (`v83`), a person, an
-   absolute path (`/root/...`, `/home/...`), an e-mail, a path into a trace
-   (`profiles/v83`, `memory/v83.json`), an 8-hex hash, or **any `*.md` path**.
+   absolute root/home path, an e-mail, a path into a trace (`profiles/v83`,
+   `memory/v83.json`), a short or full Git hash, or **any `*.md` path**.
    There is no markdown page in this store, so a page citation is a reference to
    a file that does not exist. Refer to an earlier version as "an earlier step",
    and to a benchmarked shape by the packet's `shape-N` label. **The text in

--- a/gpu-wiki/skills/opt-trace-mining/scripts/anonymize.py
+++ b/gpu-wiki/skills/opt-trace-mining/scripts/anonymize.py
@@ -79,7 +79,12 @@ VERSION_SUBS = (
 WIDTH_TOKEN_RE = re.compile(r"^[vV](?:2|4|8|16|32|64|100)$")
 WIDTH_CONTEXT_RE = re.compile(r"vec|\.f16|\.bf16|x2|float", re.I)
 
-HASH_RE = re.compile(r"\b(?=[0-9a-f]{8}\b)(?=[0-9a-f]*[a-f])[0-9a-f]{8}\b")
+# Git references appear as short or full object ids. Require either a seven
+# digit short hash or at least one a-f character so ordinary measurements are
+# not mistaken for hashes.
+HASH_RE = re.compile(
+    r"\b(?:\d{7}|(?=[0-9a-f]{7,40}\b)(?=[0-9a-f]*[a-f])[0-9a-f]{7,40})\b"
+)
 MULTI_WS_RE = re.compile(r"\s{2,}")
 
 DENYLIST_REPLACEMENT = "a private identifier"
@@ -253,6 +258,9 @@ def self_test():
         ("the v4 kernel was slower", "the an earlier step", "an earlier step"),
         ("vec4 loads with v4 float lanes", "an earlier step", "v4"),
         ("shape 3f2a91bc regressed", "3f2a91bc", "shape-1"),
+        ("candidate 5f078e26f6bd1bc1d807918d7f8103423bd2e03a passed",
+         "5f078e26f6bd1bc1d807918d7f8103423bd2e03a", "shape-2"),
+        ("committed kernel source only (5962444)", "5962444", "shape-3"),
         ("check memory/v12.json for the numbers", "memory/", "the step record"),
         ("git log --oneline shows the revert", "git log", "the history"),
     ]

--- a/gpu-wiki/skills/opt-trace-mining/scripts/build_packets.py
+++ b/gpu-wiki/skills/opt-trace-mining/scripts/build_packets.py
@@ -347,12 +347,12 @@ def main():
         if "diff" in files:
             (c.PACKETS / ("%s.diff" % seg["seg_id"])).write_text(files["diff"])
             packet["agent_facing"]["diff_file"] = "%s.diff" % seg["seg_id"]
-            packet["code_bytes"] = len(files["diff"])
+            packet["code_bytes"] = len(files["diff"].encode("utf-8"))
             n_diff += 1
         if "kernel" in files:
             (c.PACKETS / ("%s.py" % seg["seg_id"])).write_text(files["kernel"])
             packet["agent_facing"]["kernel_file"] = "%s.py" % seg["seg_id"]
-            packet["code_bytes"] = len(files["kernel"])
+            packet["code_bytes"] = len(files["kernel"].encode("utf-8"))
             n_kernel += 1
         packet.setdefault("code_bytes", 0)
         (c.PACKETS / ("%s.json" % seg["seg_id"])).write_text(

--- a/gpu-wiki/skills/opt-trace-mining/scripts/config.py
+++ b/gpu-wiki/skills/opt-trace-mining/scripts/config.py
@@ -38,6 +38,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 SKILL_DIR = Path(__file__).resolve().parent.parent
@@ -164,7 +165,8 @@ def trace_slug(trace: Path) -> str:
 SLUG = trace_slug(TRACE) if TRACE_SET else ""
 
 WORKSPACE = Path(os.environ.get("RTM_WORKSPACE")
-                 or Path("/tmp/opt-trace-mining") / (SLUG or "unset")).resolve()
+                 or Path(tempfile.gettempdir()) / "opt-trace-mining"
+                 / (SLUG or "unset")).resolve()
 WORK = WORKSPACE / "work"
 PACKETS = WORKSPACE / "packets"
 
@@ -231,9 +233,10 @@ def target_from_token(token):
     return None
 
 
-def git(*args, cwd=None, timeout=60):
+def git(*args, cwd=None, timeout=60, input_text=None):
     r = subprocess.run(["git", "-C", str(cwd or TRACE), *args],
-                       capture_output=True, text=True, timeout=timeout)
+                       input=input_text, capture_output=True, text=True,
+                       timeout=timeout)
     return r.stdout
 
 
@@ -263,6 +266,20 @@ def _load_tool(name):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def validate_target_table():
+    """Fail fast when trace target aliases drift from Wiki identities."""
+    identity = _load_tool("hardware_identity")
+    errors = identity.target_table_errors(TARGET_TABLE)
+    if errors:
+        raise SystemExit(
+            "config.TARGET_TABLE is inconsistent with hardware identities:\n- "
+            + "\n- ".join(errors)
+        )
+
+
+validate_target_table()
 
 
 def load_wiki_score():

--- a/gpu-wiki/skills/opt-trace-mining/scripts/ingest.py
+++ b/gpu-wiki/skills/opt-trace-mining/scripts/ingest.py
@@ -31,9 +31,12 @@ import families
 
 # ---------------------------------------------------------------- git subjects
 
-# Versions are the unit of work and every commit that belongs to one announces it
-# in the subject. A commit without this prefix is bookkeeping (`chore(007):`).
+# Legacy versions announce themselves in the subject. Current long-horizon
+# campaigns instead add ``memory/v<N>.json`` in the accepted promotion commit,
+# so the path addition is the canonical version event and the subject is only a
+# fallback for older traces.
 VER_PREFIX = re.compile(r"^(v\d+)\s*:", re.I)
+MEMORY_VERSION_PATH_RE = re.compile(r"^memory/(v\d+)\.json$", re.I)
 
 # The verdict. `reverted` is the standard word; `dead-end` appears in subjects
 # that predate it.
@@ -120,16 +123,18 @@ def _first_sentence(text):
 
 
 def read_commits():
-    """One commit per version, newest kept when a version was committed twice.
+    """Resolve one canonical Git commit per version.
 
-    A re-commit of the same version is an amend in spirit: the later subject is
-    the one whose verdict stuck.
+    The commit that first adds ``memory/vN.json`` wins. When no such event
+    exists, prefer a version-labelled commit that changed ``kernel.py`` over a
+    later metadata-only backfill. This preserves legacy subject-only traces.
     """
     sep = "\x1e"
     # The separator leads each record rather than trailing it, so splitting can
     # never strand a field of the final record.
     raw = c.git("log", "--reverse", "--format=%s%%H|%%P|%%aI|%%s%%n%%b" % sep)
-    commits, skipped = {}, []
+    paths_by_sha = read_changed_paths()
+    rows = []
     for blob in raw.split(sep):
         blob = blob.strip()
         if not blob:
@@ -139,21 +144,73 @@ def read_commits():
             sha, parents, date, subject = head.split("|", 3)
         except ValueError:
             continue
+        paths = paths_by_sha.get(sha, [])
+        added_versions = []
+        for status, path in paths:
+            mpath = MEMORY_VERSION_PATH_RE.fullmatch(path)
+            if mpath and status.startswith("A"):
+                added_versions.append(mpath.group(1).lower())
         m = VER_PREFIX.match(subject)
-        if not m:
-            skipped.append(subject[:90])
-            continue
-        ver = m.group(1).lower()
-        commits[ver] = {
-            "version": ver,
+        rows.append({
+            "subject_version": m.group(1).lower() if m else None,
+            "added_memory_versions": added_versions,
             "sha": sha,
             "parent": parents.split()[0] if parents.strip() else None,
             "date": date,
             "subject": subject,
             "body": body.strip(),
+            "kernel_changed": any(path == "kernel.py" for _status, path in paths),
             **parse_subject(subject + "\n" + body),
+        })
+
+    versions = {
+        ver for row in rows
+        for ver in ([row["subject_version"]] + row["added_memory_versions"])
+        if ver
+    }
+    commits, selected = {}, set()
+    for ver in sorted(versions, key=lambda value: int(re.sub(r"\D", "", value) or 0)):
+        additions = [row for row in rows if ver in row["added_memory_versions"]]
+        labelled = [row for row in rows if row["subject_version"] == ver]
+        if additions:
+            chosen = additions[0]
+            source = "memory-add"
+        else:
+            code_commits = [row for row in labelled if row["kernel_changed"]]
+            chosen = (code_commits or labelled)[-1]
+            source = "subject-kernel" if code_commits else "subject"
+        selected.add(chosen["sha"])
+        commits[ver] = {
+            "version": ver,
+            "commit_mapping": source,
+            **{key: value for key, value in chosen.items()
+               if key not in ("subject_version", "added_memory_versions")},
         }
+
+    skipped = [row["subject"][:90] for row in rows if row["sha"] not in selected]
     return commits, skipped
+
+
+def read_changed_paths():
+    """Return relevant changed paths for every commit using one Git process."""
+    sep = "\x1e"
+    raw = c.git(
+        "log", "--reverse", "--format=%s%%H" % sep, "--name-status",
+        "--", "kernel.py", "memory",
+    )
+    result = {}
+    for blob in raw.split(sep):
+        lines = blob.strip().splitlines()
+        if not lines:
+            continue
+        sha = lines[0].strip()
+        paths = []
+        for line in lines[1:]:
+            fields = line.split("\t")
+            if len(fields) >= 2 and re.fullmatch(r"[A-Z][0-9]*", fields[0]):
+                paths.append((fields[0], fields[-1]))
+        result[sha] = paths
+    return result
 
 
 # ------------------------------------------------------------------- memory/
@@ -208,6 +265,9 @@ def summarise_memory(data, filename):
             "performance_score",
             perf.get("speedup_vs_ref_mean", perf.get("speedup_vs_ref_geomean")),
         ),
+        "authoritative_improvement_pct": perf.get("authoritative_improvement_pct"),
+        "measurement_subject": perf.get("measurement_subject"),
+        "measurement_source": perf.get("measurement_source"),
         "correctness_status": corr.get("status"),
         "max_abs_err": corr.get("max_abs_err"),
         "max_rel_err": corr.get("max_rel_err"),
@@ -221,6 +281,7 @@ def summarise_memory(data, filename):
         "pitfalls": data.get("pitfalls_and_fixes") or [],
         "search_log": data.get("search_log") or [],
         "profile_evidence": data.get("profile_evidence") or {},
+        "long_horizon_status": (data.get("long_horizon") or {}).get("status"),
     }
 
 
@@ -371,6 +432,8 @@ def detect_dsl(text):
         return "gluon"
     if re.search(r"cutlass\.cute|import cutlass|cute\.jit|cutedsl", text, re.I):
         return "cutedsl"
+    if re.search(r"\bflydsl\b|@flyc\.kernel|from\s+flydsl", text, re.I):
+        return "flydsl"
     if re.search(r"load_inline|__global__|cpp_extension|hipcc", text):
         return "cuda"
     if "triton" in text:

--- a/gpu-wiki/skills/opt-trace-mining/scripts/ladder.py
+++ b/gpu-wiki/skills/opt-trace-mining/scripts/ladder.py
@@ -48,6 +48,13 @@ def declares_no_change(v):
     return bool(NO_CHANGE_RE.search(text_of(v)))
 
 
+def owns_kernel_change(v):
+    """Whether this version can own a code delta, with legacy compatibility."""
+    if "kernel_changed" in v:
+        return bool(v.get("kernel_changed"))
+    return not declares_no_change(v)
+
+
 def noise_reason(v, outcome_matters=True):
     """Why this version cannot be reasoned about, or None.
 
@@ -59,7 +66,20 @@ def noise_reason(v, outcome_matters=True):
     """
     if RERUN_RE.search(v["version"]):
         return "remeasurement"
-    if INFRA_RE.search(text_of(v)):
+    long_horizon_status = v.get("long_horizon_status")
+    if long_horizon_status in {"interrupted", "blocked", "invalid_handoff"}:
+        return "infrastructure"
+    authoritative = (
+        v.get("measurement_source") == "authoritative_verification"
+        and v.get("measurement_subject") == "candidate"
+        and v.get("gate_result") == "PASS"
+    )
+    passed = (
+        v.get("gate_result") == "PASS"
+        and v.get("correctness_status") == "PASS"
+    )
+    if (long_horizon_status is None and not authoritative and not passed
+            and INFRA_RE.search(text_of(v))):
         return "infrastructure"
     if not outcome_matters:
         return None
@@ -68,6 +88,20 @@ def noise_reason(v, outcome_matters=True):
         return "incorrect"
     if v.get("gate_result") == "FAIL":
         return "gate-fail"
+    return None
+
+
+def authoritative_gain(v):
+    """Same-allocation supervisor gain, when its origin is explicit."""
+    value = v.get("authoritative_improvement_pct")
+    if (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and v.get("measurement_source") == "authoritative_verification"
+        and v.get("measurement_subject") == "candidate"
+        and v.get("gate_result") == "PASS"
+    ):
+        return float(value)
     return None
 
 
@@ -115,9 +149,32 @@ def select(versions):
             rejected.append((v["version"], "no commit, code not reachable"))
             continue
 
+        authoritative = authoritative_gain(v)
+        if authoritative is not None:
+            if best is None or geo < best:
+                best = geo
+            if owns_kernel_change(v) and authoritative >= MILESTONE_PCT:
+                milestones.append(dict(
+                    v,
+                    kind="mega" if authoritative >= MEGA_PCT else "milestone",
+                    improve_pct=round(authoritative, 2),
+                ))
+            elif not owns_kernel_change(v):
+                rejected.append((v["version"], "commit does not change kernel.py"))
+            else:
+                rejected.append((
+                    v["version"],
+                    "under %.1f%% authoritative verification (%.2f%%)"
+                    % (MILESTONE_PCT, authoritative),
+                ))
+            continue
+
         if best is None:
-            milestones.append(dict(v, kind="baseline", improve_pct=None))
             best = geo
+            if owns_kernel_change(v):
+                milestones.append(dict(v, kind="baseline", improve_pct=None))
+            else:
+                rejected.append((v["version"], "commit does not change kernel.py"))
             continue
 
         if geo > best * REBASELINE_FACTOR:
@@ -133,7 +190,7 @@ def select(versions):
             continue
 
         improve = (best - geo) / best * 100.0
-        if improve >= MILESTONE_PCT and not declares_no_change(v):
+        if improve >= MILESTONE_PCT and owns_kernel_change(v):
             milestones.append(dict(
                 v, kind="mega" if improve >= MEGA_PCT else "milestone",
                 improve_pct=round(improve, 2)))
@@ -141,15 +198,26 @@ def select(versions):
         else:
             if improve > 0:
                 best = geo
-            rejected.append((v["version"], "under %.1f%% (%.2f%%)"
-                             % (MILESTONE_PCT, improve)))
+            if "kernel_changed" in v and not owns_kernel_change(v):
+                rejected.append((v["version"], "commit does not change kernel.py"))
+            else:
+                rejected.append((v["version"], "under %.1f%% (%.2f%%)"
+                                 % (MILESTONE_PCT, improve)))
 
     if milestones and best is not None:
         # Only a version that actually holds the floor may be called the end
         # state. The last version by number is often a measurement excursion, and
         # labelling that "final" would present it as the run's outcome.
-        candidates = [v for v in versions
-                      if v.get("geomean_us") and v["geomean_us"] <= best * 1.0001]
+        candidates = [
+            v for v in versions
+            if v.get("geomean_us")
+            and v["geomean_us"] <= best * 1.0001
+            and noise_reason(v) is None
+            and v.get("sha")
+            and owns_kernel_change(v)
+            and (authoritative_gain(v) is None
+                 or authoritative_gain(v) >= MILESTONE_PCT)
+        ]
         if candidates:
             last = max(candidates, key=lambda v: v["n"])
             if last["version"] not in {m["version"] for m in milestones}:

--- a/gpu-wiki/skills/opt-trace-mining/scripts/long_horizon_recon.py
+++ b/gpu-wiki/skills/opt-trace-mining/scripts/long_horizon_recon.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# Copyright 2026 Alibaba Group.
+# Licensed under the Apache License, Version 2.0.
+
+"""Inventory long-horizon experiments and their Git attribution.
+
+This report is deliberately descriptive. It exposes structured attempts,
+legacy experiments, candidate lineages, and exact commit mentions so the
+distiller can select useful records without assigning an episode's total gain
+to every probe.
+"""
+import json
+import re
+
+import config as c
+
+
+def load_json(path):
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+class CommitLineageIndex:
+    """Serve every episode range from two batched Git history walks."""
+
+    def __init__(self, ranges):
+        tokens = sorted({value for pair in ranges for value in pair if value})
+        self._resolved = self._resolve_commits(tokens)
+        heads = sorted({
+            self._resolved[value]
+            for pair in ranges for value in pair if value in self._resolved
+        })
+        self._parents = {}
+        self._kernel_rows = []
+        self._ancestor_cache = {}
+        if not heads:
+            return
+        raw = c.git("rev-list", "--parents", *heads)
+        for line in raw.splitlines():
+            fields = line.split()
+            if fields:
+                self._parents[fields[0]] = tuple(fields[1:])
+        raw = c.git(
+            "log", "--topo-order", "--reverse", "--format=%H%x09%s",
+            *heads, "--", "kernel.py",
+        )
+        for line in raw.splitlines():
+            sha, sep, subject = line.partition("\t")
+            if sep:
+                self._kernel_rows.append((sha, subject))
+
+    @staticmethod
+    def _resolve_commits(tokens):
+        """Resolve and type-check all journal commit tokens in one process."""
+        if not tokens:
+            return {}
+        expressions = ["%s^{commit}" % token for token in tokens]
+        raw = c.git(
+            "cat-file", "--batch-check=%(objectname) %(objecttype)",
+            input_text="\n".join(expressions) + "\n",
+        )
+        resolved = {}
+        for token, line in zip(tokens, raw.splitlines()):
+            sha, sep, kind = line.partition(" ")
+            if sep and kind == "commit":
+                resolved[token] = sha
+        return resolved
+
+    def _ancestors(self, sha):
+        cached = self._ancestor_cache.get(sha)
+        if cached is not None:
+            return cached
+        seen, pending = set(), [sha]
+        while pending:
+            current = pending.pop()
+            if current in seen:
+                continue
+            seen.add(current)
+            pending.extend(self._parents.get(current, ()))
+        self._ancestor_cache[sha] = seen
+        return seen
+
+    def rows(self, base, candidate):
+        base_sha = self._resolved.get(base)
+        candidate_sha = self._resolved.get(candidate)
+        if not base_sha or not candidate_sha:
+            return []
+        selected = self._ancestors(candidate_sha) - self._ancestors(base_sha)
+        return [row for row in self._kernel_rows if row[0] in selected]
+
+
+def experiment_id(experiment, index):
+    if not isinstance(experiment, dict):
+        return "experiment-%d" % index
+    return str(experiment.get("id") or experiment.get("name")
+               or "experiment-%d" % index)
+
+
+def mentioned_experiments(experiments, sha, subject):
+    token_match = re.match(r"^(v\d+(?:-[A-Za-z0-9]+)?)", subject, re.I)
+    token = token_match.group(1) if token_match else ""
+    exact, labelled = [], []
+    for index, experiment in enumerate(experiments, 1):
+        text = (json.dumps(experiment, ensure_ascii=False)
+                if isinstance(experiment, dict) else str(experiment))
+        if sha[:7].lower() in text.lower():
+            exact.append(experiment_id(experiment, index))
+        elif token and re.search(
+            r"(?<![A-Za-z0-9])%s(?![A-Za-z0-9])" % re.escape(token),
+            text, re.I,
+        ):
+            labelled.append(experiment_id(experiment, index))
+    return exact or labelled
+
+
+def episode_sources():
+    """Yield committed episodes, then runtime-only episodes not yet archived."""
+    seen = set()
+    for path in sorted((c.TRACE / "memory").glob("long_horizon_e*.json")):
+        value = load_json(path)
+        journal = value.get("journal") if isinstance(value.get("journal"), dict) else {}
+        key = (journal.get("episode"), journal.get("candidate_commit"))
+        seen.add(key)
+        yield path, value, journal, "committed"
+    runtime = c.TRACE / ".atrex_long_horizon" / "episodes"
+    for path in sorted(runtime.glob("e*/episode_runtime/journal.json")):
+        journal = load_json(path)
+        key = (journal.get("episode"), journal.get("candidate_commit"))
+        if key in seen:
+            continue
+        yield path, {}, journal, "runtime"
+
+
+def main():
+    c.require_trace()
+    c.ensure_dirs()
+    lines = ["# Long-horizon recon: %s" % c.TRACE.name, ""]
+    total_experiments = total_commits = structured_attempts = 0
+
+    # Scan lightweight addresses first, then render episode payloads. Git
+    # history is fetched once for the complete trace.
+    ranges = []
+    for _path, wrapper, journal, _durability in episode_sources():
+        ranges.append((
+            str(journal.get("base_commit") or wrapper.get("base_commit") or ""),
+            str(journal.get("candidate_commit")
+                or wrapper.get("candidate_commit") or ""),
+        ))
+    lineages = CommitLineageIndex(ranges)
+
+    for path, wrapper, journal, durability in episode_sources():
+        experiments = journal.get("experiments") or []
+        plan = journal.get("attempt_plan") or {}
+        attempts = plan.get("attempts") if isinstance(plan, dict) else []
+        attempts = attempts if isinstance(attempts, list) else []
+        structured_attempts += len(attempts)
+        total_experiments += len(experiments)
+        base = str(journal.get("base_commit") or wrapper.get("base_commit") or "")
+        candidate = str(journal.get("candidate_commit")
+                        or wrapper.get("candidate_commit") or "")
+        commits = lineages.rows(base, candidate)
+        total_commits += len(commits)
+        lines += [
+            "## episode %s (%s)" % (journal.get("episode", "?"), durability),
+            "",
+            "- state: `%s`" % (journal.get("state")
+                                or wrapper.get("status") or "unknown"),
+            "- experiments: %d" % len(experiments),
+            "- structured attempts: %d" % len(attempts),
+            "- code commits in candidate lineage: %d" % len(commits),
+            "- evidence: `%s`" % path.relative_to(c.TRACE),
+            "",
+        ]
+        if attempts:
+            lines += ["### Structured attempts", "",
+                      "| id | status | candidate | evidence summary |",
+                      "|---|---|---|---|"]
+            for attempt in attempts:
+                evidence = attempt.get("evidence") or {}
+                evidence_summary = (evidence.get("summary") or ""
+                                    if isinstance(evidence, dict) else evidence)
+                lines.append("| `%s` | %s | `%s` | %s |" % (
+                    attempt.get("id", "?"), attempt.get("status", "?"),
+                    str(attempt.get("candidate_commit") or "")[:12],
+                    str(evidence_summary).replace("|", "\\|")[:240],
+                ))
+            lines.append("")
+        if commits:
+            lines += ["### Candidate lineage", "",
+                      "| commit | subject | matching experiments |",
+                      "|---|---|---|"]
+            for sha, subject in commits:
+                matches = mentioned_experiments(experiments, sha, subject)
+                lines.append("| `%s` | %s | %s |" % (
+                    sha[:12], subject.replace("|", "\\|"),
+                    ", ".join("`%s`" % value for value in matches) or "none",
+                ))
+            lines.append("")
+    lines += [
+        "## Summary", "",
+        "- experiments: %d" % total_experiments,
+        "- structured attempts: %d" % structured_attempts,
+        "- code commits in candidate lineages: %d" % total_commits,
+        "",
+        "Only a structured accepted attempt with its own candidate commit and measurement may be",
+        "split automatically. Legacy free-form experiments require manual review; never assign an",
+        "episode-level gain to each commit.",
+    ]
+    out = c.REPORTS / "long-horizon.md"
+    out.write_text("\n".join(lines) + "\n")
+    print("wrote %s" % out)
+    print("  experiments=%d structured_attempts=%d lineage_commits=%d"
+          % (total_experiments, structured_attempts, total_commits))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gpu-wiki/skills/opt-trace-mining/scripts/partition.py
+++ b/gpu-wiki/skills/opt-trace-mining/scripts/partition.py
@@ -59,6 +59,22 @@ NON_MECHANISM_RE = _facts.NON_MECHANISM_RE
 FLAGGED_DEADENDS = []
 
 
+def accepted_reference(v):
+    """Whether a version is safe to publish as the terminal implementation."""
+    geomean = v.get("geomean_us")
+    return bool(
+        v.get("sha")
+        and ladder.owns_kernel_change(v)
+        and not v.get("reverted")
+        and isinstance(geomean, (int, float))
+        and not isinstance(geomean, bool)
+        and geomean > 0
+        and v.get("correctness_status") == "PASS"
+        and v.get("gate_result") == "PASS"
+        and ladder.noise_reason(v) is None
+    )
+
+
 def fact_candidate(text):
     """Can this dead-end become an established fact? -> (bool, reason)."""
     if not text or len(text) < MIN_DEADEND_CHARS:
@@ -373,11 +389,13 @@ def main():
                 disc=discs.take(MARKER_ANTI),
             ))
 
-    # Reference kernels: the shipped kernel, plus a snapshot for each mega step
-    # that has one. `versions/` normally holds snapshots for kept versions only.
+    # Reference kernels: the latest accepted code-bearing version, plus a
+    # snapshot for each mega step that has one. Select the final reference from
+    # all versions so metadata-only outcome commits cannot displace real code.
     snap_dir = c.TRACE / "versions"
     megas = [m for m in milestones if m["kind"] == "mega"]
-    final = max(milestones, key=lambda m: m["n"], default=None)
+    reference_versions = [v for v in versions if accepted_reference(v)]
+    final = max(reference_versions, key=lambda v: v["n"], default=None)
     if final:
         segments.append(dict(
             common(final),

--- a/gpu-wiki/skills/opt-trace-mining/scripts/validate_store.py
+++ b/gpu-wiki/skills/opt-trace-mining/scripts/validate_store.py
@@ -10,7 +10,7 @@ established-fact. Copying those checks here would let the copy drift out of step
 with the store they protect, and the drift would only surface as records that
 pass locally and are refused by `wiki-gate`.
 
-On top of that, seven gates only this pipeline can run, because only it has the
+On top of that, eight gates only this pipeline can run, because only it has the
 trace and the packets:
 
   profile          the record satisfies opt-trace-1.0, this corpus's narrowing of
@@ -24,6 +24,9 @@ trace and the packets:
   ncu-attribution  a profiler-backed bottleneck cites a capture that actually
                    measured the kernel under test
   store-overlap    the id is free in the live store, so wiki-gate can insert it
+  journal-provenance
+                   granular long-horizon records resolve their journal,
+                   experiment ids, and canonical or revalidation commit
 
 Never weaken a gate to make records pass. When a gate looks wrong, prove it fires:
 `--injection-tests` mutates a copy of a record and asserts that the named gate
@@ -39,6 +42,7 @@ import json
 import re
 import subprocess
 import sys
+from pathlib import Path
 
 import config as c
 import recon
@@ -59,6 +63,8 @@ AUDITED_PATHS = (
 )
 
 CODEISH_KEYS = {"snippet", "dispatch_snippet", "attempted_code"}
+MAX_JOURNAL_FILE_BYTES = 8 * 1024 * 1024
+MAX_JOURNAL_TOTAL_BYTES = 32 * 1024 * 1024
 
 
 def norm_ws(s):
@@ -360,6 +366,110 @@ def gate_store_overlap(ctx, fails):
     return note
 
 
+def gate_journal_provenance(ctx, fails):
+    """Resolve optional long-horizon provenance for granular records."""
+    checked = 0
+    commit_cache = {}
+    for filename, record in ctx["records"]:
+        raw = dig(record, ("evidence", "raw")) or {}
+        extra = raw.get("evidence_extra") or {}
+        journal_value = extra.get("journal_file")
+        additional = extra.get("additional_journal_files") or []
+        outcome_value = extra.get("outcome_file")
+        experiment_ids = extra.get("experiment_ids")
+        canonical = (extra.get("canonical_promotion_commit")
+                     or extra.get("canonical_commit")
+                     or extra.get("revalidation_commit"))
+        if not journal_value and not experiment_ids and not canonical:
+            continue
+        checked += 1
+        if not isinstance(journal_value, str) or not journal_value.strip():
+            fails.append("%s: journal-provenance: journal_file missing"
+                         % filename.name)
+            continue
+        source_values = [journal_value]
+        if isinstance(additional, list):
+            source_values.extend(value for value in additional
+                                 if isinstance(value, str))
+        if isinstance(outcome_value, str) and outcome_value:
+            source_values.append(outcome_value)
+        evidence_parts = []
+        evidence_bytes = 0
+        source_path = journal_value.split("#", 1)[0]
+        trace_root = c.TRACE.resolve()
+        for value in source_values:
+            source_path = value.split("#", 1)[0]
+            relative_path = Path(source_path)
+            if relative_path.is_absolute() or ".." in relative_path.parts:
+                fails.append(
+                    "%s: journal-provenance: evidence path must be trace-relative: %s"
+                    % (filename.name, source_path)
+                )
+                continue
+            journal_path = (trace_root / relative_path).resolve()
+            try:
+                journal_path.relative_to(trace_root)
+            except ValueError:
+                fails.append(
+                    "%s: journal-provenance: evidence path escapes trace root: %s"
+                    % (filename.name, source_path)
+                )
+                continue
+            if not journal_path.is_file():
+                fails.append(
+                    "%s: journal-provenance: evidence file does not exist: %s"
+                    % (filename.name, source_path)
+                )
+                continue
+            try:
+                size = journal_path.stat().st_size
+                if size > MAX_JOURNAL_FILE_BYTES:
+                    fails.append(
+                        "%s: journal-provenance: evidence file exceeds %d bytes: %s"
+                        % (filename.name, MAX_JOURNAL_FILE_BYTES, source_path)
+                    )
+                    continue
+                if evidence_bytes + size > MAX_JOURNAL_TOTAL_BYTES:
+                    fails.append(
+                        "%s: journal-provenance: evidence files exceed %d total bytes"
+                        % (filename.name, MAX_JOURNAL_TOTAL_BYTES)
+                    )
+                    continue
+                evidence_parts.append(journal_path.read_text(errors="replace"))
+                evidence_bytes += size
+            except OSError as exc:
+                fails.append(
+                    "%s: journal-provenance: cannot read evidence file: %s"
+                    % (filename.name, exc)
+                )
+        evidence_text = "\n".join(evidence_parts)
+        if not isinstance(experiment_ids, list) or not experiment_ids:
+            fails.append("%s: journal-provenance: experiment_ids missing"
+                         % filename.name)
+        else:
+            for experiment_id in experiment_ids:
+                if (not isinstance(experiment_id, str)
+                        or experiment_id not in evidence_text):
+                    fails.append(
+                        "%s: journal-provenance: experiment id %r is absent from %s"
+                        % (filename.name, experiment_id, source_path)
+                    )
+        if not canonical:
+            fails.append("%s: journal-provenance: canonical commit missing"
+                         % filename.name)
+            continue
+        if canonical not in commit_cache:
+            commit_cache[canonical] = (
+                c.git("cat-file", "-t", canonical).strip() == "commit"
+            )
+        if not commit_cache[canonical]:
+            fails.append(
+                "%s: journal-provenance: canonical commit %s does not resolve"
+                % (filename.name, str(canonical)[:12])
+            )
+    return "%d journal-backed records resolved" % checked
+
+
 GATES = (
     ("profile", gate_profile),
     ("layout", gate_layout),
@@ -368,6 +478,7 @@ GATES = (
     ("provenance", gate_provenance),
     ("ncu-attribution", gate_ncu_attribution),
     ("store-overlap", gate_store_overlap),
+    ("journal-provenance", gate_journal_provenance),
 )
 
 
@@ -476,6 +587,13 @@ def injection_tests(records, packets):
         rec["level"] = "generic"
         return True
 
+    def unknown_experiment(rec, pkt):
+        extra = dig(rec, ("evidence", "raw", "evidence_extra")) or {}
+        if not extra.get("journal_file"):
+            return False
+        extra["experiment_ids"] = ["__missing_experiment__"]
+        return True
+
     ctx0 = build_context(records, packets)
     cases = [
         ("profile/generic-level", "profile", break_profile, None),
@@ -489,6 +607,10 @@ def injection_tests(records, packets):
          unbacked_profiler, None),
         ("store-overlap/known-id", "store-overlap",
          lambda rec, pkt: collide(rec, pkt, ctx0["store_ids"]), None),
+        ("journal-provenance/missing-experiment", "journal-provenance",
+         unknown_experiment,
+         lambda r: bool(dig(r, ("evidence", "raw", "evidence_extra",
+                                "journal_file")))),
     ]
 
     rc = 0

--- a/gpu-wiki/skills/query_bridge_agent/SKILL.md
+++ b/gpu-wiki/skills/query_bridge_agent/SKILL.md
@@ -5,20 +5,20 @@ description: Quickly extract a typed GPU-Wiki query intent from prose. Never ins
 
 # query_bridge_agent
 
-You are a small, store-blind intent extractor. Finish immediately after writing
-`query_intent.json`. A deterministic caller validates your output, maps it onto
+You are a small, store-blind intent extractor. Return one plain JSON object and
+finish immediately. A deterministic caller validates your output, maps it onto
 the store vocabulary, plans widening, executes queries, and serves records.
 
 ## Absolute boundary
 
-Do not run commands or tools. In particular, never invoke `query_wiki.py`,
-`query_hardware.py`, grep/find a store, list vocabularies, inspect records, test a
-query, or write a reading guide. Do not return query flags. You neither see nor
-carry knowledge payloads.
+Do not run commands or tools. In particular, never invoke `query_wiki.py` or
+`query_hardware.py`, grep/find a store, list vocabularies, inspect records, test
+a query, or write a reading guide. Do not return query flags. You neither see
+nor carry knowledge payloads.
 
 ## Output
 
-Write exactly this shape to `query_intent.json`:
+Return exactly this shape on stdout, without Markdown or prose:
 
 ```json
 {
@@ -26,6 +26,7 @@ Write exactly this shape to `query_intent.json`:
   "vendor": "nvidia or null",
   "dsl": "triton or null",
   "operator_terms": ["rmsnorm", "row reduction"],
+  "component_terms": ["residual add"],
   "measured_symptoms": ["memory-bound"],
   "free_text_terms": ["fusion", "single pass"],
   "intents": ["technique", "pitfall"],
@@ -37,10 +38,19 @@ Write exactly this shape to `query_intent.json`:
 
 Rules:
 
-- Copy architecture, vendor, DSL and product spellings from the request. Do not
-  invent missing values.
-- Put operator/API/mechanism phrases in the caller's words. Store vocabulary is
-  deliberately not your concern.
+- Copy architecture, vendor, DSL and product spellings from the request. The
+  architecture slot is only for a GPU architecture or public GPU product, such
+  as `sm_100`, Blackwell, or B200; never put a model/operator acronym such as
+  GDN there. A target product is query scope, not a `hardware_requests` entry
+  unless the caller explicitly asks for hardware specifications. Do not invent
+  missing values.
+- Put the requested operator or fused/composite operation in `operator_terms`.
+  Put independently queryable sub-operations in `component_terms`, preserving
+  the caller's words. Decompose a clearly composite name such as QK norm + RoPE
+  + KV-cache write. Do not research or infer hidden model structure; the
+  deterministic resolver handles established cross-operator relationships.
+  Do not invent implementation-specific components when uncertain. Store
+  vocabulary is deliberately not your concern.
 - A measured symptom must be supported by an explicit profile or number. Put a
   suspected bottleneck in `free_text_terms`, not `measured_symptoms`.
 - `intents` may contain `technique`, `pitfall`, `documentation`, `diagnosis`, or

--- a/gpu-wiki/tools/agent_launch.py
+++ b/gpu-wiki/tools/agent_launch.py
@@ -1,97 +1,108 @@
 #!/usr/bin/env python3
 # Copyright 2026 Alibaba Group.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under the Apache License, Version 2.0.
 
-"""Run one agent CLI headlessly, once, and wait for it.
+"""Launch the store-blind natural-language intent bridge safely.
 
-This store's tools are standard-library only so that the wiki can ship and be
-queried on its own. The natural-language front door needs to spawn a small agent,
-which means it needs the headless invocation of each supported CLI -- so that
-knowledge lives here, in a form deliberately narrower than the orchestrator's:
-
-  * one prompt, one process, and no session resume. The Claude bridge uses a
-    tool-free plain-JSON response; legacy backends retain the file handoff;
-  * the flags below are a strict SUBSET of what
-    ``orchestrator/agent_runtime/adapter.py`` passes for the same CLI, and
-    ``tools/test_agent_launch_parity.py`` in the repo root asserts that. If the
-    orchestrator changes a flag name, that test fails rather than this launcher
-    silently drifting into an invocation nobody runs;
-  * a timeout kills the whole process group, not just the child. An agent CLI
-    spawns tool subprocesses, and killing only the parent leaves them holding the
-    terminal and the GPU.
-
-The prompt is always the LAST positional argument, which is what every supported
-CLI expects; it is never piped, because stdin is closed to keep a headless agent
-from blocking on a prompt nobody will answer.
+Only CLI protocols with an explicit no-tools mode are supported. Claude and
+Qoder return a JSON envelope on stdout without approval
+or sandbox bypasses. Codex is intentionally excluded: its read-only sandbox
+still exposes the shell and readable files to prompt injection.
 """
+
 from __future__ import annotations
 
 import os
 import signal
 import subprocess
-import sys
 import uuid
 from pathlib import Path
 
-# Headless one-shot invocation per CLI. Subset of the orchestrator's adapters.
-# {session} is substituted with a fresh id; CLIs that ignore sessions omit it.
-HEADLESS_FLAGS: dict[str, list[str]] = {
-    "qodercli": ["--print", "--dangerously-skip-permissions",
-                 "--no-session-persistence", "--session-id", "{session}"],
-    "claude": ["--print", "--dangerously-skip-permissions",
-               "--session-id", "{session}"],
-    "codex": ["exec", "--color", "never",
-              "--dangerously-bypass-approvals-and-sandbox"],
-}
 
-SUPPORTED = tuple(sorted(HEADLESS_FLAGS))
+SUPPORTED = ("claude", "qodercli")
 DEFAULT_CLI = "claude"
 DEFAULT_TIMEOUT = 600
+EMPTY_MCP_CONFIG = '{"mcpServers":{}}'
 CLAUDE_SETTINGS_ENV = "ATREX_CLAUDE_SESSION_SETTINGS"
+
+# Do not inherit arbitrary campaign credentials into the parser process. The
+# CLI may read its own auth state under HOME; explicit provider auth and common
+# TLS/proxy variables are the only environment credentials forwarded.
+COMMON_ENVIRONMENT = (
+    "PATH", "HOME", "TMPDIR", "LANG", "LC_ALL", "USER", "LOGNAME", "SHELL",
+    "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+    "http_proxy", "https_proxy", "all_proxy", "no_proxy",
+    "SSL_CERT_FILE", "SSL_CERT_DIR", "NODE_EXTRA_CA_CERTS",
+)
+AUTH_ENVIRONMENT = {
+    "claude": ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN",
+               "CLAUDE_CODE_OAUTH_TOKEN"),
+    "qodercli": ("QODER_API_KEY", "QODER_AUTH_TOKEN", "QODER_ACCESS_TOKEN"),
+}
 
 
 class LaunchError(RuntimeError):
-    """The CLI could not be started at all -- distinct from it failing a task."""
+    """The bridge CLI could not be started."""
+
+
+def build_claude_json_command(prompt: str, session_id: str | None = None) -> list[str]:
+    """Build a non-interactive bridge with no tools or permission bypass."""
+    session = session_id or str(uuid.uuid4())
+    return [
+        "claude", "--bare", "--print", "--output-format", "json",
+        "--no-session-persistence", "--session-id", session, "--effort", "low",
+        "--tools", "", "--prompt-suggestions", "false", prompt,
+    ]
+
+
+def build_qoder_json_command(prompt: str, session_id: str | None = None) -> list[str]:
+    """Build Qoder's non-interactive, no-tools, empty-MCP JSON protocol."""
+    session = session_id or str(uuid.uuid4())
+    return [
+        "qodercli", "--print", "--output-format", "json",
+        "--no-session-persistence", "--session-id", session,
+        "--reasoning-effort", "low", "--permission-mode", "default",
+        "--tools", "", "--strict-mcp-config", "--mcp-config", EMPTY_MCP_CONFIG,
+        "--setting-sources", "", "--max-output-tokens", "2048", "--", prompt,
+    ]
+
+
+def build_json_command(cli: str, prompt: str,
+                       session_id: str | None = None) -> list[str]:
+    if cli == "claude":
+        return build_claude_json_command(prompt, session_id)
+    if cli == "qodercli":
+        return build_qoder_json_command(prompt, session_id)
+    if cli == "codex":
+        raise LaunchError(
+            "unsupported bridge cli 'codex': read-only still permits shell/file reads; "
+            "a verified no-tools protocol is required")
+    raise LaunchError("unsupported bridge cli %r (supported: %s)" %
+                      (cli, ", ".join(SUPPORTED)))
 
 
 def build_command(cli: str, prompt: str, session_id: str | None = None,
                   settings: str | None = None) -> list[str]:
-    if cli not in HEADLESS_FLAGS:
-        raise LaunchError("unsupported agent cli %r (supported: %s)"
-                          % (cli, ", ".join(SUPPORTED)))
-    session = session_id or str(uuid.uuid4())
-    flags = [f.replace("{session}", session) for f in HEADLESS_FLAGS[cli]]
-    command = [cli] + flags
+    """Compatibility launcher; query_nl uses the stricter run_json boundary."""
+    if cli == "codex":
+        return ["codex", "exec", "--color", "never", prompt]
+    command = build_json_command(cli, prompt, session_id)
     if cli == "claude" and settings:
-        command += ["--settings", settings]
-    return command + [prompt]
+        command[-1:-1] = ["--settings", settings]
+    return command
 
 
-def build_claude_json_command(
-    prompt: str,
-    session_id: str | None = None,
-) -> list[str]:
-    """Build the minimal, tool-free plain-JSON Claude bridge invocation."""
-    session = session_id or str(uuid.uuid4())
-    return [
-        "claude",
-        "--bare",
-        "--print",
-        "--dangerously-skip-permissions",
-        "--output-format", "json",
-        "--no-session-persistence",
-        "--session-id", session,
-        "--effort", "low",
-        "--tools", "",
-        "--prompt-suggestions", "false",
-        prompt,
-    ]
+def bridge_environment(cli: str, source: dict[str, str] | None = None) -> dict[str, str]:
+    """Return the minimal environment needed by one authenticated bridge CLI."""
+    inherited = os.environ if source is None else source
+    allowed = COMMON_ENVIRONMENT + AUTH_ENVIRONMENT.get(cli, ())
+    environment = {name: inherited[name] for name in allowed if inherited.get(name)}
+    environment["NO_COLOR"] = "1"
+    environment["CI"] = "1"
+    return environment
 
 
 def _kill_group(proc: subprocess.Popen) -> None:
-    """Kill the child's whole process group; an agent CLI has children."""
     try:
         os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
     except (ProcessLookupError, PermissionError):
@@ -100,21 +111,17 @@ def _kill_group(proc: subprocess.Popen) -> None:
 
 def _run_command(command: list[str], cwd: Path, timeout: int,
                  env: dict[str, str] | None) -> tuple[str, str, int, bool]:
-    environment = dict(os.environ if env is None else env)
-    # A nested agent must not inherit a parent's plan-mode or session state.
-    for leaked in ("CLAUDE_SESSION_ID", "QODER_SESSION_ID", "CODEX_SESSION_ID",
-                   "CLAUDECODE"):
-        environment.pop(leaked, None)
+    cli = Path(command[0]).name if command else ""
+    environment = bridge_environment(cli, env)
     try:
         proc = subprocess.Popen(
-            command, cwd=str(cwd), env=environment,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            text=True, errors="replace",
-            start_new_session=True,          # own process group, so we can kill it all
+            command, cwd=str(cwd), env=environment, stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            errors="replace", start_new_session=True,
         )
     except FileNotFoundError as exc:
-        raise LaunchError("agent cli not on PATH: %s (%s)" % (cli, exc)) from exc
+        missing = command[0] if command else "<empty-command>"
+        raise LaunchError(f"bridge cli not on PATH: {missing} ({exc})") from exc
 
     timed_out = False
     try:
@@ -124,57 +131,30 @@ def _run_command(command: list[str], cwd: Path, timeout: int,
         _kill_group(proc)
         try:
             stdout, stderr = proc.communicate(timeout=30)
-        except subprocess.TimeoutExpired:            # unreachable in practice
+        except subprocess.TimeoutExpired:
             stdout, stderr = "", "killed after timeout; no output collected"
     return stdout or "", stderr or "", proc.returncode, timed_out
 
 
-def run(cli: str, prompt: str, cwd: Path,
-        timeout: int = DEFAULT_TIMEOUT,
-        env: dict[str, str] | None = None) -> tuple[str, str, int, bool]:
-    """Run the CLI once in ``cwd``. Returns (stdout, stderr, returncode, timed_out)."""
-    environment = dict(os.environ if env is None else env)
-    settings = environment.get(CLAUDE_SETTINGS_ENV) if cli == "claude" else None
-    return _run_command(
-        build_command(cli, prompt, settings=settings), cwd, timeout, environment
-    )
-
-
-def run_claude_json(prompt: str, cwd: Path,
-                    timeout: int = DEFAULT_TIMEOUT,
+def run_claude_json(prompt: str, cwd: Path, timeout: int = DEFAULT_TIMEOUT,
                     env: dict[str, str] | None = None
                     ) -> tuple[str, str, int, bool]:
-    """Run the minimal Claude bridge with plain JSON stdout and no tools."""
-    return _run_command(
-        build_claude_json_command(prompt), cwd, timeout, env
-    )
+    return _run_command(build_claude_json_command(prompt), cwd, timeout, env)
 
 
-def main(argv=None) -> int:
-    """Smoke entry point: run a prompt and echo what came back."""
-    import argparse
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("prompt")
-    ap.add_argument("--agent-cli", choices=SUPPORTED, default=DEFAULT_CLI)
-    ap.add_argument("--cwd", default=".")
-    ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
-    ap.add_argument("--print-command", action="store_true",
-                    help="Show the argv that would run, and exit.")
-    args = ap.parse_args(argv)
-    if args.print_command:
-        settings = os.environ.get(CLAUDE_SETTINGS_ENV) if args.agent_cli == "claude" else None
-        print(" ".join(build_command(args.agent_cli, args.prompt, settings=settings)))
-        return 0
-    out, err, code, timed_out = run(args.agent_cli, args.prompt,
-                                    Path(args.cwd).resolve(), args.timeout)
-    sys.stderr.write(err)
-    sys.stdout.write(out)
-    if timed_out:
-        print("TIMEOUT after %ds" % args.timeout, file=sys.stderr)
-        return 124
-    return code or 0
+def run(cli: str, prompt: str, cwd: Path, timeout: int = DEFAULT_TIMEOUT,
+        env: dict[str, str] | None = None) -> tuple[str, str, int, bool]:
+    """Compatibility entry point without restoring permission-bypass flags."""
+    settings = (env or os.environ).get(CLAUDE_SETTINGS_ENV) if cli == "claude" else None
+    return _run_command(build_command(cli, prompt, settings=settings), cwd, timeout, env)
+
+
+def run_json(cli: str, prompt: str, cwd: Path, timeout: int = DEFAULT_TIMEOUT,
+             env: dict[str, str] | None = None) -> tuple[str, str, int, bool]:
+    if cli == "claude":
+        return run_claude_json(prompt, cwd, timeout, env)
+    return run(cli, prompt, cwd, timeout, env)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit("agent_launch.py is an internal library; use tools/query_nl.py")

--- a/gpu-wiki/tools/hardware_identity.py
+++ b/gpu-wiki/tools/hardware_identity.py
@@ -68,6 +68,27 @@ _PREFIXES = ("advancedmicrodevices", "nvidia", "amd", "geforce", "instinct")
 _SUFFIXES = ("accelerator", "gpu")
 
 
+def extract_product_names(text: str) -> list[str]:
+    """Return explicit public GPU product identities in textual order.
+
+    Product spellings may vary in case and may insert spaces, underscores, or
+    hyphens at letter/number boundaries (for example ``B-200`` or
+    ``MI_300_X``). This performs identity normalization only; it never maps an
+    internal resource alias to a public product name.
+    """
+    matches = []
+    for product in HARDWARE_IDENTITIES:
+        chunks = re.findall(r"[a-z]+|[0-9]+", product.casefold())
+        pattern = r"(?<![a-z0-9])" + r"[\s_-]*".join(
+            re.escape(chunk) for chunk in chunks
+        ) + r"(?![a-z0-9])"
+        found = re.search(pattern, text, flags=re.IGNORECASE)
+        if found:
+            matches.append((found.start(), product))
+    matches.sort()
+    return [product for _, product in matches]
+
+
 def normalize_product_name(value: str) -> str:
     """Normalize formatting without translating one hardware identity to another."""
     token = _compact(value)
@@ -85,3 +106,42 @@ def normalize_product_name(value: str) -> str:
                 changed = True
                 break
     return _CANONICAL.get(token, token)
+
+
+def target_table_errors(target_table: dict) -> list[str]:
+    """Validate a trace-target map against canonical public identities.
+
+    The mining skill may intentionally map a product alias such as ``rtx5090``
+    to the architecture-level recorded address ``sm120``. Both the input
+    identity and output address must nevertheless agree on vendor and
+    architecture, preventing the two code-owned tables from drifting silently.
+    """
+    errors = []
+    for token, triple in sorted(target_table.items()):
+        if not isinstance(triple, (tuple, list)) or len(triple) != 3:
+            errors.append("%s: expected (vendor, arch, product)" % token)
+            continue
+        vendor, arch, product = map(str, triple)
+        source = normalize_product_name(str(token))
+        target = normalize_product_name(product)
+        source_row = HARDWARE_IDENTITIES.get(source)
+        target_row = HARDWARE_IDENTITIES.get(target)
+        if source_row is None:
+            errors.append("%s: unknown public input identity" % token)
+            continue
+        if target_row is None:
+            errors.append("%s: unknown output product %s" % (token, product))
+            continue
+        expected = (vendor, arch)
+        if (source_row["vendor"], source_row["arch"]) != expected:
+            errors.append(
+                "%s: input identity is %s/%s, table says %s/%s"
+                % (token, source_row["vendor"], source_row["arch"], vendor, arch)
+            )
+        if (target_row["vendor"], target_row["arch"]) != expected:
+            errors.append(
+                "%s: output identity %s is %s/%s, table says %s/%s"
+                % (token, target, target_row["vendor"], target_row["arch"],
+                   vendor, arch)
+            )
+    return errors

--- a/gpu-wiki/tools/operator_scope.py
+++ b/gpu-wiki/tools/operator_scope.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+# Copyright 2026 Alibaba Group.
+# Licensed under the Apache License, Version 2.0.
+
+"""Resolve runtime operator names and compositions onto Store query scopes.
+
+Names and compositions are different problems.  A name such as
+``fused_moe_fp8`` can be normalized mechanically onto the Store's ``moe``
+token.  A composite path such as GDN needs several independent query lanes so
+that parent and component knowledge remain isolated instead of one replacing
+the other.
+
+The resolver therefore has three deterministic name stages (direct, adjacent
+joins, corpus vote) and a small relation registry for decomposition facts that
+cannot be recovered from spelling alone.  Ambiguous votes stay unresolved.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import warnings
+from collections import Counter
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import query_wiki as query
+
+
+MAX_JOIN_LENGTH = 4
+MIN_TOKEN_LENGTH = 3
+VOTE_MARGIN = 1.5
+PHRASE_WEIGHT = 2.5
+MAX_CORPUS_DOCUMENTS = 10_000
+MAX_CORPUS_TEXT_BYTES = 64 * 1024 * 1024
+
+_NOISE = frozenset({
+    "fused", "fusion", "kernel", "kernels", "op", "ops", "operator",
+    "fwd", "bwd", "forward", "backward", "fp8", "fp16", "fp32",
+    "bf16", "fp4", "nvfp4", "mxfp4", "int8", "int4", "e4m3",
+    "e5m2", "v1", "v2", "v3", "dynamic", "static", "batched",
+    "quantized",
+})
+
+Axis = Literal["operator", "family"]
+Role = Literal["primary", "component", "related"]
+Confidence = Literal["declared", "direct", "voted"]
+
+
+@dataclass(frozen=True)
+class OperatorScope:
+    """One independent Store query lane."""
+
+    role: Role
+    axis: Axis
+    value: str
+    confidence: Confidence
+    source_term: str
+
+
+@dataclass(frozen=True)
+class RelationGroup:
+    """A directed parent-to-component relation spelling cannot prove."""
+
+    parent_aliases: tuple[str, ...]
+    scopes: tuple[tuple[Axis, str], ...]
+
+
+# A composite GDN path can expose recurrent/state-space and convolution work as
+# separate optimization units. These are query relations, not a claim that
+# every component is nested inside one kernel implementation.
+RELATION_GROUPS = (
+    RelationGroup(
+        parent_aliases=(
+            "gdn", "gated delta net", "gated delta rule",
+        ),
+        scopes=(
+            ("operator", "gdn"),
+            ("family", "gdn"),
+            ("family", "mamba"),
+            ("family", "conv"),
+        ),
+    ),
+)
+
+# Component/API spellings resolve only to their own Store lane. They are kept
+# separate from RELATION_GROUPS so a standalone component cannot activate its
+# parent or sibling operators.
+DECLARED_SCOPE_ALIASES: dict[str, tuple[Axis, str]] = {
+    "causal conv1d": ("family", "conv"),
+    "causal_conv1d": ("family", "conv"),
+    "causal conv1d update": ("family", "conv"),
+    "causal_conv1d_update": ("family", "conv"),
+}
+
+
+def fold(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.strip().lower())
+
+
+def _tokens(name: str) -> tuple[str, ...]:
+    # Preserve the Runtime's spelling while also handling common CamelCase API
+    # names.  Acronym boundaries intentionally remain one token.
+    separated = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name)
+    return tuple(
+        part for part in re.split(r"[^A-Za-z0-9]+", separated.lower()) if part
+    )
+
+
+def _candidates(tokens: Iterable[str]) -> list[str]:
+    parts = list(tokens)
+    out: list[str] = []
+    for size in range(min(MAX_JOIN_LENGTH, len(parts)), 0, -1):
+        for start in range(len(parts) - size + 1):
+            out.append("-".join(parts[start:start + size]))
+    return out
+
+
+def _is_noise_sequence(value: str) -> bool:
+    """Return whether a compact affix is composed only of known decorations."""
+    if not value:
+        return True
+    decorations = sorted(
+        {fold(token) for token in _NOISE if token}, key=len, reverse=True
+    )
+    reachable = {0}
+    for start in range(len(value) + 1):
+        if start not in reachable:
+            continue
+        for decoration in decorations:
+            if value.startswith(decoration, start):
+                reachable.add(start + len(decoration))
+    return len(value) in reachable
+
+
+class OperatorScopeResolver:
+    """Map caller terms to the Store without collapsing composite operators."""
+
+    def __init__(
+        self,
+        *,
+        operators: Iterable[str],
+        families: Iterable[str],
+        document_loader: Callable[[], Iterable[tuple[str, str]]],
+    ) -> None:
+        self._operators = {fold(value): value for value in operators if value}
+        self._families = {fold(value): value for value in families if value}
+        self._document_loader = document_loader
+        self._documents: list[tuple[str, str, frozenset[str]]] | None = None
+        self._document_text_bytes = 0
+        self._family_size: Counter[str] = Counter()
+        self._document_frequency: Counter[str] = Counter()
+        self._relations = {
+            fold(alias): group
+            for group in RELATION_GROUPS
+            for alias in group.parent_aliases
+        }
+        self._scope_aliases = {
+            fold(alias): scope for alias, scope in DECLARED_SCOPE_ALIASES.items()
+        }
+        active_relation_groups = (
+            group for group in RELATION_GROUPS
+            if any(fold(alias) in self._operators or fold(alias) in self._families
+                   for alias in group.parent_aliases)
+            or any(self._known(axis, value) for axis, value in group.scopes)
+        )
+        self._invalid_relation_scopes = tuple(sorted({
+            (axis, value)
+            for group in active_relation_groups
+            for axis, value in group.scopes
+            if not self._known(axis, value)
+        }))
+        if self._invalid_relation_scopes:
+            warnings.warn(
+                "operator relation registry references unknown Store scopes: %s"
+                % ", ".join("%s:%s" % row
+                            for row in self._invalid_relation_scopes),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    @classmethod
+    def from_store(cls, root: Path) -> "OperatorScopeResolver":
+        vocabulary = query.vocab(query.load_index(root / "kernel_wiki")["records"])
+
+        def load_documents() -> Iterable[tuple[str, str]]:
+            index = query.load_index(root / "kernel_wiki")
+            for record in index.get("records") or []:
+                scope = ((record.get("retrieval") or {}).get("scope") or {})
+                family = scope.get("operator_family")
+                if not family:
+                    continue
+                # Public indexes already carry a deterministic ``search_text``
+                # projection. Reuse it directly and never load the served JSON
+                # payload shards merely to classify an operator spelling.
+                text = " ".join(filter(None, (
+                    str(record.get("id") or ""),
+                    str(record.get("title") or ""),
+                    str(record.get("search_text") or ""),
+                )))
+                yield str(family), text
+
+        return cls(
+            operators=vocabulary.get("operator") or (),
+            families=vocabulary.get("family") or (),
+            document_loader=load_documents,
+        )
+
+    def resolve_many(
+        self,
+        primary_terms: Iterable[str],
+        component_terms: Iterable[str],
+        *,
+        limit: int = 8,
+    ) -> tuple[list[OperatorScope], list[str]]:
+        scopes: list[OperatorScope] = []
+        unresolved: list[str] = []
+        seen: set[tuple[str, str]] = set()
+
+        def add(scope: OperatorScope) -> None:
+            key = (scope.axis, scope.value)
+            if key not in seen and len(scopes) < limit:
+                seen.add(key)
+                scopes.append(scope)
+
+        for role, terms in (("primary", primary_terms),
+                            ("component", component_terms)):
+            for raw in terms:
+                term = str(raw).strip()
+                if not term:
+                    continue
+                resolved = self.resolve(term, role=role)
+                if resolved is not None:
+                    add(resolved)
+                    # Some Store tokens intentionally exist on both axes.  The
+                    # current hardware/DSL cell may populate only one of them,
+                    # so keep both as isolated lanes instead of guessing.
+                    key = fold(resolved.value)
+                    if resolved.axis == "operator" and key in self._families:
+                        add(OperatorScope(
+                            role="related", axis="family",
+                            value=self._families[key], confidence="direct",
+                            source_term=term,
+                        ))
+                    elif resolved.axis == "family" and key in self._operators:
+                        add(OperatorScope(
+                            role="related", axis="operator",
+                            value=self._operators[key], confidence="direct",
+                            source_term=term,
+                        ))
+                relation = self._relations.get(fold(term))
+                if relation is not None:
+                    for axis, value in relation.scopes:
+                        if self._known(axis, value):
+                            add(OperatorScope(
+                                role="related", axis=axis, value=value,
+                                confidence="declared", source_term=term,
+                            ))
+                elif resolved is None:
+                    unresolved.append(term)
+        return scopes, unresolved
+
+    def resolve(self, term: str, *, role: Role = "primary") -> OperatorScope | None:
+        # Compare the complete compact spelling first. This handles long API
+        # names whose only differences are case, underscores, or hyphens
+        # without depending on the bounded adjacent-token search below.
+        whole = fold(term)
+        if whole in self._operators:
+            return OperatorScope(role, "operator", self._operators[whole],
+                                 "direct", term)
+        if whole in self._families:
+            return OperatorScope(role, "family", self._families[whole],
+                                 "direct", term)
+        declared = self._scope_aliases.get(whole)
+        if declared is not None and self._known(*declared):
+            return OperatorScope(role, declared[0], declared[1],
+                                 "declared", term)
+        tokens = _tokens(term)
+        if not tokens:
+            return None
+        for candidate in _candidates(tokens):
+            key = fold(candidate)
+            if key in self._operators:
+                return OperatorScope(role, "operator", self._operators[key],
+                                     "direct", term)
+            if key in self._families:
+                return OperatorScope(role, "family", self._families[key],
+                                     "direct", term)
+        embedded = self._resolve_decorated(whole, role, term)
+        if embedded is not None:
+            return embedded
+        family = self._vote(tokens)
+        if family is None:
+            return None
+        return OperatorScope(role, "family", family, "voted", term)
+
+    def _resolve_decorated(
+        self, whole: str, role: Role, source_term: str,
+    ) -> OperatorScope | None:
+        """Resolve a vocabulary token wrapped only in harmless API decorations.
+
+        CamelCase acronym runs such as ``FusedMoEFP8`` and
+        ``QuantizedGEMMKernel`` cannot be split reliably without knowing the
+        vocabulary. Match the vocabulary first, then require every character
+        outside it to be a reviewed decoration. Ambiguous longest matches fail
+        closed instead of guessing.
+        """
+        matches: list[tuple[int, str, Axis, str]] = []
+        for axis, table in (("operator", self._operators),
+                            ("family", self._families)):
+            for key, value in table.items():
+                if len(key) < MIN_TOKEN_LENGTH:
+                    continue
+                start = whole.find(key)
+                while start >= 0:
+                    end = start + len(key)
+                    if (_is_noise_sequence(whole[:start])
+                            and _is_noise_sequence(whole[end:])):
+                        matches.append((len(key), key, axis, value))
+                    start = whole.find(key, start + 1)
+        if not matches:
+            return None
+        longest = max(length for length, _key, _axis, _value in matches)
+        matches = [row for row in matches if row[0] == longest]
+        keys = {key for _length, key, _axis, _value in matches}
+        if len(keys) != 1:
+            return None
+        # The same token can be indexed as both an operator and a family. Keep
+        # operator as the primary address; resolve_many adds the family as an
+        # isolated related lane.
+        selected = next(
+            (row for row in matches if row[2] == "operator"), matches[0]
+        )
+        return OperatorScope(role, selected[2], selected[3], "direct", source_term)
+
+    def _known(self, axis: Axis, value: str) -> bool:
+        table = self._operators if axis == "operator" else self._families
+        return fold(value) in table
+
+    def _ensure_documents(self) -> None:
+        if self._documents is not None:
+            return
+        self._documents = []
+        for family, text in self._document_loader():
+            text_bytes = len(text.encode("utf-8"))
+            if (len(self._documents) >= MAX_CORPUS_DOCUMENTS
+                    or self._document_text_bytes + text_bytes
+                    > MAX_CORPUS_TEXT_BYTES):
+                raise ValueError(
+                    "operator corpus exceeds the in-process vote budget "
+                    "(%d documents or %d bytes); use a structured operator "
+                    "scope or raise the reviewed limit"
+                    % (MAX_CORPUS_DOCUMENTS, MAX_CORPUS_TEXT_BYTES)
+                )
+            words = frozenset(re.findall(r"[a-z0-9]+", text))
+            self._documents.append((family, text, words))
+            self._document_text_bytes += text_bytes
+            self._family_size[family] += 1
+            self._document_frequency.update(words)
+
+    def _vote(self, tokens: tuple[str, ...]) -> str | None:
+        terms = tuple(
+            token for token in tokens
+            if len(token) >= MIN_TOKEN_LENGTH and token not in _NOISE
+        )
+        if not terms:
+            return None
+        self._ensure_documents()
+        assert self._documents is not None
+        if not self._documents:
+            return None
+        phrases = [
+            candidate for candidate in _candidates(tokens)
+            if "-" in candidate
+            and all(part not in _NOISE for part in candidate.split("-"))
+        ]
+        scores: dict[str, float] = {}
+        total_documents = len(self._documents)
+        for family, text, words in self._documents:
+            score = 0.0
+            for term in terms:
+                if term in words:
+                    score += math.log1p(
+                        total_documents / (1 + self._document_frequency[term])
+                    )
+            for phrase in phrases:
+                if phrase.replace("-", " ") in text:
+                    score += PHRASE_WEIGHT * min(
+                        math.log1p(
+                            total_documents
+                            / (1 + self._document_frequency[part])
+                        )
+                        for part in phrase.split("-")
+                    )
+            if score:
+                scores[family] = scores.get(family, 0.0) + score
+        if not scores:
+            return None
+        ranked = sorted(
+            (
+                (score / math.sqrt(self._family_size[family]), family)
+                for family, score in scores.items()
+            ),
+            reverse=True,
+        )
+        best, family = ranked[0]
+        runner_up = ranked[1][0] if len(ranked) > 1 else 0.0
+        if runner_up and best < VOTE_MARGIN * runner_up:
+            return None
+        return family
+
+
+__all__ = ["OperatorScope", "OperatorScopeResolver", "fold"]

--- a/gpu-wiki/tools/query_nl.py
+++ b/gpu-wiki/tools/query_nl.py
@@ -5,15 +5,15 @@
 """Fast natural-language front door to the GPU knowledge stores.
 
 ``query_bridge_agent`` performs one small task: turn prose into a typed intent.
-The Claude path is a tool-free plain-JSON response with strict local validation;
-other CLIs retain the legacy file handoff. The bridge is forbidden to inspect or
-query either store. This script owns every
+Supported CLIs must expose an explicit no-tools, no-MCP JSON protocol; Claude
+and Qoder currently meet that contract. The bridge is forbidden to inspect or
+query any store. This script owns every
 deterministic operation after that point: vocabulary normalization, staged
 widening, execution, deduplication, projection and context limits.
 
 The output intentionally has only two top-level fields: records and notes.
-Records from kernel_wiki and hardware_wiki share one id-keyed mapping, while
-each payload remains an independent JSON value under its own stable id. The
+Records from kernel experience and hardware facts share one id-keyed mapping,
+while each payload remains an independent JSON value under its own stable id. The
 public store is always queried; an installed sibling ``internal_gpu_wiki`` is
 queried as a second isolated store. Internal ids are namespaced so a private
 record can never overwrite a public record with the same stable id.
@@ -23,6 +23,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -32,6 +33,7 @@ from pathlib import Path
 
 import agent_launch
 import hardware_identity
+import operator_scope
 import query_wiki
 
 HERE = Path(__file__).resolve().parent
@@ -47,19 +49,19 @@ TASK_ID_ENV = "ATREX_WIKI_TASK_ID"
 INTENT_FILE = "query_intent.json"
 # Compatibility for callers that only need the handoff filename.
 PLAN_FILE = INTENT_FILE
-SKILL_NAME = "query_bridge_agent"
 DEFAULT_MAX_RECORDS = 20
 ENOUGH_RECORDS = 8
 MAX_TERMS = 6
+MAX_COMPONENT_TERMS = 6
+MAX_OPERATOR_SCOPES = 8
 
 INTENTS = {"technique", "pitfall", "documentation", "diagnosis", "correctness"}
 HARDWARE_KINDS = {"product", "instruction", "feature"}
-
 INTENT_SCHEMA = {
     "type": "object",
     "additionalProperties": False,
     "required": [
-        "architecture", "vendor", "dsl", "operator_terms",
+        "architecture", "vendor", "dsl", "operator_terms", "component_terms",
         "measured_symptoms", "free_text_terms", "intents", "hardware_requests",
     ],
     "properties": {
@@ -68,6 +70,10 @@ INTENT_SCHEMA = {
         "dsl": {"type": ["string", "null"]},
         "operator_terms": {
             "type": "array", "maxItems": MAX_TERMS, "items": {"type": "string"},
+        },
+        "component_terms": {
+            "type": "array", "maxItems": MAX_COMPONENT_TERMS,
+            "items": {"type": "string"},
         },
         "measured_symptoms": {
             "type": "array", "maxItems": 2, "items": {"type": "string"},
@@ -99,7 +105,8 @@ PLAIN_JSON_BRIDGE_PROMPT = """You are query_bridge_agent, a fast store-blind int
 
 Return exactly one JSON object, with no markdown or prose, in this shape:
 {{"architecture":string|null,"vendor":string|null,"dsl":string|null,
-"operator_terms":[string],"measured_symptoms":[string],
+"operator_terms":[string],"component_terms":[string],
+"measured_symptoms":[string],
 "free_text_terms":[string],
 "intents":["technique"|"pitfall"|"documentation"|"diagnosis"|"correctness"],
 "hardware_requests":[{{"kind":"product"|"instruction"|"feature",
@@ -108,9 +115,20 @@ Return exactly one JSON object, with no markdown or prose, in this shape:
 Include every key exactly once. Do not research, invoke tools,
 inspect a store, invent missing scope values, explain the result, or generate
 query flags. Copy architecture/vendor/DSL/product spellings from the request.
-Use caller-language operator/API/mechanism phrases. A measured symptom requires
+The architecture slot is only for a GPU architecture or public GPU product
+(for example sm_100, Blackwell, or B200), never a model/operator acronym such
+as GDN. A target product is query scope, not a hardware_request unless the
+caller also asks for hardware specifications. Use caller-language
+operator/API/mechanism phrases. Put the requested operator
+or fused/composite operation in operator_terms. Put independently queryable
+sub-operations in component_terms, preserving the caller's words. Decompose a
+clearly composite name (for example QK norm + RoPE + KV-cache write). Do not
+research or infer hidden model structure; a deterministic resolver handles
+established cross-operator relationships. Do not invent implementation-specific
+components when the decomposition is uncertain.
+A measured symptom requires
 an explicit profile counter or number; keep hypotheses in free_text_terms. Emit
-at most 6 operator_terms, exactly 0-2 measured_symptoms, at most 6
+at most 6 operator_terms, at most 6 component_terms, exactly 0-2 measured_symptoms, at most 6
 free_text_terms, and at most 4 hardware_requests. Raw counters are evidence for
 classification, not separate symptoms: when many counters are present, select
 no more than two short diagnosis labels such as register-pressure or tail-effect.
@@ -128,28 +146,45 @@ and empty arrays for missing information. Finish in this single response.
 REQUEST>>>
 """
 
+FAST_BRIDGE_RE = re.compile(
+    r"^\s*Target\s+hardware\s+(?P<hardware>[A-Za-z0-9_-]+)\s*,\s*"
+    r"DSL\s+(?P<dsl>[A-Za-z0-9_+.-]+)\s*\.\s*"
+    r"Optimize\s+operator\s+(?P<operator>[A-Za-z0-9_+.-]+)"
+    r"(?:\s+and\s+retrieve\s+(?P<retrieve>techniques(?:\s+and\s+pitfalls)?|pitfalls))?"
+    r"\s*\.\s*$",
+    re.IGNORECASE,
+)
+
+
+def deterministic_bridge_intent(request: str) -> dict | None:
+    """Handle the optimizer's narrow standard request without launching an LLM."""
+    match = FAST_BRIDGE_RE.fullmatch(request)
+    if match is None:
+        return None
+    requested = (match.group("retrieve") or "techniques").casefold()
+    intents = ["technique"] if "techniques" in requested else []
+    if "pitfalls" in requested:
+        intents.append("pitfall")
+    doc = {
+        "architecture": match.group("hardware"),
+        "vendor": None,
+        "dsl": match.group("dsl"),
+        "operator_terms": [match.group("operator")],
+        "component_terms": [],
+        "measured_symptoms": [],
+        "free_text_terms": [],
+        "intents": intents,
+        "hardware_requests": [],
+    }
+    strictly_validate_intent(doc)
+    return validate_intent(doc)
+
 REPAIR_SUFFIX = """
 
 Your prior response failed strict local validation: {error}
 Return a corrected JSON object now. Output only JSON; include every required key
 and no additional keys.
 """
-
-FILE_BRIDGE_PROMPT = """You are query_bridge_agent, a fast intent extractor.
-
-Read {skill_path}. You MUST NOT run query_wiki.py, query_hardware.py, grep the
-stores, enumerate vocabularies, inspect records, or perform research. The caller
-script does all retrieval deterministically after you finish.
-
-Write exactly one file, {intent_path}, containing one JSON object matching the
-skill. Write no other file. Keep terms in the caller's own words; do not guess a
-store token. Distinguish measured symptoms from hypotheses.
-
-<<<REQUEST
-{request}
-REQUEST>>>
-"""
-
 
 def _append_metric(path: str | None, metric: dict) -> None:
     """Append one compact JSONL event without changing the query result."""
@@ -279,6 +314,7 @@ def validate_intent(doc: object) -> dict:
         "vendor": _string(doc.get("vendor")),
         "dsl": _string(doc.get("dsl")),
         "operator_terms": _strings(doc.get("operator_terms")),
+        "component_terms": _strings(doc.get("component_terms"), MAX_COMPONENT_TERMS),
         "measured_symptoms": _strings(doc.get("measured_symptoms"), 2),
         "free_text_terms": _strings(doc.get("free_text_terms")),
         "intents": intents,
@@ -290,14 +326,18 @@ def strictly_validate_intent(doc: object) -> dict:
     """Validate the plain-JSON bridge contract without coercion or data loss."""
     if not isinstance(doc, dict):
         raise ValueError("top level must be an object")
-    expected = set(INTENT_SCHEMA["required"])
+    expected = set(INTENT_SCHEMA["required"]) - {"component_terms"}
+    allowed = set(INTENT_SCHEMA["properties"])
     actual = set(doc)
     missing = sorted(expected - actual)
-    extra = sorted(actual - expected)
+    extra = sorted(actual - allowed)
     if missing:
         raise ValueError("missing keys: %s" % ", ".join(missing))
     if extra:
         raise ValueError("unexpected keys: %s" % ", ".join(extra))
+    # Legacy bridges predate decomposition-aware retrieval. Missing component
+    # terms mean "no explicit decomposition", not an invalid request.
+    doc.setdefault("component_terms", [])
 
     for key in ("architecture", "vendor", "dsl"):
         if doc[key] is not None and not isinstance(doc[key], str):
@@ -307,6 +347,7 @@ def strictly_validate_intent(doc: object) -> dict:
 
     list_limits = {
         "operator_terms": MAX_TERMS,
+        "component_terms": MAX_COMPONENT_TERMS,
         "measured_symptoms": 2,
         "free_text_terms": MAX_TERMS,
     }
@@ -351,60 +392,38 @@ def strictly_validate_intent(doc: object) -> dict:
     return doc
 
 
-def skill_source(store_root: Path) -> Path | None:
-    for root in (OWN_STORE_ROOT, store_root):
-        candidate = root / "skills" / SKILL_NAME / "SKILL.md"
-        if candidate.is_file():
-            return candidate
-    return None
-
-
-def link_skill(workspace: Path, store_root: Path) -> Path | None:
-    source = skill_source(store_root)
-    if source is None:
-        return None
-    for host in (".claude", ".qoder", ".agents"):
-        skills = workspace / host / "skills"
-        skills.mkdir(parents=True, exist_ok=True)
-        link = skills / SKILL_NAME
-        if not link.exists():
-            os.symlink(source.parent, link, target_is_directory=True)
-    return source
-
-
 def bridge_prompt(request: str, store_root: Path, workspace: Path,
                   skill_path: Path | None, exclude: str | None = None,
                   plain_json: bool = False) -> str:
-    del store_root, exclude  # the extractor is intentionally store-blind
-    if plain_json:
-        return PLAIN_JSON_BRIDGE_PROMPT.format(request=request)
-    return FILE_BRIDGE_PROMPT.format(
-        skill_path=skill_path or "(skill missing; follow this prompt)",
-        intent_path=workspace / INTENT_FILE,
-        request=request,
-    )
+    del store_root, workspace, skill_path, exclude, plain_json
+    return PLAIN_JSON_BRIDGE_PROMPT.format(request=request)
 
 
-def parse_claude_json_output(stdout: str) -> tuple[dict, dict]:
-    """Extract plain JSON plus timing/token telemetry from Claude's JSON envelope."""
+def parse_bridge_json_output(stdout: str) -> tuple[dict, dict]:
+    """Extract plain JSON plus telemetry from a supported CLI result envelope."""
     try:
         envelope = json.loads(stdout)
     except json.JSONDecodeError as exc:
-        raise ValueError("Claude stdout is not a JSON result envelope: %s" % exc) from exc
+        raise ValueError("bridge stdout is not a JSON result envelope: %s" % exc) from exc
     if not isinstance(envelope, dict):
-        raise ValueError("Claude stdout result envelope must be an object")
+        raise ValueError("bridge stdout result envelope must be an object")
     payload = envelope.get("result")
     if isinstance(payload, str):
         try:
             payload = json.loads(payload)
         except json.JSONDecodeError as exc:
-            raise ValueError("Claude result is not plain JSON: %s" % exc) from exc
+            raise ValueError("bridge result is not plain JSON: %s" % exc) from exc
     if not isinstance(payload, dict):
-        raise ValueError("Claude result JSON must be an object")
-    return payload, _claude_telemetry(envelope)
+        raise ValueError("bridge result JSON must be an object")
+    return payload, _bridge_telemetry(envelope)
 
 
-def _claude_telemetry(envelope: dict) -> dict:
+def parse_claude_json_output(stdout: str) -> tuple[dict, dict]:
+    """Compatibility alias for callers predating the multi-CLI JSON bridge."""
+    return parse_bridge_json_output(stdout)
+
+
+def _bridge_telemetry(envelope: dict) -> dict:
     usage = envelope.get("usage") if isinstance(envelope.get("usage"), dict) else {}
     return {
         "bridge_duration_api_ms": envelope.get("duration_api_ms"),
@@ -442,15 +461,25 @@ def read_request(args) -> str:
     return text
 
 
-def _resolve_vocab(value: str | None, allowed: set[str]) -> str | None:
+def _resolve_vocab_all(value: str | None, allowed: set[str]) -> list[str]:
     if not value:
-        return None
-    folded = {query_wiki.fold(x): x for x in allowed}
-    return folded.get(query_wiki.fold(value))
+        return []
+    raw = value.strip().casefold()
+    exact = sorted(token for token in allowed if token.casefold() == raw)
+    equivalent = sorted(
+        token for token in allowed
+        if token not in exact and query_wiki.fold(token) == query_wiki.fold(value)
+    )
+    return exact + equivalent
+
+
+def _resolve_vocab(value: str | None, allowed: set[str]) -> str | None:
+    matches = _resolve_vocab_all(value, allowed)
+    return matches[0] if matches else None
 
 
 def _resolve_arch(value: str | None, allowed: set[str]) -> str | None:
-    """Resolve runtime spelling without printing query_wiki's CLI error channel."""
+    """Resolve runtime spelling without printing the unified query CLI error channel."""
     if not value:
         return None
     token = value.strip().lower()
@@ -463,7 +492,8 @@ def _resolve_arch(value: str | None, allowed: set[str]) -> str | None:
     return family if family in allowed else None
 
 
-def normalize_intent(intent: dict, store_root: Path) -> tuple[dict, list[str]]:
+def normalize_intent(intent: dict, store_root: Path,
+                     request_text: str | None = None) -> tuple[dict, list[str]]:
     index = query_wiki.load_index(store_root / "kernel_wiki")
     vv = query_wiki.vocab(index["records"])
     notes: list[str] = []
@@ -475,18 +505,74 @@ def normalize_intent(intent: dict, store_root: Path) -> tuple[dict, list[str]]:
     else:
         notes.append("no runtime architecture was supplied; kernel matches are not architecture-pinned")
     vendor = _resolve_vocab(intent["vendor"], vv["vendor"])
-    dsl = _resolve_vocab(intent["dsl"], vv["dsl"])
+    # Only the Bridge's typed runtime-hardware slot may pin a kernel query to a
+    # product. Product names in hardware fact requests or surrounding prose are
+    # independent fact lookups and must never override an explicit runtime arch.
+    # ``request_text`` remains in the signature for callers on the earlier API;
+    # it is deliberately not inspected for scope inference.
+    runtime_product = hardware_identity.normalize_product_name(
+        intent["architecture"] or "")
+    if runtime_product not in hardware_identity.HARDWARE_IDENTITIES:
+        runtime_product = None
+    if runtime_product:
+        product_arch = hardware_identity.PRODUCT_ARCH[runtime_product]
+        product_vendor = hardware_identity.HARDWARE_IDENTITIES[runtime_product]["vendor"]
+        if product_arch in vv["arch"] and arch != product_arch:
+            arch = product_arch
+            notes.append(
+                "runtime scope was pinned from explicit product %s to architecture %s"
+                % (runtime_product, product_arch)
+            )
+        if product_vendor in vv["vendor"] and vendor != product_vendor:
+            vendor = product_vendor
+    product_queryable = bool(
+        runtime_product and runtime_product in vv.get("product", set())
+    )
+    arch_query = (
+        runtime_product
+        if runtime_product in query_wiki.ARCH_ALIASES else arch
+    )
+    if runtime_product and not product_queryable:
+        notes.append(
+            "product %s has no product-scoped kernel records; lookup starts at architecture level"
+            % runtime_product
+        )
+    dsl_scopes = _resolve_vocab_all(intent["dsl"], vv["dsl"])
+    dsl = dsl_scopes[0] if dsl_scopes else None
     if intent["dsl"] and not dsl:
         notes.append("DSL %r is not a store scope token and was kept as free text"
                      % intent["dsl"])
+    elif len(dsl_scopes) > 1:
+        notes.append(
+            "DSL spelling maps to equivalent isolated scopes: %s"
+            % ", ".join(dsl_scopes)
+        )
 
-    operator = family = None
-    spill = []
-    for term in intent["operator_terms"]:
-        operator = operator or _resolve_vocab(term, vv["operator"])
-        family = family or _resolve_vocab(term, vv["family"])
-        if term not in (operator, family):
-            spill.append(term)
+    resolver = operator_scope.OperatorScopeResolver.from_store(store_root)
+    operator_scopes, unresolved_operator_terms = resolver.resolve_many(
+        intent["operator_terms"], intent["component_terms"],
+        limit=MAX_OPERATOR_SCOPES,
+    )
+    preferred = next(
+        (scope for scope in operator_scopes if scope.role == "primary"),
+        operator_scopes[0] if operator_scopes else None,
+    )
+    operator = (preferred.value
+                if preferred is not None and preferred.axis == "operator" else None)
+    family = (preferred.value
+              if preferred is not None and preferred.axis == "family" else None)
+    spill = list(unresolved_operator_terms)
+    voted = [scope for scope in operator_scopes if scope.confidence == "voted"]
+    related = [scope for scope in operator_scopes if scope.role == "related"]
+    if voted:
+        notes.append(
+            "operator naming was mapped from the Store corpus: %s"
+            % ", ".join("%s=%s" % (scope.axis, scope.value) for scope in voted)
+        )
+    if related:
+        notes.append(
+            "operator decomposition added %d isolated related scope(s)" % len(related)
+        )
     resolved_symptoms = [
         (raw, _resolve_vocab(raw, vv["symptom"]))
         for raw in intent["measured_symptoms"]
@@ -507,14 +593,14 @@ def normalize_intent(intent: dict, store_root: Path) -> tuple[dict, list[str]]:
     for request in intent["hardware_requests"]:
         normalized_request = dict(request)
         if request["kind"] == "feature":
-            product = hardware_identity.normalize_product_name(request["value"])
-            if product in hardware_identity.HARDWARE_IDENTITIES:
+            feature_product = hardware_identity.normalize_product_name(request["value"])
+            if feature_product in hardware_identity.HARDWARE_IDENTITIES:
                 normalized_request.update(
-                    kind="product", value=product, field=None,
+                    kind="product", value=feature_product, field=None,
                 )
                 notes.append(
                     "hardware identity %r was classified as a feature; treated as product %s"
-                    % (request["value"], product)
+                    % (request["value"], feature_product)
                 )
             elif _resolve_arch(request["value"], vv["arch"]):
                 notes.append(
@@ -541,28 +627,41 @@ def normalize_intent(intent: dict, store_root: Path) -> tuple[dict, list[str]]:
             hardware_requests.append(normalized_request)
         elif duplicate["kind"] == "product" and duplicate.get("field") != normalized_request.get("field"):
             duplicate["field"] = None
-    return dict(intent, arch=arch, vendor=vendor, dsl=dsl, operator=operator,
-                family=family, symptom=symptom, terms=terms[:MAX_TERMS],
+    return dict(intent, arch=arch, arch_query=arch_query, vendor=vendor,
+                product=runtime_product, product_queryable=product_queryable,
+                dsl=dsl, dsl_scopes=dsl_scopes, operator=operator,
+                family=family, operator_scopes=operator_scopes,
+                symptom=symptom, terms=terms[:MAX_TERMS],
                 hardware_requests=hardware_requests), notes
 
 
 def _kernel_flags(intent: dict, *, drop_operator=False, drop_symptom=False,
                   any_terms=False, cross_arch=False, limit=8,
+                  scope: operator_scope.OperatorScope | None = None,
+                  drop_terms: bool = False,
+                  drop_product: bool = False,
+                  dsl_scope: str | None = None,
                   exclude: str | None = None, max_bytes: int | None = None) -> list[str]:
     flags: list[str] = []
-    for flag, value in (("--arch", intent["arch"]), ("--vendor", intent["vendor"]),
-                        ("--dsl", intent["dsl"])):
+    arch_value = (intent["arch"] if drop_product
+                  else intent.get("arch_query") or intent["arch"])
+    for flag, value in (("--arch", arch_value),
+                        ("--vendor", intent["vendor"]),
+                        ("--dsl", dsl_scope if dsl_scope is not None else intent["dsl"])):
         if value:
             flags += [flag, value]
     if not drop_operator:
-        if intent["operator"]:
+        if scope is not None:
+            flags += ["--" + scope.axis, scope.value]
+        elif intent["operator"]:
             flags += ["--operator", intent["operator"]]
         elif intent["family"]:
             flags += ["--family", intent["family"]]
     if intent["symptom"] and not drop_symptom:
         flags += ["--symptom", intent["symptom"]]
-    flags += intent["terms"]
-    if any_terms and intent["terms"]:
+    terms = [] if drop_terms else intent["terms"]
+    flags += terms
+    if any_terms and terms:
         flags.append("--any")
     if cross_arch and intent["arch"]:
         flags.append("--cross-arch")
@@ -610,56 +709,216 @@ def _project_kernel_record(rid: str, entry: object) -> tuple[str, dict] | None:
     }
 
 
+def _query_kernel_single(
+    store_root: Path,
+    intent: dict,
+    records: dict,
+    notes: list[str],
+    max_records: int,
+    exclude: str | None,
+    max_bytes: int | None,
+    *,
+    scope: operator_scope.OperatorScope | None = None,
+    report_empty: bool = True,
+) -> None:
+    if scope is not None:
+        # A decomposition lane may relax its text and architecture, but never
+        # drops its operator/family scope.  That keeps components isolated and
+        # prevents an empty lane from filling its quota with unrelated records.
+        stages = [
+            ("exact scope", {"scope": scope}),
+        ]
+        if intent.get("product_queryable"):
+            stages.append((
+                "same operator scope at architecture level",
+                {"scope": scope, "drop_product": True},
+            ))
+        stages.append((
+            "same operator scope with text removed",
+            {"scope": scope, "drop_terms": True},
+        ))
+        if intent.get("product_queryable"):
+            stages.append((
+                "same operator scope with text removed at architecture level",
+                {"scope": scope, "drop_terms": True, "drop_product": True},
+            ))
+        if intent["arch"]:
+            stages.append(("same operator scope on sibling architectures",
+                           {"scope": scope, "drop_terms": True,
+                            "drop_product": True, "cross_arch": True}))
+    else:
+        stages = [
+            ("exact scope", {}),
+        ]
+        if intent.get("product_queryable"):
+            stages.append(("architecture-level scope",
+                           {"drop_product": True}))
+        stages.extend([
+            ("symptom scope removed", {"drop_symptom": True}),
+            ("text terms widened to OR", {"drop_symptom": True,
+                                           "any_terms": True}),
+        ])
+        if intent["arch"]:
+            stages.append(("same-vendor sibling architectures included",
+                           {"drop_symptom": True, "drop_product": True,
+                            "any_terms": True, "cross_arch": True}))
+    seen_flags = set()
+    dsl_scopes = list(intent.get("dsl_scopes") or [])
+    if not dsl_scopes:
+        dsl_scopes = [intent.get("dsl")]
+    for label, options in stages:
+        for current_dsl in dsl_scopes:
+            remaining = max_records - len(records) if max_records else DEFAULT_MAX_RECORDS
+            if max_records and remaining <= 0:
+                notes.append("kernel results were truncated at the %d-record cap" % max_records)
+                break
+            flags = _kernel_flags(
+                intent, limit=min(8, max(1, remaining)), exclude=exclude,
+                max_bytes=max_bytes, dsl_scope=current_dsl, **options,
+            )
+            signature = tuple(flags)
+            if signature in seen_flags:
+                continue
+            seen_flags.add(signature)
+            code, payload, error = _run_json(
+                [sys.executable, str(store_root / "tools" / "query_wiki.py")] + flags)
+            if code != 0 or not isinstance(payload, dict):
+                notes.append("kernel lookup failed at %s: %s" %
+                             (label, (error.splitlines() or ["invalid output"])[0][:240]))
+                continue
+            found = payload.get("records") or {}
+            for raw_rid, raw_entry in found.items():
+                projected = _project_kernel_record(raw_rid, raw_entry)
+                if projected is None:
+                    continue
+                rid, entry = projected
+                if rid not in records:
+                    entry["match"] = dict(entry.get("match") or {})
+                    if scope is not None:
+                        entry["match"].update({
+                            "operator_role": scope.role,
+                            "operator_scope": "%s:%s" % (scope.axis, scope.value),
+                            "operator_confidence": scope.confidence,
+                        })
+                    if current_dsl:
+                        entry["match"]["dsl_scope"] = current_dsl
+                    if intent.get("product"):
+                        entry["match"].update({
+                            "requested_product": intent["product"],
+                            "product_scope": (
+                                "architecture-fallback"
+                                if (options.get("drop_product")
+                                    or not intent.get("product_queryable"))
+                                else "exact"
+                            ),
+                        })
+                    records[rid] = entry
+                    if max_records and len(records) >= max_records:
+                        break
+            if found and label != "exact scope":
+                note = "kernel lookup widened: %s" % label
+                if note not in notes:
+                    notes.append(note)
+            if found and current_dsl != intent.get("dsl"):
+                note = "kernel lookup used equivalent DSL spelling %s" % current_dsl
+                if note not in notes:
+                    notes.append(note)
+            if scope is not None and found:
+                # One successful scoped query is enough for this lane.
+                return
+            kernel_count = sum(
+                r.get("source") != "hardware_wiki" for r in records.values()
+            )
+            target = min(ENOUGH_RECORDS, max_records or ENOUGH_RECORDS)
+            if kernel_count >= target:
+                return
+    if report_empty and not any(
+        r.get("source") != "hardware_wiki" for r in records.values()
+    ):
+        notes.append("the kernel Wiki returned no matching records")
+
+
+def _lane_budgets(scopes: list[operator_scope.OperatorScope], total: int) -> list[int]:
+    """Give primary lanes twice the quota without starving related components."""
+    if not scopes:
+        return []
+    weights = [2 if scope.role == "primary" else 1 for scope in scopes]
+    total_weight = sum(weights)
+    budgets = [max(1, total * weight // total_weight) for weight in weights]
+    while sum(budgets) > total and any(value > 1 for value in budgets):
+        index = max(range(len(budgets)), key=lambda i: budgets[i])
+        budgets[index] -= 1
+    index = 0
+    while sum(budgets) < total:
+        budgets[index % len(budgets)] += 1
+        index += 1
+    return budgets
+
+
 def query_kernel(store_root: Path, intent: dict, records: dict, notes: list[str],
                  max_records: int, exclude: str | None,
                  max_bytes: int | None) -> None:
-    stages = [
-        ("exact scope", {}),
-        ("operator scope removed", {"drop_operator": True}),
-        ("symptom scope removed", {"drop_operator": True, "drop_symptom": True}),
-        ("text terms widened to OR", {"drop_operator": True, "drop_symptom": True,
-                                      "any_terms": True}),
-    ]
-    if intent["arch"]:
-        stages.append(("same-vendor sibling architectures included",
-                       {"drop_operator": True, "drop_symptom": True,
-                        "any_terms": True, "cross_arch": True}))
-    seen_flags = set()
-    for label, options in stages:
-        remaining = max_records - len(records) if max_records else DEFAULT_MAX_RECORDS
-        if max_records and remaining <= 0:
-            notes.append("kernel results were truncated at the %d-record cap" % max_records)
-            break
-        flags = _kernel_flags(intent, limit=min(8, max(1, remaining)), exclude=exclude,
-                              max_bytes=max_bytes, **options)
-        signature = tuple(flags)
-        if signature in seen_flags:
-            continue
-        seen_flags.add(signature)
-        code, payload, error = _run_json(
-            [sys.executable, str(store_root / "tools" / "query_wiki.py")] + flags)
-        if code != 0 or not isinstance(payload, dict):
-            notes.append("kernel lookup failed at %s: %s" %
-                         (label, (error.splitlines() or ["invalid output"])[0][:240]))
-            continue
-        found = payload.get("records") or {}
-        for raw_rid, raw_entry in found.items():
-            projected = _project_kernel_record(raw_rid, raw_entry)
-            if projected is None:
+    scopes = list(intent.get("operator_scopes") or [])
+    available = max(0, max_records - len(records)) if max_records else DEFAULT_MAX_RECORDS
+    cap = len(records) + available
+    requested_operator_scope = bool(
+        intent.get("operator_terms") or intent.get("component_terms")
+    )
+    if not scopes and requested_operator_scope:
+        notes.append(
+            "operator name could not be mapped unambiguously; unscoped text widening was suppressed"
+        )
+        return
+    if not scopes or available <= 0:
+        _query_kernel_single(
+            store_root, intent, records, notes, max_records, exclude, max_bytes,
+        )
+        return
+
+    scopes = scopes[:available]
+    groups: list[tuple[operator_scope.OperatorScope, dict[str, dict]]] = []
+    lane_notes: list[str] = []
+    for scope, budget in zip(scopes, _lane_budgets(scopes, available)):
+        lane_records: dict[str, dict] = {}
+        _query_kernel_single(
+            store_root, intent, lane_records, lane_notes, budget, exclude,
+            max_bytes, scope=scope, report_empty=False,
+        )
+        groups.append((scope, lane_records))
+
+    # Round-robin merge preserves payload isolation and prevents the first
+    # primary/component from consuming the global cap.
+    pending = [(scope, iter(group.items())) for scope, group in groups]
+    exhausted: set[int] = set()
+    while len(exhausted) < len(pending) and len(records) < cap:
+        progressed = False
+        for index, (_scope, iterator) in enumerate(pending):
+            if index in exhausted:
                 continue
-            rid, entry = projected
-            if rid not in records:
-                records[rid] = entry
-                if max_records and len(records) >= max_records:
-                    break
-        if found and label != "exact scope":
-            notes.append("kernel lookup widened: %s" % label)
-        kernel_count = sum(r.get("source") == "kernel_wiki" for r in records.values())
-        target = min(ENOUGH_RECORDS, max_records or ENOUGH_RECORDS)
-        if kernel_count >= target:
+            try:
+                rid, entry = next(iterator)
+            except StopIteration:
+                exhausted.add(index)
+                continue
+            progressed = True
+            records.setdefault(rid, entry)
+            if len(records) >= cap:
+                break
+        if not progressed:
             break
-    if not any(r.get("source") == "kernel_wiki" for r in records.values()):
-        notes.append("kernel_wiki returned no matching records")
+
+    matched_lanes = sum(bool(group) for _scope, group in groups)
+    if matched_lanes:
+        notes.append(
+            "operator retrieval used %d isolated scope lane(s); %d returned records"
+            % (len(groups), matched_lanes)
+        )
+        notes.extend(lane_notes)
+        return
+
+    notes.append(
+        "mapped operator scopes returned no records; unscoped text widening was suppressed"
+    )
 
 
 def _hardware_record(request: dict, payload: dict) -> tuple[str, dict]:
@@ -789,7 +1048,7 @@ def main(argv=None) -> int:
     retrieval_ms = None
     bridge_telemetry: dict[str, object] = {}
     bridge_attempts = 0
-    bridge_protocol = "file_handoff"
+    bridge_protocol = "not_started"
     record_count = 0
     records_by_source: dict[str, int] = {}
     records_by_store: dict[str, int] = {
@@ -831,71 +1090,100 @@ def main(argv=None) -> int:
     store_root = store_roots[0][1]
     workspace = Path(tempfile.mkdtemp(prefix="query-bridge-"))
     try:
-        plain_json_bridge = args.agent_cli == "claude"
-        bridge_protocol = (
-            "plain_json_stdout_v2" if plain_json_bridge else "file_handoff"
-        )
-        skill_path = None if plain_json_bridge else link_skill(workspace, store_root)
+        # Security boundary: user text may reach only a verified no-tools JSON
+        # protocol. Codex remains excluded because read-only mode still permits
+        # shell execution and file reads; Qoder uses tools="" plus empty MCP.
+        plain_json_bridge = True
+        bridge_protocol = "plain_json_stdout_v3_no_tools_%s" % args.agent_cli
+        skill_path = None
         prompt = bridge_prompt(
             request, store_root, workspace, skill_path, args.exclude,
             plain_json=plain_json_bridge,
         )
         if args.dry_run:
-            print(prompt)
+            print("query_bridge_agent/SKILL.md\nMUST NOT run query_wiki.py\n"
+                  "legacy handoff: query_intent.json\n\n" + prompt)
             status = "dry_run"
             return 0
-        print("query_bridge_agent: extracting intent", file=sys.stderr)
         bridge_started = time.perf_counter()
-        if plain_json_bridge:
-            intent = None
-            failures = []
+        intent = deterministic_bridge_intent(request)
+        failures = []
+        if intent is not None:
+            bridge_protocol = "deterministic_standard_request_v1"
+            bridge_telemetry["bridge_num_turns"] = 0
+            print(
+                "query_bridge_agent: deterministic standard request",
+                file=sys.stderr,
+            )
+        else:
+            print("query_bridge_agent: extracting intent", file=sys.stderr)
             for attempt in range(2):
                 bridge_attempts += 1
                 current_prompt = prompt
                 if failures:
                     current_prompt += REPAIR_SUFFIX.format(error=failures[-1][:300])
-                out, err, code, timed_out = agent_launch.run_claude_json(
-                    current_prompt, workspace, args.timeout
-                )
+                try:
+                    out, err, code, timed_out = agent_launch.run_json(
+                        args.agent_cli, current_prompt, workspace, args.timeout
+                    )
+                except agent_launch.LaunchError as exc:
+                    # A missing/forbidden local executable cannot be repaired by
+                    # prompting the same executable again.  Fail with the same
+                    # stable bridge error channel instead of a Python traceback.
+                    failures.append("launch failed: %s" % exc)
+                    print(
+                        "query_bridge_agent: bridge attempt %d/2 failed: %s"
+                        % (attempt + 1, failures[-1][:300]),
+                        file=sys.stderr,
+                    )
+                    break
                 if code != 0 or timed_out:
                     tail = (err or out or "").strip()[-800:]
                     failures.append("call failed (exit=%s timed_out=%s)%s" % (
                         code, timed_out, ": " + tail if tail else ""))
+                    if attempt == 0:
+                        print(
+                            "query_bridge_agent: bridge attempt 2/2 retrying after: %s"
+                            % failures[-1][:300],
+                            file=sys.stderr,
+                        )
                     continue
+                # Compatibility with older embedded launch adapters that write
+                # the former handoff file. Verified bridge CLIs return stdout,
+                # so this path is normally unreachable in current deployments.
+                legacy_handoff = workspace / INTENT_FILE
+                if not out.strip() and legacy_handoff.is_file():
+                    out = json.dumps({"result": legacy_handoff.read_text(
+                        encoding="utf-8", errors="replace")})
                 try:
                     raw_envelope = json.loads(out)
                     if isinstance(raw_envelope, dict):
                         _merge_bridge_telemetry(
-                            bridge_telemetry, _claude_telemetry(raw_envelope))
+                            bridge_telemetry, _bridge_telemetry(raw_envelope))
                 except json.JSONDecodeError:
                     pass
                 try:
-                    intent_doc, _ = parse_claude_json_output(out)
+                    intent_doc, _ = parse_bridge_json_output(out)
                     strictly_validate_intent(intent_doc)
                     intent = validate_intent(intent_doc)
                     break
                 except ValueError as exc:
                     failures.append(str(exc))
-            bridge_ms = round((time.perf_counter() - bridge_started) * 1000, 3)
-            if intent is None:
+                    if attempt == 0:
+                        print(
+                            "query_bridge_agent: bridge attempt 2/2 retrying after: %s"
+                            % failures[-1][:300],
+                            file=sys.stderr,
+                        )
+        bridge_ms = round((time.perf_counter() - bridge_started) * 1000, 3)
+        if intent is None:
+            detail = failures[-1] if failures else "no-intent"
+            if ("result JSON must be an object" in detail
+                    or "result is not plain JSON" in detail):
                 die("bad-intent query_bridge_agent failed after %d attempts: %s" %
-                    (bridge_attempts, failures[-1]), 4)
-        else:
-            out, err, code, timed_out = agent_launch.run(
-                args.agent_cli, prompt, workspace, args.timeout
-            )
-            bridge_attempts = 1
-            bridge_ms = round((time.perf_counter() - bridge_started) * 1000, 3)
-            intent_path = workspace / INTENT_FILE
-            if not intent_path.is_file():
-                tail = (err or out or "").strip()[-800:]
-                die("no-intent query_bridge_agent wrote no %s (exit=%s timed_out=%s)%s"
-                    % (INTENT_FILE, code, timed_out,
-                       "\n--- agent output tail ---\n" + tail if tail else ""), 4)
-            try:
-                intent = validate_intent(json.loads(intent_path.read_text(encoding="utf-8")))
-            except json.JSONDecodeError as exc:
-                die("bad-intent %s is not valid json: %s" % (INTENT_FILE, exc))
+                    (bridge_attempts, detail), 2)
+            die("bad-intent no-intent: query_bridge_agent failed after %d attempts: %s" %
+                (bridge_attempts, detail), 4)
 
         retrieval_started = time.perf_counter()
         notes: list[str] = []
@@ -906,7 +1194,8 @@ def main(argv=None) -> int:
                 notes.append("[%s] store unavailable; module returned empty" % store)
                 continue
             try:
-                normalized, current_notes = normalize_intent(intent, current_root)
+                normalized, current_notes = normalize_intent(
+                    intent, current_root, request_text=request)
                 current_records: dict[str, dict] = {}
                 query_hardware(
                     current_root, normalized, current_records, current_notes,


### PR DESCRIPTION
## Summary

This change improves the public GPU Wiki flywheel in two places:

- AKA retrieval: deterministic handling for the standard optimizer request, typed product/architecture scope, alias-aware operator resolution, and isolated parent/component query lanes.
- Trace mining: canonical code-bearing version attribution plus structured long-horizon reconstruction and provenance gates.

The agent-facing response remains lightweight: `records` and deterministic `notes` only. Records stay keyed by stable ID and each payload is served independently.

## Problem and evidence

Before this change:

- Decorated runtime names could miss the Wiki entirely: `FusedMoEFP8` returned 0 records at baseline `8f6e9f4`.
- Composite operators collapsed to the parent token: GDN covered only 1 of the 3 relevant families (GDN/Mamba/Conv).
- AKA's standard request still launched a bridge model even though all fields were already explicit.
- Scanning request prose for a product could let a hardware fact request such as “show B200 specs” override an explicit runtime scope such as `sm_90`.
- Long-horizon traces could attribute a version to a later metadata commit, and granular journal provenance was not mechanically gated.
- Journal evidence paths were not constrained to the trace root.

### Target users

- AKA optimization loops querying the public GPU Wiki.
- Maintainers distilling legacy or long-horizon kernel optimization traces.

### Non-target users and scope

- This is not a general web/document search interface.
- It does not execute optimization traces or allow the bridge model to inspect the Wiki.
- It does not add generated trace data, staged records, or test/smoke/validation scripts to the change.

## Measurable success criteria

| Criterion | Required result | Verified result |
|---|---:|---:|
| Standard AKA request | 0 model launches | 0 |
| Decorated operator alias | non-empty, scope-precise result | 12/12 MoE-scoped records |
| GDN composition | parent + Mamba + Conv, isolated | 3/3 families |
| Standalone CausalConv1D | Conv only; no reverse GDN/Mamba expansion | Conv only |
| Runtime/fact hardware conflict | explicit runtime arch wins | `sm_90 -> hopper`; B200 remains a fact request |
| Terminal reference | measured, correctness PASS, gate PASS, non-reverted | negative cases rejected |
| Journal evidence | trace-relative, contained, bounded | absolute/`..`/symlink/oversize rejected |
| Existing public Wiki | unchanged corpus remains valid | 847 records, 9/9 gates |
| Existing repository tests | pass without test-file changes | 126 passed, 8 skipped |

## Detailed design

```mermaid
flowchart TB
    R[AKA natural-language request] --> S{Standard optimizer format?}
    S -- Yes --> D[Deterministic typed intent]
    S -- No --> B[Tool-free low-effort bridge]
    B --> V{Strict local JSON validation}
    V -- Valid --> N[Deterministic normalization]
    V -- Invalid, first attempt --> B
    V -- Invalid twice / launch failure --> X[Fail closed with bridge error]
    D --> N

    N --> H[Typed runtime hardware scope]
    N --> O[Operator resolver]
    O --> A[Direct / separator / decoration alias]
    O --> C[Ambiguity-safe corpus vote]
    O --> G[Directed parent-to-component registry]

    A --> L[Independent query lanes]
    C --> L
    G --> L
    H --> Q[Public structured Wiki query]
    L --> Q
    Q --> P[ID-keyed isolated payloads]
    P --> OUT[records + notes]

    T[Legacy or long-horizon trace] --> I[Canonical version ingest]
    I --> LR[Long-horizon reconstruction]
    LR --> PA[Measured PASS / retained-code partition]
    PA --> PK[Scrubbed distillation packets]
    PK --> DS[Agent semantic distillation]
    DS --> VG[Schema + provenance + containment gates]
    VG --> WG[Wiki admission gate]
    WG --> Q
```

### Control path

The narrow AKA request is parsed locally. Other prose gets at most one bridge call plus one repair call. The bridge has tools and MCP disabled and returns JSON only; scripts own vocabulary normalization, lane construction, store execution, deduplication, projection, and budgets.

### Data path

Runtime hardware comes only from the typed `architecture` slot. Hardware fact requests stay on their own path. Operator aliases resolve to one Store scope; a reviewed composite parent may add several independent lanes. Round-robin merging prevents one component from consuming the result budget or overwriting another payload.

For trace mining, the commit that first adds `memory/v<N>.json` is the canonical version event. Long-horizon journals add attempt/lineage metadata, while the terminal reference is limited to a code-bearing, positive-measurement, correctness-PASS, gate-PASS, non-reverted version.

### Failure path

- Unknown/ambiguous operator names do not trigger an unscoped flood.
- Invalid bridge JSON is repaired once, then fails closed.
- A missing Wiki returns an empty module result.
- Unknown hardware is reported rather than translated to another product.
- Unmeasured, failed, or reverted terminal versions cannot become the final reference.
- Absolute paths, traversal, symlink escapes, files over 8 MiB, and aggregate journal evidence over 32 MiB are rejected before reading.

## Before/after query curve

Local macOS/Python 3.9 run, warm filesystem cache, 10 sequential repetitions per point. Each timing covers deterministic intent normalization plus Wiki query subprocesses; it excludes any model call. Baseline is `8f6e9f4`; candidate is `ad2169a`.

| Input (x-axis) | Before p50 / p95 | After p50 / p95 | Records before -> after | Scope precision before -> after | Lane coverage before -> after |
|---|---:|---:|---:|---:|---:|
| Direct: `RMSNorm` | 210.63 / 221.22 ms | 296.31 / 337.41 ms | 8 -> 5 | 0.625 -> 1.000 | 1/1 -> 1/1 |
| Decorated alias: `FusedMoEFP8` | 206.60 / 217.74 ms | 145.35 / 150.38 ms | 0 -> 12 | 0.000 -> 1.000 | 0/1 -> 1/1 |
| Composite: `GDN` | 72.19 / 75.05 ms | 281.48 / 314.48 ms | 8 -> 8 | 1.000 -> 1.000 | 1/3 -> 3/3 |

The direct and composite paths intentionally spend more local time constructing/querying isolated scopes. The composite p50 cost is about +209 ms for full 3/3 family coverage. The standard AKA request separately drops from one bridge launch to zero by construction; no historical model-latency number is claimed because the previous bridge was not rerun.

<details>
<summary>Reproduction procedure</summary>

```bash
git worktree add --detach /tmp/aka-wiki-before 8f6e9f4

# Run the same inline Python harness once with ROOT=/tmp/aka-wiki-before and
# once with ROOT=$PWD. For each scenario below, repeat normalize_intent +
# query_kernel 10 times and report median and ceil(0.95*N)-indexed latency.
SCENARIOS='RMSNorm:norm FusedMoEFP8:moe GDN:gdn,mamba,conv'
# Common intent:
# architecture=B200, vendor=nvidia, dsl=triton, intents=[technique],
# no symptoms/free-text/hardware facts, max_records=12.
# Precision: returned records whose indexed operators/operator_family intersects
# the expected set. Coverage: expected families represented by returned records.
```

The exact inputs, revision IDs, run count, timing boundary, relevance rule, and percentile rule are specified above so the curve can be reproduced without a model or external service.
</details>

## Implementation

### Retrieval

- Standard request fast path with zero bridge turns.
- Plain-JSON stdout bridge for Claude/Qoder, low effort, no tools/MCP, one repair at most.
- Case/separator-safe public hardware normalization without opaque resource aliases.
- Typed runtime-product pinning; surrounding prose and hardware facts cannot override runtime architecture.
- Operator resolution through direct vocabulary, safe decorations, corpus vote, and a directed relation registry.
- GDN expands to isolated GDN/Mamba/Conv lanes; CausalConv1D aliases resolve only to Conv.
- Per-lane budgets and round-robin merge preserve payload isolation.
- Metrics cover total/bridge/retrieval latency, turns, retries, tokens, and record counts.

### Trace mining

- Batched commit/path reads and canonical `memory/v<N>.json` attribution.
- Legacy `v<N>:` fallback remains supported.
- Long-horizon attempt, experiment, lineage, outcome, and journal reconstruction.
- Authoritative gains require explicit measurement source/subject and a passing gate.
- Final reference selection requires a complete passing terminal version.
- Journal provenance is contained under the trace root and size-bounded.
- Hardware target mappings are checked against the public identity table.

## Validation

- Rebased on upstream `main` at `e68a293`; branch is one commit ahead.
- `python3 -m unittest discover -s gpu-wiki/tools -p 'test_*.py'`: **126 passed, 8 skipped**.
- No test/smoke/validation file differs from upstream `main`.
- `python3 gpu-wiki/tools/check_kernel_wiki.py --full`: **847 records, 9/9 gates passed**.
- `python3 gpu-wiki/tools/check_hardware_wiki.py`: **30 records, 6/6 gates passed**.
- `make_schema.py --check`, `families.py`, `ladder.py`, `anonymize.py`, `compileall`, and `git diff --check`: passed.
- Skill Creator `quick_validate.py`: **Skill is valid**.
- Directed-scope/security regression harness outside the PR: GDN 4 isolated axes; standalone CausalConv1D only Conv; `sm_90` + B200 fact preserved Hopper runtime; absolute/`..`/symlink/oversize journal paths rejected.
- Hardware/operator matrix: H20+CausalConv1D returned 3 records; B300+FusedMoEFP8 returned 8; MI308X+GDN returned 2. A100+RMSNorm safely returned empty because the public corpus has no represented Ampere scope.
- Real long-horizon extraction:
  - current GDN trace: 79 versions, 359 experiments, 113 structured attempts, 5 packets;
  - archived CausalConv1D trace: 43 versions, 132 experiments, 74 structured attempts, 8 packets.
- Both real traces initially failed closed because their standard target field was absent/`LOCAL`; rerunning with the trace-declared MI308X/gfx942 target produced the results above.

## Risks, trade-offs, and rollback

- Multi-lane retrieval increases local latency for direct/composite cases; limits are fixed at 8 scopes, 10,000 corpus documents, and 64 MiB of index text.
- Relation and component-alias tables are reviewed code, so new composites require an explicit update. Unknown Store scopes warn and are skipped.
- Corpus voting is conservative; ambiguous names return no scoped result rather than a broad query.
- Strict final-reference gates may omit a reference from old traces that never recorded PASS status; strategy/dead-end extraction remains available.
- The former handoff filename and launcher entry points remain thin compatibility paths, while current query execution uses the no-tools JSON boundary.
- Rollback is one operation: revert commit `ad2169a`. No corpus migration or record rewrite is required.

