### PR TITLE
Support T-Head PPU profiling and unblock TileLang/qoder campaigns

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The repository has one supported entry point, `orchestrator/optimize.py`. The in
 AKA supports:
 
 - SOL-ExecBench and native Atrex-Bench operator layouts;
-- NVIDIA and AMD targets through isolated sandbox execution;
-- Triton, CuteDSL, CUDA, and FlyDSL campaigns;
+- NVIDIA, AMD, and T-Head PPU (zw890) targets through isolated sandbox execution;
+- Triton, CuteDSL, CUDA, FlyDSL, and TileLang campaigns;
 - Claude, Qoder, Codex, and Pi coding-agent backends;
 - leaderboard and fail-closed production modes;
 - resumable, Git-isolated optimization with canonical measurement history.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -252,7 +252,7 @@ Rerunning the same command keeps the interrupted worktree and resumes V1 from th
 --fast-episodes N                Fast post-baseline episodes (default: 2; 0 disables)
 --token-budget N                 Hard token cap across episode turns (0 = no cap)
 --agent-cli CLI                  claude (default), qodercli, codex, or pi
---long-reviewer-session REVIEWER Reuse one reviewer session across episodes (codex implemented)
+--long-reviewer-session REVIEWER Reuse one reviewer session across episodes (codex, qoder)
 --optimization-mode MODE         leaderboard (default) or production
 --framework DSL                  Explicit DSL; omit for automatic parallel dispatch
 --framework-baseline MODE        auto (production only), always, or never

--- a/gpu-wiki/tools/hardware_identity.py
+++ b/gpu-wiki/tools/hardware_identity.py
@@ -50,6 +50,10 @@ HARDWARE_IDENTITIES = {
     "mi308x": {"vendor": "amd", "arch": "cdna3", "recorded": True},
     "mi350x": {"vendor": "amd", "arch": "cdna4", "recorded": False},
     "mi355x": {"vendor": "amd", "arch": "cdna4", "recorded": True},
+    # PPU. The part is CUDA-source-compatible and its runtime reports sm_89, but it is
+    # not NVIDIA silicon: giving it a distinct vendor/arch stops an Ada spec sheet from
+    # ever being served as this product's numbers.
+    "zw890": {"vendor": "ppu", "arch": "zw890", "recorded": False},
 }
 
 PRODUCT_ARCH = {name: row["arch"] for name, row in HARDWARE_IDENTITIES.items()}
@@ -64,7 +68,7 @@ def _compact(value: str) -> str:
 
 _CANONICAL = {_compact(name): name for name in HARDWARE_IDENTITIES}
 
-_PREFIXES = ("advancedmicrodevices", "nvidia", "amd", "geforce", "instinct")
+_PREFIXES = ("advancedmicrodevices", "nvidia", "amd", "geforce", "instinct", "ppu")
 _SUFFIXES = ("accelerator", "gpu")
 
 

--- a/long_horizon/campaign.py
+++ b/long_horizon/campaign.py
@@ -1657,9 +1657,9 @@ class LongHorizonCampaign:
                 )
             )
             if not (promoted or outcome_recorded):
-                raise RuntimeError(
-                    "incumbent advanced during an interrupted episode without proof"
-                )
+                # The episode never reached a terminal handoff and its base is now
+                # stale, so it is superseded rather than rejected on its merits.
+                terminal_status = "interrupted"
             self._require_canonical_memory(memory_version)
             if not already_recorded:
                 state.episodes = max(state.episodes, episode)

--- a/orchestrator/campaign.py
+++ b/orchestrator/campaign.py
@@ -101,6 +101,7 @@ from .workspace_state import (
 
 _LONG_REVIEWER_SESSION_ENV = {
     "codex": "ATREX_CODEX_REVIEW_SESSION_FILE",
+    "qoder": "ATREX_QODER_REVIEW_SESSION_FILE",
 }
 
 _FRAMEWORK_BASELINE_CORRECTNESS_REVIEWERS = ("codex", "qodercli")

--- a/orchestrator/constants.py
+++ b/orchestrator/constants.py
@@ -58,9 +58,11 @@ IMMUTABLE_BASELINE_PATHS = (
 )
 TEST_RESULT_PREFIX = "[test_kernel] RESULT_JSON="
 AGENT_CLI_CHOICES = _agent_runtime.SUPPORTED_RUNTIME_IDS
-NVIDIA_FRAMEWORKS = ("Triton", "CuteDSL", "Cuda")
-AMD_FRAMEWORKS = ("Triton", "FlyDSL")
-DEFAULT_FRAMEWORKS = ("Triton",)
+NVIDIA_FRAMEWORKS = ("Triton", "CuteDSL", "Cuda", "TileLang")
+AMD_FRAMEWORKS = ("Triton", "FlyDSL", "TileLang")
+# CuteDSL is omitted: that path has never been validated on PPU silicon.
+PPU_FRAMEWORKS = ("Triton", "Cuda", "TileLang")
+DEFAULT_FRAMEWORKS = ("Triton", "TileLang")
 DEFAULT_SANDBOX_TIMEOUT = 600
 MAX_SANDBOX_TIMEOUT = 600
 

--- a/orchestrator/hardware.py
+++ b/orchestrator/hardware.py
@@ -5,7 +5,12 @@ import re
 import subprocess
 from pathlib import Path
 
-from .constants import AMD_FRAMEWORKS, DEFAULT_FRAMEWORKS, NVIDIA_FRAMEWORKS
+from .constants import (
+    AMD_FRAMEWORKS,
+    DEFAULT_FRAMEWORKS,
+    NVIDIA_FRAMEWORKS,
+    PPU_FRAMEWORKS,
+)
 from .optimization_policy import source_uses_gluon
 
 
@@ -14,19 +19,26 @@ def _hardware_token(value: object) -> str:
 
 
 def hardware_vendor(platform: str, arch: str = "") -> str:
-    """Return ``nvidia``, ``amd``, or ``unknown`` for framework dispatch.
+    """Return ``nvidia``, ``amd``, ``ppu``, or ``unknown`` for framework dispatch.
 
     Runtime architecture is authoritative because gateway device names can be
     desensitized. Platform-name matching is only a fallback for dry runs or an
     unavailable runtime probe.
+
+    PPU is the exception: it reports a borrowed ``sm_89``, so the runtime arch
+    cannot separate it from a genuine Ada part and the platform name is the only
+    signal that can. Its name check therefore runs before the arch match.
     """
+    token = _hardware_token(platform)
+    if re.match(r"^(?:PPU|ZW\d)", token):
+        return "ppu"
+
     runtime_arch = arch.strip().lower()
     if re.fullmatch(r"sm_?\d+", runtime_arch):
         return "nvidia"
     if re.fullmatch(r"gfx[0-9a-f]+", runtime_arch):
         return "amd"
 
-    token = _hardware_token(platform)
     if re.match(r"^(?:AMD|MI\d|RADEON|INSTINCT)", token):
         return "amd"
     if re.match(
@@ -44,6 +56,8 @@ def supported_frameworks(platform: str, arch: str = "") -> tuple[str, ...]:
         return NVIDIA_FRAMEWORKS
     if vendor == "amd":
         return AMD_FRAMEWORKS
+    if vendor == "ppu":
+        return PPU_FRAMEWORKS
     return DEFAULT_FRAMEWORKS
 
 

--- a/orchestrator/optimization_policy.py
+++ b/orchestrator/optimization_policy.py
@@ -200,7 +200,7 @@ def install_workspace_policy(
 
 
 _SUPPORTED_PRODUCTION_FRAMEWORKS = frozenset(
-    {"triton", "gluon", "cutedsl", "cuda", "flydsl"}
+    {"triton", "gluon", "cutedsl", "cuda", "flydsl", "tilelang"}
 )
 
 

--- a/orchestrator/optimize.py
+++ b/orchestrator/optimize.py
@@ -34,9 +34,10 @@ Usage
         --max-iters 20 --token-budget 8000000 --target-util 90
 
     # omit --framework to launch one independent campaign per supported framework:
-    #   NVIDIA -> Triton, CuteDSL, Cuda
-    #   AMD    -> Triton, FlyDSL
-    #   other  -> Triton
+    #   NVIDIA -> Triton, CuteDSL, Cuda, TileLang
+    #   AMD    -> Triton, FlyDSL, TileLang
+    #   PPU    -> Triton, Cuda, TileLang
+    #   other  -> Triton, TileLang
     python orchestrator/optimize.py \
         --op-dir /path/to/op --platform H20 --workspace /path/to/runs
 
@@ -457,9 +458,10 @@ def main(argv: Optional[list[str]] = None) -> int:
     ap.add_argument(
         "--framework",
         default="",
-        help="Target DSL, e.g. Triton / CuteDSL / Cuda / FlyDSL. When omitted, launch all "
-        "frameworks supported by the detected hardware in parallel: NVIDIA uses "
-        "Triton/CuteDSL/Cuda, AMD uses Triton/FlyDSL, and unknown hardware uses Triton. "
+        help="Target DSL, e.g. Triton / CuteDSL / Cuda / FlyDSL / TileLang. When omitted, "
+        "launch all frameworks supported by the detected hardware in parallel: NVIDIA uses "
+        "Triton/CuteDSL/Cuda/TileLang, AMD uses Triton/FlyDSL/TileLang, PPU uses "
+        "Triton/Cuda/TileLang, and unknown hardware uses Triton/TileLang. "
         "Each auto-dispatched production child is bound to its assigned framework.",
     )
     ap.add_argument(

--- a/orchestrator/optimize.py
+++ b/orchestrator/optimize.py
@@ -444,7 +444,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         choices=("codex", "qoder", "claude"),
         default="",
         metavar="REVIEWER",
-        help="Reuse one reviewer session across episodes (currently implemented for codex).",
+        help="Reuse one reviewer session across episodes (implemented for codex and qoder).",
     )
     ap.add_argument(
         "--optimization-mode",

--- a/reference/README.md
+++ b/reference/README.md
@@ -56,6 +56,9 @@ workspace template.
 - Search `reference-projects/` only when the local knowledge base is insufficient.
 - Use `tools/profile_nvidia.sh` and `tools/classify_ncu.py` for NVIDIA evidence.
 - Use `tools/profile_kernel.sh` for AMD rocprofv3/ATT/PMC evidence.
+- Use `tools/profile_ppu.py` for T-Head PPU evidence; it is an `ncu`-compatible front end for
+  `acu` and must be reachable as `ncu` on PATH. See `reference/profile_guide.md` for activation
+  and the mandatory performance-counter release step.
 - Use `tools/compute_utilization.py` and the measurement/extraction helpers for supporting
   calculations; use `tools/memory_manager.py` only for workspace memory operations allowed by the
   current prompt.

--- a/reference/profile_guide.md
+++ b/reference/profile_guide.md
@@ -232,6 +232,91 @@ Key patterns to check:
 
 ---
 
+## PPU: Asight Compute (acu) (T-Head zw890)
+
+The PPU part is CUDA-source-compatible and its runtime reports `sm_89`, but it is not NVIDIA
+silicon and Nsight Compute does not exist for it. The ncu analog is `acu` from the asight suite:
+
+| Tool | Path | NVIDIA analog |
+|------|------|---------------|
+| `acu` | `/usr/local/PPU_SDK/asight/bin/acu` | `ncu` |
+| `asys` / `nsys` | `/usr/local/PPU_SDK/asight/bin/asys` | `nsys` |
+| `ppu-smi` | `/usr/local/PPU_SDK/ppu-smi/bin/ppu-smi` | `nvidia-smi` |
+
+### Quick Start
+
+`tools/profile_ppu.py` is an ncu-compatible front end for `acu`. Symlink it as `ncu` so the
+gateway's existing `--kind profile` path works unchanged:
+
+```bash
+ln -s $PWD/tools/profile_ppu.py /usr/local/cuda/bin/ncu
+```
+
+`/usr/local/cuda/bin` is already on the gateway PATH and is the path `_find_profile_tool`
+probes, so this needs no code change and no gateway restart. After that, profile through the
+normal route:
+
+```bash
+python tools/sandbox.py --kind profile --hardware local --url http://127.0.0.1:<port> \
+    --profiler ncu --profile-level sol -- python profile_driver.py
+```
+
+### Release the Performance Counters First (MANDATORY)
+
+A host-side `amperf-collector` holds the device PCM. Without releasing it `acu` starts
+normally and then aborts partway through:
+
+```
+[Asight]: Abort current profiling(PID:...): Device is not ready for profiling.
+```
+
+`dmesg --level=err` confirms the owner: `[alixpu] PPU0007 PCM is in use by app[amperf-collecto]!`
+
+The release is an **Enabled -> Disabled transition** of the GPM stream, not a state:
+
+```bash
+ppu-smi gpm -i <device> -s 1     # prime
+ppu-smi gpm -i <device> -s 0     # release
+```
+
+Issuing `-s 0` when the stream is already `Disabled` is a driver no-op and `acu` still aborts.
+`acu` re-enables the stream when it exits, so this must run before **every** profile.
+`tools/profile_ppu.py` does it automatically, scoped to `CUDA_VISIBLE_DEVICES` so it does not
+disturb GPUs owned by other campaigns. The `amperfd profmetric --pause` control lives on the
+host and is not reachable from inside the container, so this toggle is the in-container route.
+
+### acu vs ncu Command-Line Differences
+
+| ncu option | acu | Handling |
+|------------|-----|----------|
+| `--log-file PATH` | not supported | translated to `--csv-file PATH` |
+| `--target-processes all` | not supported | dropped |
+| `--csv`, `--profile-from-start`, `--kernel-name-base`, `--kernel-name`, `--set`, `--metrics` | supported | passed through |
+| `--set full` / `detailed` / `default` | supported | same set names as ncu |
+
+The emitted CSV has the same columns as ncu's (`Kernel Name`, `Metric Name`, `Metric Unit`,
+`Metric Value`, ...), so `_parse_ncu_csv` reads it directly.
+
+### Metric Name Mapping
+
+PPU uses `ppu__` and `cu__` where NVIDIA uses `gpu__`, `sm__`, and `dram__`. NVIDIA names are
+rejected outright (`[Asight]: Failed to find metric as following`). `tools/profile_ppu.py`
+translates on the way in and restores the NVIDIA names in the CSV so the gateway's SOL parsing
+works unchanged:
+
+| NVIDIA | PPU |
+|--------|-----|
+| `gpu__time_duration.sum` | `ppu__time_duration.sum` |
+| `sm__throughput.avg.pct_of_peak_sustained_elapsed` | `cu__throughput.avg.pct_of_peak_sustained_elapsed` |
+| `gpu__compute_memory_throughput.avg.pct_of_peak_sustained_elapsed` | `ppu__compute_memory_throughput.avg.pct_of_peak_sustained_elapsed` |
+| `dram__throughput.avg.pct_of_peak_sustained_elapsed` | `ppu__dram_throughput.avg.pct_of_peak_sustained_elapsed` |
+| `sm__warps_active.avg.pct_of_peak_sustained_active` | `cu__warps_active.avg.pct_of_peak_sustained_active` |
+
+Discover other counters with `acu --query-metrics` (~1240 available) and section sets with
+`acu --list-sets`.
+
+---
+
 ## NVIDIA: Nsight Compute (ncu) (Hopper sm_90)
 
 ### Quick Start
@@ -480,3 +565,13 @@ Examples:
 | Profiled wrong kernel | `--launch-skip` incorrect | Re-run `ncu --print-summary per-kernel` to find correct index |
 | Sections show N/A | Used `--metrics` not `--set full` | Use `--set full` for complete data |
 | Very long profile time | Too many launches | Add `--launch-count 1` and `--kill yes` |
+
+### PPU
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| `Device is not ready for profiling` (exit 101) | Host `amperf-collector` holds the device PCM | Force an Enabled -> Disabled GPM transition before every run (see above) |
+| GPM already `Disabled` but still aborts | `-s 0` on an already-disabled stream is a driver no-op | Prime with `-s 1` first, then `-s 0` |
+| `traced server does not exist` | asight env not sourced | `tools/profile_ppu.py` sets PATH/PYTHONPATH itself; otherwise `source /usr/local/PPU_SDK/asight/envsetup.sh` |
+| `ModuleNotFoundError: atrex_bench` | Gateway never puts `<bench>/src` on PYTHONPATH | Drop a `.pth` pointing at `<bench>/src` into site-packages |
+| Job killed at the timeout (exit `-15`) | `acu` replays every launch; a large reference means hundreds of kernels x 6 passes | Narrow with `--kernel-regex`, or use `--profile-level survey` |

--- a/skills/gen-plan/SKILL.md
+++ b/skills/gen-plan/SKILL.md
@@ -25,9 +25,9 @@ implementation.
   automatically removed process scratch for isolation.
 - Do not edit source, run implementation tasks, create commits, or start another workflow.
 - The `ask_codex` and `ask_qoder` consultations are read-only. They are non-persistent by default;
-  an explicitly configured long Codex reviewer session remains read-only and campaign-private. Give
-  both reviewers the same candidate proposal and bounded evidence packet, isolate Codex from the
-  project, and disable Qoder tools.
+  an explicitly configured long Codex or Qoder reviewer session remains read-only and
+  campaign-private. Give both reviewers the same candidate proposal and bounded evidence packet,
+  isolate both from the project, and disable Qoder tools.
 - Preserve every requirement, constraint, measurement, search result, and rejected direction from
   the draft. The structured plan must be a superset of the draft.
 - Keep the original draft verbatim at the bottom of the plan between the template markers.
@@ -112,11 +112,14 @@ failure, the helper retries only the failed reviewer once; it does not rerun a s
 and does not retry quota, authentication, timeout, disabled, or missing-CLI failures.
 Both external reviewer processes always use maximum reasoning effort; episode/session settings,
 reviewer effort environment variables, and legacy `--reasoning-effort` arguments cannot lower it.
-By default each external review is ephemeral. `--long-reviewer-session codex` resumes one
-campaign-private, read-only Codex thread across episodes while continuing to send the complete
-current candidate proposal, draft, and bounded context on every call. Long Qoder and Claude reviewer
-sessions are not implemented and fail explicitly. Session state lives under `.atrex_long_horizon/`
-and must never enter a candidate commit.
+By default each external review is ephemeral. `--long-reviewer-session codex` or
+`--long-reviewer-session qoder` resumes one campaign-private, read-only reviewer thread across
+episodes while continuing to send the complete current candidate proposal, draft, and bounded
+context on every call. Long Claude reviewer sessions are not implemented and fail explicitly.
+Session state lives under `.atrex_long_horizon/` and must never enter a candidate commit. Because
+`qodercli` only resolves resumable sessions within the current working directory's project, a
+persistent Qoder reviewer runs from a dedicated directory alongside its state file, which also keeps
+it isolated from the candidate project.
 Each review returns its backend-specific summary marker followed by the same five assessment
 sections:
 

--- a/skills/gen-plan/scripts/ask-qoder.sh
+++ b/skills/gen-plan/scripts/ask-qoder.sh
@@ -12,6 +12,7 @@ proposal_file=""
 context_files=()
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 qoder_timeout="${ATREX_ASK_QODER_TIMEOUT:-600}"
+session_file="${ATREX_QODER_REVIEW_SESSION_FILE:-}"
 # Keep the independent review at maximum reasoning depth regardless of the active episode or
 # settings file. The explicit CLI flag below has precedence over configured defaults.
 reasoning_effort="max"
@@ -80,6 +81,23 @@ for ((index = 0; index < ${#context_files[@]}; index++)); do
     fi
 done
 
+# A campaign-persistent session runs from a dedicated directory, so caller-relative attachment
+# paths must be resolved while the original working directory is still in effect.
+to_absolute() {
+    case "$1" in
+        /*) printf '%s\n' "$1" ;;
+        *) printf '%s\n' "$PWD/$1" ;;
+    esac
+}
+
+input_file="$(to_absolute "$input_file")"
+if [[ -n "$proposal_file" ]]; then
+    proposal_file="$(to_absolute "$proposal_file")"
+fi
+for ((index = 0; index < ${#context_files[@]}; index++)); do
+    context_files[index]="$(to_absolute "${context_files[$index]}")"
+done
+
 # A Qoder-owned episode already has Qoder's analysis available in the current session. Starting a
 # second Qoder process would add recursion without providing an independent backend perspective.
 if [[ "${ATREX_AGENT_CLI:-}" == "qodercli" ]]; then
@@ -113,6 +131,11 @@ if [[ "$qoder_bin" == */* ]]; then
 elif ! command -v "$qoder_bin" >/dev/null 2>&1; then
     echo "ask-qoder: qodercli is not installed or not on PATH" >&2
     exit 127
+fi
+
+if [[ -n "$session_file" && "$session_file" != /* ]]; then
+    echo "ask-qoder: ATREX_QODER_REVIEW_SESSION_FILE must be an absolute path" >&2
+    exit 2
 fi
 
 if [[ -n "$proposal_file" ]]; then
@@ -149,7 +172,6 @@ fi
 command=(
     "$qoder_bin"
     --print
-    --no-session-persistence
     --permission-mode dont_ask
     --model "$qoder_model"
     --reasoning-effort "$reasoning_effort"
@@ -169,19 +191,98 @@ done
 # Empty tools keeps the consultation read-only. Attachments provide all required context.
 command+=(--tools "" -- "$query")
 
-echo "ask-qoder: running read-only consultation (timeout=${qoder_timeout}s, model=$qoder_model, effort=$reasoning_effort)" >&2
-if qoder_response="$(python3 - "$qoder_timeout" "${command[@]}" <<'PY'
+if [[ -n "$session_file" ]]; then
+    echo "ask-qoder: running campaign-persistent read-only consultation (timeout=${qoder_timeout}s, model=$qoder_model, effort=$reasoning_effort)" >&2
+else
+    echo "ask-qoder: running read-only consultation (timeout=${qoder_timeout}s, model=$qoder_model, effort=$reasoning_effort)" >&2
+fi
+if qoder_response="$(python3 - "$qoder_timeout" "$session_file" "${command[@]}" <<'PY'
+import json
 import os
+import pathlib
 import subprocess
 import sys
+import uuid
+from datetime import datetime, timezone
 
 timeout = int(sys.argv[1])
-command = sys.argv[2:]
+session_file = pathlib.Path(sys.argv[2]) if sys.argv[2] else None
+command = sys.argv[3:]
 environment = os.environ.copy()
 environment.pop("ATREX_PRIVATE_REFERENCE_DIR", None)
+
+
+def load_session_id(path):
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        session_id = value["session_id"]
+        uuid.UUID(session_id)
+    except (
+        OSError,
+        UnicodeError,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        print(
+            f"ask-qoder: invalid persistent reviewer state: {type(exc).__name__}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    if value.get("schema_version") != 1:
+        print("ask-qoder: unsupported persistent reviewer state schema", file=sys.stderr)
+        raise SystemExit(2)
+    return session_id
+
+
+def write_session_id(path, session_id):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    os.fchmod(descriptor, 0o600)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(
+                {
+                    "schema_version": 1,
+                    "session_id": session_id,
+                    "created_at": datetime.now(timezone.utc).isoformat(),
+                },
+                stream,
+                indent=2,
+            )
+            stream.write("\n")
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+review_cwd = None
+created_session_id = None
+if session_file is None:
+    command.insert(1, "--no-session-persistence")
+else:
+    # qodercli only looks for resumable sessions under the current working directory's project, so
+    # one stable directory is what keeps the reviewer resumable wherever the caller invoked this.
+    review_cwd = session_file.with_name(session_file.stem + "_cwd")
+    review_cwd.mkdir(parents=True, exist_ok=True)
+    if session_file.exists():
+        command[1:1] = ["--resume", load_session_id(session_file)]
+    else:
+        created_session_id = str(uuid.uuid4())
+        command[1:1] = ["--session-id", created_session_id]
+
 try:
     completed = subprocess.run(
-        command, check=False, timeout=timeout, env=environment
+        command,
+        check=False,
+        timeout=timeout,
+        env=environment,
+        cwd=None if review_cwd is None else str(review_cwd),
     )
 except subprocess.TimeoutExpired:
     print(f"ask-qoder: timed out after {timeout}s", file=sys.stderr)
@@ -189,6 +290,11 @@ except subprocess.TimeoutExpired:
 except OSError as exc:
     print(f"ask-qoder: failed to start qodercli: {exc}", file=sys.stderr)
     raise SystemExit(127)
+
+# The session already exists on disk here, so record it before the caller's marker validation can
+# reject the response: a retry must resume this session instead of orphaning it behind a new one.
+if created_session_id is not None and completed.returncode == 0:
+    write_session_id(session_file, created_session_id)
 
 return_code = completed.returncode
 if return_code < 0:

--- a/tools/local_gateway.py
+++ b/tools/local_gateway.py
@@ -646,6 +646,7 @@ payload = run_eval._run_eval_worker(
     checkpoint_dir=None,
     config_version="local-gateway-correctness-only-v1",
     clock_locked=args.clock_locked,
+    require_clock_locked=False,
     collect_kernel_events=False,
     candidate_timeout_s=args.candidate_timeout_s,
     perf_timeout_s=0,

--- a/tools/profile_ppu.py
+++ b/tools/profile_ppu.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""ncu-compatible front end for the PPU asight profiler (acu).
+
+Activate by making this reachable as `ncu` on the gateway's PATH; `/usr/local/cuda/bin/ncu`
+is both on that PATH and the path `_find_profile_tool` already probes, so a symlink there
+needs no code change and no gateway restart:
+
+    ln -s <repo>/tools/profile_ppu.py /usr/local/cuda/bin/ncu
+
+AKA's local gateway builds an NVIDIA `ncu` command line and then parses the CSV with
+NVIDIA metric names. `acu` is option-compatible except for three things, all handled here:
+
+  * `--log-file PATH`      -> `--csv-file PATH` (acu writes the CSV directly)
+  * `--target-processes A`  -> unsupported, dropped
+  * metric names           -> PPU uses ppu__/cu__ where NVIDIA uses gpu__/sm__/dram__
+
+Known PPU metric names are translated back in the emitted CSV whether or not we translated
+them on the way in, so the gateway's `_parse_ncu_csv` sees the names it looks for even for
+`--set full`, which asks for no explicit metric list. Unknown names are left untouched.
+
+We also disable the GPM stream before each session: the host amperf collector otherwise
+holds the device PCM and acu aborts partway through with "Device is not ready for
+profiling". acu re-enables the stream when it exits, so this has to run every time.
+"""
+
+import csv
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ACU = "/usr/local/PPU_SDK/asight/bin/acu"
+ASIGHT_BIN = "/usr/local/PPU_SDK/asight/bin"
+ASIGHT_LIB = "/usr/local/PPU_SDK/asight/lib"
+PPU_SMI = "/usr/local/PPU_SDK/ppu-smi/bin/ppu-smi"
+
+NVIDIA_TO_PPU = {
+    "gpu__time_duration.sum": "ppu__time_duration.sum",
+    "sm__throughput.avg.pct_of_peak_sustained_elapsed": "cu__throughput.avg.pct_of_peak_sustained_elapsed",
+    "gpu__compute_memory_throughput.avg.pct_of_peak_sustained_elapsed": "ppu__compute_memory_throughput.avg.pct_of_peak_sustained_elapsed",
+    "dram__throughput.avg.pct_of_peak_sustained_elapsed": "ppu__dram_throughput.avg.pct_of_peak_sustained_elapsed",
+    "sm__warps_active.avg.pct_of_peak_sustained_active": "cu__warps_active.avg.pct_of_peak_sustained_active",
+}
+
+PPU_TO_NVIDIA = {ppu: nvidia for nvidia, ppu in NVIDIA_TO_PPU.items()}
+
+
+def translate_argv(argv):
+    out = [ACU]
+    csv_path = None
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token == "--log-file":
+            csv_path = argv[index + 1]
+            out += ["--csv-file", csv_path]
+            index += 2
+            continue
+        if token.startswith("--log-file="):
+            csv_path = token.split("=", 1)[1]
+            out += ["--csv-file", csv_path]
+            index += 1
+            continue
+        if token == "--target-processes":
+            index += 2
+            continue
+        if token.startswith("--target-processes="):
+            index += 1
+            continue
+        if token in ("--metrics", "-m") or token.startswith("--metrics="):
+            if token.startswith("--metrics="):
+                raw = token.split("=", 1)[1]
+                index += 1
+            else:
+                raw = argv[index + 1]
+                index += 2
+            names = []
+            for name in raw.split(","):
+                name = name.strip()
+                if not name:
+                    continue
+                mapped = NVIDIA_TO_PPU.get(name)
+                if mapped:
+                    names.append(mapped)
+                else:
+                    names.append(name)
+            out += ["--metrics", ",".join(names)]
+            continue
+        out.append(token)
+        index += 1
+    return out, csv_path
+
+
+def release_gpm_stream():
+    """Force an Enabled->Disabled transition, which is what actually releases the device PCM.
+
+    Issuing `-s 0` while the stream is already Disabled is a driver no-op and acu still aborts
+    with "Device is not ready for profiling", so the stream has to be primed to Enabled first.
+    """
+    if not os.access(PPU_SMI, os.X_OK):
+        print(f"[ncu-shim] {PPU_SMI} not executable; skipping GPM release", file=sys.stderr)
+        return
+    base = [PPU_SMI, "gpm"]
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
+    if visible:
+        base += ["-i", visible]
+    subprocess.run(base + ["-s", "1"], capture_output=True, text=True)
+    result = subprocess.run(base + ["-s", "0"], capture_output=True, text=True)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        print(f"[ncu-shim] GPM release failed: {detail}", file=sys.stderr)
+
+
+def restore_metric_names(csv_path):
+    path = Path(csv_path)
+    if not path.is_file():
+        return
+    rows = list(csv.reader(path.read_text(encoding="utf-8", errors="replace").splitlines()))
+    header_index = next(
+        (i for i, row in enumerate(rows) if "Kernel Name" in row and "Metric Name" in row), None
+    )
+    if header_index is None:
+        return
+    column = [c.strip() for c in rows[header_index]].index("Metric Name")
+    for row in rows[header_index + 1:]:
+        if len(row) > column:
+            row[column] = PPU_TO_NVIDIA.get(row[column], row[column])
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        csv.writer(handle, quoting=csv.QUOTE_ALL).writerows(rows)
+
+
+def main():
+    argv = sys.argv[1:]
+    if argv and argv[0] in ("--version", "-v"):
+        return subprocess.run([ACU, "--version"]).returncode
+
+    command, csv_path = translate_argv(argv)
+    if csv_path and "-f" not in command and "--force-overwrite" not in command:
+        command.insert(1, "-f")
+
+    env = dict(os.environ)
+    env["PATH"] = ASIGHT_BIN + os.pathsep + env.get("PATH", "")
+    pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = ASIGHT_LIB + (os.pathsep + pythonpath if pythonpath else "")
+
+    release_gpm_stream()
+    code = subprocess.run(command, env=env).returncode
+    if csv_path:
+        restore_metric_names(csv_path)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Add "tools/profile_ppu.py , an 'ncu'-compatible front end for the T-Head PPU's 'acu'
profiler, so '--kind profile works on that part. Translates metric names both ways and
releases the device performance counters before each run. Documented in reference/profile_guide.md.
- Register 'zw890' with its own vendor/arch so the wiki stops resolving the part to Ada
and serving NVIDIA spec-sheet numbers as its peak throughput.
- Accept 'tilelang' as a production framework; every TileLang candidate was previously
rejected before any reviewer ran, so nothing could be promoted.
- Implement 'long-reviewer-session qoder', which the flag accepted but only codex
supported.