### PR TITLE
Configure reviewers by optimization stage

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -128,8 +128,8 @@ runtime-detected GPU vendor.
 1. Materialize or resume a Git workspace and validate its committed V0.
 2. In production mode by default, create and pin a self-contained framework-native V1.
 3. Create one private branch/worktree per canonical version. The first two optimization episodes use
-   five reviewed fast `plan -> implement -> evaluator` trials per episode by default; later episodes
-   use the full evidence loop.
+   five fast `plan -> implement -> evaluator` trials per episode by default; later episodes use the
+   full evidence loop. The primary Agent uses maximum reasoning effort in both modes.
 4. Validate its structured journal and `candidate_ready`, `pivot`, or `blocked` handoff, with
    bounded same-thread recovery for Claude and Codex.
 5. Check protected paths, the exact committed `kernel.py`, and production policy while allowing
@@ -166,12 +166,11 @@ inside each campaign workspace. It also prepares backend-specific project-local 
 - `.claude/` and `.qoder/` receive Agent definitions and knowledge skills;
 - `.agents/skills/` receives repository-scoped Codex/Pi optimization skills;
 - The repository-native `gen-plan` skill is linked into every backend's local discovery tree. It
-  freezes a concrete candidate proposal and independently obtains read-only Codex and Qoder reviews
-  against that proposal and the same bounded evidence before cross-review synthesis. A matching
-  primary backend reviews in its current session to avoid
-  recursion. Before the first optimization episode, the campaign probes each external reviewer once,
-  caches the
-  result in private runtime state, and disables later calls to reviewers that were unavailable.
+  freezes a concrete candidate proposal and independently obtains the Codex and Qoder reviews enabled
+  for the current episode mode against that proposal and the same bounded evidence. A matching primary
+  backend reviews in its current session to avoid recursion. The campaign probes each reviewer when it
+  is first enabled, caches the result in private runtime state, and disables later calls to reviewers
+  that were unavailable.
 
 ### Sandbox execution
 
@@ -264,7 +263,8 @@ Production mode runs a dedicated framework-baseline session by default
 (`--framework-baseline=auto`). For a supervisor-seeded reference V0 it skips the redundant pre-V1
 policy review and pre-creates a minimal native `solution.json`. Before the implementation Agent starts,
 the supervisor gives the bounded public contract, immutable reference, input builder, and V0 evidence to
-isolated Codex and Qoder reviewers in parallel. Their correctness-only reviews are cached under
+the enabled isolated Codex and Qoder reviewers, in parallel when both are enabled. Their
+correctness-only reviews are cached under
 `.atrex_long_horizon/framework_baseline/`, reconciled in the V1 prompt, and never receive private shapes or
 permission to edit the candidate. Each reviewer may nominate at most two paths from a mechanically bounded
 local reference catalog. The supervisor prefers reviewer consensus, publishes no more than two exact paths,
@@ -293,8 +293,9 @@ repeat five times:
 select fastest passing hash-matched trial -> handoff
 ```
 
-Fast mode uses the normal `gen-plan` external Codex/Qoder review synthesis inside its planning phase,
-but does not run a separate research phase, profile, run multi-seed correctness, or run ABBA. The
+Fast mode uses the normal `gen-plan` synthesis with the reviewers enabled for fast episodes inside its
+planning phase. Those reviewers default off. Fast mode does not run a separate research phase,
+profile, run multi-seed correctness, or run ABBA. The
 sandbox records the evaluator result with the final `kernel.py` hash. The supervisor uses that result
 for correctness and compares it with the latest complete passing canonical incumbent measurement.
 `--fast-episodes 0` disables this path; another non-negative value changes its window.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,17 +17,18 @@ agent in this repository to translate the task into that command and start the c
 The orchestrator verifies required submodules before starting and initializes missing ones
 automatically; the large `reference-projects/` collection remains optional.
 
-The repository-native `gen-plan` skill freezes a concrete candidate proposal, then requests
-independent, read-only reviews from Codex and Qoder against the same proposal and bounded repository
-evidence. It resolves their agreements and disagreements before producing the final plan. A
-Codex- or Qoder-owned episode performs its matching review in the current session to avoid recursion;
-external reviewers are probed once before the first optimization episode. Fast and full modes both
-use this reviewed planning path. Reviews are non-persistent
-by default; an optional campaign-private Codex reviewer thread may span episodes. The campaign
-caches that decision under `.atrex_long_horizon/`, reuses it after restarts, and never retries a
-reviewer that failed the startup probe. An unavailable reviewer is recorded explicitly and does not
-discard the other review. External `ask-codex` and `ask-qoder` consultations always run with maximum
-reasoning effort, independently of the primary episode's configured effort.
+The repository-native `gen-plan` skill freezes a concrete candidate proposal, then requests the
+configured independent, read-only Codex and Qoder reviews against the same proposal and bounded
+repository evidence. V1, fast episodes, and full episodes each have independent Codex and Qoder
+switches. V1 and fast reviewers default off; full reviewers default on. A Codex- or Qoder-owned
+episode performs an enabled matching review in the current session to avoid recursion. The campaign
+probes a reviewer only when
+it is first enabled for an episode mode, caches that decision under `.atrex_long_horizon/`, reuses it
+after restarts, and never retries a reviewer that failed the probe. Reviews are non-persistent by
+default; an optional campaign-private Codex reviewer thread may span episodes. Disabled and
+unavailable reviewers are recorded explicitly without discarding available reviews. Enabled
+external consultations always run with maximum reasoning effort, independently of the primary
+episode's configured effort.
 
 ## 1. Clone the Repository
 
@@ -100,13 +101,14 @@ python orchestrator/optimize.py \
    full-workload base-seed evaluation, and records canonical `memory/v0.json` without launching a
    coding Agent.
 4. **Establish V1 when enabled.** `--framework-baseline=auto` creates a self-contained
-   framework-native V1 in production mode. Read-only reviewers provide bounded correctness guidance;
-   the coding Agent implements and smoke-tests, while the supervisor owns full evaluation, policy
-   review, memory, and the final commit.
+   framework-native V1 in production mode. When enabled, read-only reviewers provide bounded
+   correctness guidance; the coding Agent implements and smoke-tests, while the supervisor owns full
+   evaluation, policy review, memory, and the final commit.
 5. **Run isolated optimization episodes.** Each episode owns one candidate direction in a private
-   Git branch and worktree. By default, the first two episodes run five reviewed
-   `plan -> implement -> evaluator` trials without profiling, multi-seed validation, or ABBA. Later
-   episodes use the full profile/research/plan/edit/repair loop.
+   Git branch and worktree. By default, the first two episodes run five
+   `plan -> implement -> evaluator` trials at maximum primary-Agent reasoning effort without
+   profiling, multi-seed validation, or ABBA. Later episodes use the full
+   profile/research/plan/edit/repair loop.
 6. **Verify and promote.** Fast mode compares the fastest passing hash-matched trial with canonical
    incumbent memory. Full mode runs an independent incumbent/candidate ABBA comparison in one
    isolated GPU allocation. Production also applies its fail-closed policy review. Only a strict
@@ -114,7 +116,6 @@ python orchestrator/optimize.py \
 7. **Recover or finalize.** A restarted supervisor reopens the registered episode worktree with its
    intermediate state. The campaign stops on mechanical budgets or target utilization, summarizes
    canonical memory, and emits a directly consumable `submission.json` for SOL campaigns.
-
 GPU evaluations and full-mode profiles run through `tools/sandbox.py` on `--sandbox-hardware`;
 `memory/`, episode journals, worktrees, and Git stay local. `--platform` is required and names the
 logical target.
@@ -226,14 +227,14 @@ leaderboard campaign.
 
 With the default `--framework-baseline=auto`, production inserts one dedicated framework bring-up
 session after V0. Native V1 receives a pre-seeded manifest and three latency-quantile smoke ids; the
-supervisor first runs isolated Codex and Qoder correctness reviews concurrently over the bounded public
-contract and immutable reference. Reviewers nominate only from a bounded local path catalog; the supervisor
-reconciles their choices and injects at most two exact reference paths alongside both reviews. V1 reads only
-that shortlist without recursively browsing siblings. The reviews are cached for restart and never receive
-private shapes or write access to the candidate. The coding Agent implements and smoke-tests only, without
-full evaluation, memory writing, or commits. The supervisor then runs policy review in parallel with one
-combined full-workload evaluator that measures the base seed and checks five additional seeds, writes memory,
-and pins V1. Use
+supervisor first runs the enabled isolated Codex and Qoder correctness reviews over the bounded public
+contract and immutable reference, concurrently when both are enabled. Reviewers nominate only from a
+bounded local path catalog; the supervisor reconciles their choices and injects at most two exact reference
+paths alongside the available reviews. V1 reads only that shortlist without recursively browsing siblings.
+The reviews are cached for restart and never receive private shapes or write access to the candidate. The
+coding Agent implements and smoke-tests only, without full evaluation, memory writing, or commits. The
+supervisor then runs policy review in parallel with one combined full-workload evaluator that measures the
+base seed and checks five additional seeds, writes memory, and pins V1. Use
 `--framework-baseline=always` to enable the same stage in leaderboard mode, or `never` to seed
 optimization directly from V0. A Triton campaign escalates to Gluon after three consecutive stalls
 by default; once triggered, conversion retries until correctness and performance parity pass, and
@@ -253,6 +254,16 @@ Rerunning the same command keeps the interrupted worktree and resumes V1 from th
 --token-budget N                 Hard token cap across episode turns (0 = no cap)
 --agent-cli CLI                  claude (default), qodercli, codex, or pi
 --long-reviewer-session REVIEWER Reuse one reviewer session across episodes (codex, qoder)
+--v1-ask-codex / --no-v1-ask-codex                 Configure ask-codex for V1 (default: off)
+--v1-ask-qoder / --no-v1-ask-qoder                 Configure ask-qoder for V1 (default: off)
+--fast-episode-ask-codex / --no-fast-episode-ask-codex
+                                                    Configure fast ask-codex (default: off)
+--fast-episode-ask-qoder / --no-fast-episode-ask-qoder
+                                                    Configure fast ask-qoder (default: off)
+--full-episode-ask-codex / --no-full-episode-ask-codex
+                                                    Configure full ask-codex (default: on)
+--full-episode-ask-qoder / --no-full-episode-ask-qoder
+                                                    Configure full ask-qoder (default: on)
 --optimization-mode MODE         leaderboard (default) or production
 --framework DSL                  Explicit DSL; omit for automatic parallel dispatch
 --framework-baseline MODE        auto (production only), always, or never

--- a/long_horizon/campaign.py
+++ b/long_horizon/campaign.py
@@ -60,7 +60,7 @@ EPISODE_EVALUATIONS_PATH = Path(".atrex_long_horizon/evaluations.jsonl")
 FAST_POLICY_REVIEW_REQUEST_PATH = Path(
     ".atrex_long_horizon/policy_review_request.json"
 )
-FAST_REASONING_EFFORT = "xhigh"
+FAST_REASONING_EFFORT = "max"
 FULL_REASONING_EFFORT = "max"
 
 
@@ -1871,9 +1871,6 @@ class LongHorizonCampaign:
                 reason = "budget: token-budget"
                 break
             resumed = recovered_episode is not None
-            # Planning uses the same external-review synthesis in fast and full modes.
-            # The probe is cached, so this is effectively once per campaign.
-            self.base_campaign.ensure_plan_reviewer_availability()
             if recovered_episode is not None:
                 worktree, active = recovered_episode
                 recovered_episode = None
@@ -1886,6 +1883,16 @@ class LongHorizonCampaign:
                     if mode in {"fast", "full"}
                     else self._is_fast_episode(episode)
                 )
+            else:
+                episode = state.episodes + 1
+                fast_mode = self._is_fast_episode(episode)
+
+            episode_mode = "fast" if fast_mode else "full"
+            self.base_campaign.ensure_plan_reviewer_availability(
+                episode_mode=episode_mode
+            )
+
+            if resumed:
                 active.setdefault("mode", "fast" if fast_mode else "full")
                 active.setdefault(
                     "fast_trials", self.fast_trials if fast_mode else None
@@ -1895,8 +1902,6 @@ class LongHorizonCampaign:
                         self.base_campaign, worktree.path
                     )
             else:
-                episode = state.episodes + 1
-                fast_mode = self._is_fast_episode(episode)
                 memory_version = main_adapter.latest_version(self.workspace) + 1
                 base_commit = git_head(self.workspace)
                 worktree = EpisodeWorktree.plan(
@@ -1965,7 +1970,9 @@ class LongHorizonCampaign:
                 "ATREX_TELEMETRY_ITERATION_ID": f"episode-{episode:04d}",
                 "ATREX_TELEMETRY_ATTEMPT_ID": "invocation",
             }
-            telemetry_environment.update(self.base_campaign.agent_environment())
+            telemetry_environment.update(
+                self.base_campaign.agent_environment(episode_mode=episode_mode)
+            )
             policy_stop: Event | None = None
             policy_executor: ThreadPoolExecutor | None = None
             policy_future: Future[None] | None = None

--- a/orchestrator/campaign.py
+++ b/orchestrator/campaign.py
@@ -58,7 +58,11 @@ from .optimization_policy import (
     production_kernel_violations,
     production_structure_violations,
 )
-from .plan_reviewers import discover_plan_reviewers, plan_reviewer_environment
+from .plan_reviewers import (
+    REVIEWER_ENVIRONMENT,
+    discover_plan_reviewers,
+    plan_reviewer_environment,
+)
 from .session_io import (
     SessionResult,
     _production_review_candidate_paths,
@@ -104,7 +108,6 @@ _LONG_REVIEWER_SESSION_ENV = {
     "qoder": "ATREX_QODER_REVIEW_SESSION_FILE",
 }
 
-_FRAMEWORK_BASELINE_CORRECTNESS_REVIEWERS = ("codex", "qodercli")
 _FRAMEWORK_BASELINE_CORRECTNESS_REVIEW_TIMEOUT_S = 600
 _FRAMEWORK_BASELINE_CORRECTNESS_REVIEW_SCHEMA_VERSION = 3
 _FRAMEWORK_BASELINE_CORRECTNESS_REVIEW_PATH = Path(
@@ -179,6 +182,12 @@ class Campaign:
     verify_run_timeout: int = DEFAULT_VERIFY_RUN_TIMEOUT
     min_improvement_pct: float = 0.0
     long_reviewer_session: str = ""
+    v1_ask_codex: bool = False
+    v1_ask_qoder: bool = False
+    fast_episode_ask_codex: bool = False
+    fast_episode_ask_qoder: bool = False
+    full_episode_ask_codex: bool = True
+    full_episode_ask_qoder: bool = True
     tokens_spent: int = field(default=0, init=False)
     _production_review_cache: dict[str, tuple[tuple[str, ...], dict[str, object]]] = (
         field(default_factory=dict, init=False, repr=False, compare=False)
@@ -324,9 +333,37 @@ class Campaign:
                 )
                 return
 
-    def agent_environment(self) -> dict[str, str]:
+    def _episode_plan_reviewers(self, episode_mode: str) -> tuple[str, ...]:
+        if episode_mode not in ("fast", "full"):
+            raise ValueError(f"unsupported episode mode: {episode_mode}")
+        return tuple(
+            reviewer
+            for reviewer in ("codex", "qoder")
+            if getattr(self, f"{episode_mode}_episode_ask_{reviewer}")
+        )
+
+    def _framework_baseline_correctness_reviewers(self) -> tuple[str, ...]:
+        return tuple(
+            reviewer
+            for reviewer, enabled in (
+                ("codex", self.v1_ask_codex),
+                ("qodercli", self.v1_ask_qoder),
+            )
+            if enabled
+        )
+
+    def agent_environment(self, *, episode_mode: str = "") -> dict[str, str]:
         private_dir = self.private_reference_dir
         environment = dict(self._plan_reviewer_environment)
+        if episode_mode:
+            enabled_reviewers = set(self._episode_plan_reviewers(episode_mode))
+            for reviewer, (enabled_name, reason_name) in REVIEWER_ENVIRONMENT.items():
+                if reviewer in enabled_reviewers:
+                    continue
+                environment[enabled_name] = "0"
+                environment[reason_name] = (
+                    f"disabled by --no-{episode_mode}-episode-ask-{reviewer}"
+                )
         if self.long_reviewer_session:
             env_name = _LONG_REVIEWER_SESSION_ENV[self.long_reviewer_session]
             state_file = (
@@ -338,23 +375,31 @@ class Campaign:
             environment[ATREX_PRIVATE_REFERENCE_ENV] = str(private_dir)
         return environment
 
-    def ensure_plan_reviewer_availability(self) -> None:
-        """Probe optional plan reviewers once and reuse the campaign-local decision."""
-        if self._plan_reviewer_environment:
+    def ensure_plan_reviewer_availability(self, *, episode_mode: str) -> None:
+        """Probe the reviewers enabled for this episode mode at most once each."""
+        reviewers = self._episode_plan_reviewers(episode_mode)
+        if not reviewers:
+            return
+        if all(
+            REVIEWER_ENVIRONMENT[reviewer][0] in self._plan_reviewer_environment
+            for reviewer in reviewers
+        ):
             return
         value, reused = discover_plan_reviewers(
             self.workspace,
             agent_cli=self.agent_cli,
+            reviewers=reviewers,
         )
         self._plan_reviewer_environment = plan_reviewer_environment(value)
         statuses = []
-        for name in ("codex", "qoder"):
+        for name in reviewers:
             record = value["reviewers"][name]
             status = "available" if record["available"] else "disabled"
             statuses.append(f"{name}={status} ({record['reason']})")
         source = "cached" if reused else "startup probe"
         print(
-            f"[orchestrator] plan reviewers ({source}): " + "; ".join(statuses),
+            f"[orchestrator] {episode_mode} episode plan reviewers ({source}): "
+            + "; ".join(statuses),
             flush=True,
         )
 
@@ -989,6 +1034,8 @@ class Campaign:
         baseline_report.md. Review failure remains non-fatal here: the ordinary V1
         entry point validates the cache and retries synchronously when necessary.
         """
+        if not self._framework_baseline_correctness_reviewers():
+            return self._run_v0_evaluator()
         print(
             "[orchestrator] V0 evaluator: prefetching V1 correctness review in parallel",
             flush=True,
@@ -1756,7 +1803,7 @@ class Campaign:
         catalog = self._framework_baseline_reference_catalog()
         rank = {path: index for index, path in enumerate(catalog)}
         nominations: dict[str, dict[str, object]] = {}
-        for reviewer in _FRAMEWORK_BASELINE_CORRECTNESS_REVIEWERS:
+        for reviewer in self._framework_baseline_correctness_reviewers():
             record = reviews.get(reviewer)
             if not isinstance(record, dict):
                 continue
@@ -1783,6 +1830,10 @@ class Campaign:
         digest.update(
             f"v1-correctness-review-v{_FRAMEWORK_BASELINE_CORRECTNESS_REVIEW_SCHEMA_VERSION}"
             .encode()
+        )
+        digest.update(b"\0enabled-reviewers\0")
+        digest.update(
+            ",".join(self._framework_baseline_correctness_reviewers()).encode()
         )
         for value in (self.framework, self.platform, self.arch):
             digest.update(b"\0")
@@ -1818,12 +1869,15 @@ class Campaign:
         reviews = value.get("reviews")
         if not isinstance(reviews, dict):
             return None
+        enabled_reviewers = self._framework_baseline_correctness_reviewers()
+        if not enabled_reviewers:
+            return None
         if not any(
             isinstance(reviews.get(reviewer), dict)
             and reviews[reviewer].get("status") == "ok"
             and isinstance(reviews[reviewer].get("guidance"), str)
             and reviews[reviewer]["guidance"].strip()
-            for reviewer in _FRAMEWORK_BASELINE_CORRECTNESS_REVIEWERS
+            for reviewer in enabled_reviewers
         ):
             return None
         selected_references = value.get("selected_references")
@@ -1973,26 +2027,39 @@ class Campaign:
             )
 
     def _ensure_framework_baseline_correctness_guidance(self) -> None:
-        """Ask Codex and Qoder concurrently for correctness-first V1 guidance."""
+        """Ask the configured V1 reviewers for correctness-first guidance."""
+        reviewers = self._framework_baseline_correctness_reviewers()
+        labels = [
+            "Qoder" if reviewer == "qodercli" else "Codex" for reviewer in reviewers
+        ]
+        if not reviewers:
+            print(
+                "[orchestrator] V1 pre-implementation correctness review: disabled by "
+                "configuration",
+                flush=True,
+            )
+            return
         if self._load_framework_baseline_correctness_guidance() is not None:
             print(
                 "[orchestrator] V1 pre-implementation correctness review: using cached "
-                "Codex/Qoder guidance",
+                + "/".join(labels)
+                + " guidance",
                 flush=True,
             )
             return
 
         print(
-            "[orchestrator] V1 pre-implementation correctness review: launching Codex "
-            "and Qoder in parallel",
+            "[orchestrator] V1 pre-implementation correctness review: launching "
+            + " and ".join(labels)
+            + (" in parallel" if len(reviewers) > 1 else ""),
             flush=True,
         )
-        with ThreadPoolExecutor(max_workers=2) as executor:
+        with ThreadPoolExecutor(max_workers=len(reviewers)) as executor:
             futures = {
                 reviewer: executor.submit(
                     self._run_framework_baseline_correctness_reviewer, reviewer
                 )
-                for reviewer in _FRAMEWORK_BASELINE_CORRECTNESS_REVIEWERS
+                for reviewer in reviewers
             }
             completed = {
                 reviewer: future.result() for reviewer, future in futures.items()
@@ -2000,7 +2067,7 @@ class Campaign:
 
         reviews: dict[str, object] = {}
         statuses: list[str] = []
-        for reviewer in _FRAMEWORK_BASELINE_CORRECTNESS_REVIEWERS:
+        for reviewer in reviewers:
             record, result = completed[reviewer]
             reviews[reviewer] = record
             if result is not None:
@@ -2032,8 +2099,8 @@ class Campaign:
         )
         if self._load_framework_baseline_correctness_guidance() is None:
             print(
-                "[orchestrator] WARNING: neither Codex nor Qoder produced valid V1 "
-                "correctness guidance; continuing with the public contract",
+                "[orchestrator] WARNING: no configured reviewer produced valid V1 correctness "
+                "guidance; continuing with the public contract",
                 file=sys.stderr,
                 flush=True,
             )
@@ -2057,28 +2124,44 @@ class Campaign:
         return "\n".join(lines).strip()
 
     def _framework_baseline_correctness_guidance_text(self) -> str:
+        reviewers = self._framework_baseline_correctness_reviewers()
+        if not reviewers:
+            return (
+                "## External pre-implementation correctness guidance\n\n"
+                "External V1 correctness review is disabled by configuration. Derive every "
+                "correctness requirement directly from the public contract and immutable "
+                "reference before editing.\n"
+            )
         value = self._load_framework_baseline_correctness_guidance()
         if value is None:
             return (
                 "## External pre-implementation correctness guidance\n\n"
-                "No valid external guidance is available. Derive every correctness requirement "
-                "directly from the public contract and immutable reference before editing.\n"
+                "No valid guidance from the configured reviewers is available. Derive every "
+                "correctness requirement directly from the public contract and immutable "
+                "reference before editing.\n"
             )
         reviews = value["reviews"]
         assert isinstance(reviews, dict)
+        reviewer_labels = [
+            "Qoder" if reviewer == "qodercli" else "Codex" for reviewer in reviewers
+        ]
         sections = [
             "## Mandatory external pre-implementation correctness guidance\n",
-            "Codex and Qoder independently reviewed the bounded public packet. Before editing "
-            "`kernel.py`, reconcile both reviews against the immutable reference. Shared "
-            "requirements are mandatory; reviewer suggestions never override the public contract.\n",
+            " and ".join(reviewer_labels)
+            + " reviewed the bounded public packet. Before editing `kernel.py`, reconcile the "
+            "available guidance against the immutable reference. Shared requirements are "
+            "mandatory; reviewer suggestions never override the public contract.\n",
         ]
-        for reviewer, label in (("codex", "Codex"), ("qodercli", "Qoder")):
+        for reviewer in reviewers:
+            label = "Qoder" if reviewer == "qodercli" else "Codex"
             record = reviews.get(reviewer)
             record = record if isinstance(record, dict) else {}
             sections.append(f"\n### {label}\n")
             if record.get("status") == "ok":
-                guidance = self._framework_baseline_guidance_without_reference_nominations(
-                    str(record.get("guidance", ""))
+                guidance = (
+                    self._framework_baseline_guidance_without_reference_nominations(
+                        str(record.get("guidance", ""))
+                    )
                 )
                 sections.append(guidance + "\n")
             else:
@@ -2094,7 +2177,7 @@ class Campaign:
                 assert isinstance(item, dict)
                 sections.append(
                     f"- `{item['path']}` — {item['purpose']} "
-                    f"(nominated by {item['votes']}/2 reviewers)\n"
+                    f"(nominated by {item['votes']}/{len(reviewers)} configured reviewers)\n"
                 )
             sections.append(
                 "Read only these exact files as static design evidence. Do not open sibling "

--- a/orchestrator/optimize.py
+++ b/orchestrator/optimize.py
@@ -5,7 +5,7 @@ Owns the OUTER optimization loop so termination no longer depends on the model's
 in-session judgment (the old Stage-6 "is README's Stop Conditions met?" self-call).
 
 Each optimization version is a long-horizon engineering episode in an isolated Git worktree.
-By default the first two post-baseline episodes use five reviewed fast plan/implement/evaluator
+By default the first two post-baseline episodes use five fast plan/implement/evaluator
 trials per episode;
 later episodes use the full profile/research/repair loop. The supervisor squash-promotes only a
 strict, correctness-passing improvement, using canonical-memory comparison in fast mode and a
@@ -447,6 +447,22 @@ def main(argv: Optional[list[str]] = None) -> int:
         metavar="REVIEWER",
         help="Reuse one reviewer session across episodes (implemented for codex and qoder).",
     )
+    for stage, stage_label in (
+        ("v1", "V1 framework-baseline"),
+        ("fast-episode", "fast episodes"),
+        ("full-episode", "full episodes"),
+    ):
+        default_enabled = stage == "full-episode"
+        for reviewer in ("codex", "qoder"):
+            ap.add_argument(
+                f"--{stage}-ask-{reviewer}",
+                action=argparse.BooleanOptionalAction,
+                default=default_enabled,
+                help=(
+                    f"Configure ask-{reviewer} for {stage_label} "
+                    f"(default: {'on' if default_enabled else 'off'})."
+                ),
+            )
     ap.add_argument(
         "--optimization-mode",
         choices=OPTIMIZATION_MODE_CHOICES,
@@ -676,6 +692,13 @@ def main(argv: Optional[list[str]] = None) -> int:
         f"sandbox_hardware={sandbox_hardware} "
         f"sandbox_endpoint={args.sandbox_url or args.sandbox_profile or 'agate-config'} "
         f"frameworks={','.join(frameworks)} "
+        "reviewers="
+        f"v1[codex={'on' if args.v1_ask_codex else 'off'},"
+        f"qoder={'on' if args.v1_ask_qoder else 'off'}],"
+        f"fast[codex={'on' if args.fast_episode_ask_codex else 'off'},"
+        f"qoder={'on' if args.fast_episode_ask_qoder else 'off'}],"
+        f"full[codex={'on' if args.full_episode_ask_codex else 'off'},"
+        f"qoder={'on' if args.full_episode_ask_qoder else 'off'}] "
         "runtime_arch="
         f"{arch or 'UNKNOWN (detect failed)'} "
         f"(device name / vendor-smi may be desensitized; trusting the runtime API)",
@@ -727,6 +750,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         verify_run_timeout=args.verify_run_timeout,
         min_improvement_pct=args.min_improvement_pct,
         long_reviewer_session=args.long_reviewer_session,
+        v1_ask_codex=args.v1_ask_codex,
+        v1_ask_qoder=args.v1_ask_qoder,
+        fast_episode_ask_codex=args.fast_episode_ask_codex,
+        fast_episode_ask_qoder=args.fast_episode_ask_qoder,
+        full_episode_ask_codex=args.full_episode_ask_codex,
+        full_episode_ask_qoder=args.full_episode_ask_qoder,
         convert_after=args.convert_after,
     )
     if latest_version(campaign.workspace) < 0:

--- a/orchestrator/plan_reviewers.py
+++ b/orchestrator/plan_reviewers.py
@@ -136,8 +136,9 @@ def _valid_cache(value: Any) -> bool:
     reviewers = value.get("reviewers")
     if not isinstance(reviewers, dict):
         return False
-    for name in _REVIEWER_SPECS:
-        record = reviewers.get(name)
+    if any(name not in _REVIEWER_SPECS for name in reviewers):
+        return False
+    for record in reviewers.values():
         if not isinstance(record, dict) or not isinstance(
             record.get("available"), bool
         ):
@@ -171,13 +172,35 @@ def discover_plan_reviewers(
     workspace: Path,
     *,
     agent_cli: str,
+    reviewers: tuple[str, ...] | None = None,
 ) -> tuple[dict[str, Any], bool]:
-    """Load a campaign's reviewer decision or probe each reviewer exactly once."""
+    """Load cached decisions and probe only newly requested reviewers."""
+    requested_names = tuple(_REVIEWER_SPECS if reviewers is None else reviewers)
+    unknown = set(requested_names) - set(_REVIEWER_SPECS)
+    if unknown:
+        raise ValueError(f"unknown plan reviewers: {', '.join(sorted(unknown))}")
+    requested_names = tuple(
+        name for name in _REVIEWER_SPECS if name in set(requested_names)
+    )
     workspace = workspace.resolve()
     cache_path = workspace / PLAN_REVIEWER_CACHE
     cached = _load_cache(cache_path)
-    if cached is not None:
+    if cached is not None and cached.get("agent_cli") != agent_cli:
+        cached = None
+    cached_reviewers = dict(cached["reviewers"]) if cached is not None else {}
+    missing_names = tuple(
+        name for name in requested_names if name not in cached_reviewers
+    )
+    if cached is not None and not missing_names:
         return cached, True
+    if not missing_names:
+        return {
+            "schema_version": PLAN_REVIEWER_CACHE_SCHEMA_VERSION,
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+            "agent_cli": agent_cli,
+            "probe_timeout_seconds": _probe_timeout(),
+            "reviewers": cached_reviewers,
+        }, False
 
     timeout_s = _probe_timeout()
     with tempfile.TemporaryDirectory(prefix="atrex-plan-reviewer-probe-") as directory:
@@ -198,7 +221,9 @@ def discover_plan_reviewers(
             "- Validation: every required response marker is present.\n",
             encoding="utf-8",
         )
-        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=len(missing_names)
+        ) as executor:
             futures = {
                 name: executor.submit(
                     _probe_reviewer,
@@ -209,16 +234,20 @@ def discover_plan_reviewers(
                     agent_cli,
                     timeout_s,
                 )
-                for name in _REVIEWER_SPECS
+                for name in missing_names
             }
-            reviewers = {name: future.result() for name, future in futures.items()}
+            probed_reviewers = {
+                name: future.result() for name, future in futures.items()
+            }
+
+    cached_reviewers.update(probed_reviewers)
 
     value = {
         "schema_version": PLAN_REVIEWER_CACHE_SCHEMA_VERSION,
         "checked_at": datetime.now(timezone.utc).isoformat(),
         "agent_cli": agent_cli,
         "probe_timeout_seconds": timeout_s,
-        "reviewers": reviewers,
+        "reviewers": cached_reviewers,
     }
     _write_cache(cache_path, value)
     return value, False
@@ -229,6 +258,8 @@ def plan_reviewer_environment(value: dict[str, Any]) -> dict[str, str]:
     reviewers = value["reviewers"]
     environment: dict[str, str] = {}
     for name, (enabled_name, reason_name) in REVIEWER_ENVIRONMENT.items():
+        if name not in reviewers:
+            continue
         record = reviewers[name]
         environment[enabled_name] = "1" if record["available"] else "0"
         environment[reason_name] = _single_line(record["reason"])

--- a/orchestrator/prompts/fast_episode.md
+++ b/orchestrator/prompts/fast_episode.md
@@ -44,9 +44,9 @@ canonical `memory/vN.json`; the supervisor writes and commits one for every term
 - Do not profile. Never use `--kind profile`, `ncu`, `rocprofv3`, a profile wrapper, or create
   profile artifacts.
 - Do not start a separate research phase or the full `gpu-kernel-episode-loop` skill. Every trial's
-  planning phase must use its configured `gen-plan` flow and external Codex/Qoder reviews; keep
-  their evidence bounded to `kernel.py`, the public operator contract, prior trial journal evidence,
-  and canonical `memory/v*.json`.
+  planning phase must use its configured `gen-plan` flow and whichever Codex/Qoder reviews are
+  enabled for fast episodes; keep their evidence bounded to `kernel.py`, the public operator
+  contract, prior trial journal evidence, and canonical `memory/v*.json`.
 - Do not run multi-seed validation and do not run or simulate incumbent/candidate ABBA.
 - Never run GPU/JIT code on the host. Static source inspection is allowed; the official evaluator
   command below is the only GPU execution route and must run once per trial.
@@ -77,8 +77,8 @@ Read that kernel, recent canonical memory, and the structured results of earlier
 episode. Pick one small, coherent implementation change that is not a verbatim repeat of a failed
 trial. Write the trial's unique draft with its hypothesis, exact code change, expected effect, and
 rollback condition. Then run the matching backend-native generator below. Every invocation obtains
-the configured external Codex/Qoder reviews and writes a unique synthesized plan. Use these exact
-per-trial paths:
+the enabled external Codex/Qoder reviews, records disabled reviewer statuses, and writes a unique
+synthesized plan. Use these exact per-trial paths:
 
 {{FAST_TRIAL_PLAN_PATHS}}
 
@@ -89,9 +89,9 @@ paths with the corresponding unique paths above, while retaining direct/no-discu
 
 For trial `N`, use only the `Trial N` generator and the resulting
 `plans/v{{VERSION}}_trialN_plan.md`. Read it before editing and implement only its final bounded
-direction. An external reviewer that the campaign's availability probe explicitly disabled may be
-recorded as unavailable; do not replace it with an ad-hoc research phase. Do not collect profile
-data.
+direction. A reviewer disabled by episode configuration or by the campaign's availability probe
+must be recorded as disabled; do not replace it with an ad-hoc research phase. Do not collect
+profile data.
 
 ### 2. Implement — once per trial
 

--- a/skills/gen-plan/SKILL.md
+++ b/skills/gen-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gen-plan
-description: Generate a structured implementation plan from an evidence draft. Validate paths, obtain independent Codex and Qoder reviews, synthesize their advice against repository evidence, preserve the draft, and produce testable acceptance criteria and validation steps.
+description: Generate a structured implementation plan from an evidence draft. Validate paths, obtain configured independent Codex and Qoder reviews, synthesize available advice against repository evidence, preserve the draft, and produce testable acceptance criteria and validation steps.
 ---
 
 # Generate Plan
@@ -24,10 +24,10 @@ implementation.
 - During this workflow, persist only the requested plan file. Consultation helpers may use
   automatically removed process scratch for isolation.
 - Do not edit source, run implementation tasks, create commits, or start another workflow.
-- The `ask_codex` and `ask_qoder` consultations are read-only. They are non-persistent by default;
-  an explicitly configured long Codex or Qoder reviewer session remains read-only and
-  campaign-private. Give both reviewers the same candidate proposal and bounded evidence packet,
-  isolate both from the project, and disable Qoder tools.
+- Enabled `ask_codex` and `ask_qoder` consultations are read-only. They are non-persistent by
+  default; an explicitly configured long Codex or Qoder reviewer session remains read-only and
+  campaign-private. Give every enabled reviewer the same candidate proposal and bounded evidence
+  packet, isolate both from the project, and disable Qoder tools.
 - Preserve every requirement, constraint, measurement, search result, and rejected direction from
   the draft. The structured plan must be a superset of the draft.
 - Keep the original draft verbatim at the bottom of the plan between the template markers.
@@ -79,20 +79,20 @@ In `direct` mode, make conservative assumptions and record unresolved material c
 `Pending Decisions`; do not pause for questions. In `discussion` mode, ask only questions whose
 answers materially change scope, correctness, or acceptance.
 
-### 4. Obtain independent Codex and Qoder reviews
+### 4. Obtain configured independent reviews
 
-The campaign probes both optional reviewers once before the first optimization episode and caches
-the decision in its private runtime state. A reviewer disabled by that startup probe must not be
-retried by later plans in the same campaign; retain the helper's
-`disabled_after_startup_probe` status and recorded reason. Campaign restarts reuse the same cached
-decision.
+The campaign independently configures Codex and Qoder for fast and full episodes. It probes a
+reviewer only when that reviewer is first enabled for the current episode mode, then caches the
+availability decision in private runtime state. A reviewer disabled by configuration or by its
+availability probe must not be retried; retain the helper's `disabled` status and recorded reason.
+Campaign restarts reuse cached availability decisions.
 
-After completing the initial analysis, freeze one evidence packet and use the bundled dual-review
-helper before finalizing the plan direction. Give both reviewers the candidate proposal, original
-draft, and the same small set of directly relevant text files, normally `README.md`, `kernel.py`, the
-latest canonical memory entry, and source or profile summaries cited by the draft. The candidate is
-the primary review target; the draft and context are evidence for testing its claims. Never include
-credentials, raw secrets, unrelated files, or large binary profile artifacts.
+After completing the initial analysis, freeze one evidence packet and use the bundled review helper
+before finalizing the plan direction. Give every enabled reviewer the candidate proposal, original
+draft, and the same small set of directly relevant text files, normally `README.md`, `kernel.py`,
+the latest canonical memory entry, and source or profile summaries cited by the draft. The candidate
+is the primary review target; the draft and context are evidence for testing its claims. Never
+include credentials, raw secrets, unrelated files, or large binary profile artifacts.
 
 ```bash
 bash skills/gen-plan/scripts/ask-reviewers.sh \
@@ -104,13 +104,13 @@ bash skills/gen-plan/scripts/ask-reviewers.sh \
 
 `--proposal` is required and must name the non-empty frozen candidate proposal in process scratch.
 Add other `--context` arguments only when they materially affect the plan. The helper starts the
-applicable external reviewers concurrently so neither can see or anchor on the other's response.
+enabled external reviewers concurrently so neither can see or anchor on the other's response.
 When proposal, draft, and context would exceed Qoder's five-attachment limit, the helper folds all
-context files into one labeled temporary bundle and gives that identical bundle to both reviewers.
-Do not manually remove evidence or issue a second full dual-review call. For an eligible transient
-failure, the helper retries only the failed reviewer once; it does not rerun a successful reviewer
-and does not retry quota, authentication, timeout, disabled, or missing-CLI failures.
-Both external reviewer processes always use maximum reasoning effort; episode/session settings,
+context files into one labeled temporary bundle and gives that identical bundle to every enabled
+reviewer. Do not manually remove evidence or issue a second full review call. For an eligible
+transient failure, the helper retries only the failed reviewer once; it does not rerun a successful
+reviewer and does not retry quota, authentication, timeout, disabled, or missing-CLI failures.
+Enabled external reviewer processes always use maximum reasoning effort; episode/session settings,
 reviewer effort environment variables, and legacy `--reasoning-effort` arguments cannot lower it.
 By default each external review is ephemeral. `--long-reviewer-session codex` or
 `--long-reviewer-session qoder` resumes one campaign-private, read-only reviewer thread across
@@ -130,24 +130,29 @@ sections:
 - `VALIDATION_RECOMMENDATIONS`
 - `QUESTIONS_OR_ASSUMPTIONS`
 
-If the current episode backend is Codex or Qoder, first review the frozen candidate proposal and
-retain that backend's review in the current session using the same sections. Only then run the
-helper; it skips the matching nested process and obtains the other backend's independent review.
-Mark the retained review status
-`current_codex_session` or `current_qoder_session`. Do not revise it after seeing the external review;
-resolve new information only during synthesis. Claude and Pi backends use both external reviewers.
+If the current episode backend is Codex or Qoder and its matching
+`ATREX_PLAN_REVIEW_*_ENABLED` value is not `0`, first review the frozen candidate proposal and retain
+that backend's review in the current session using the same sections. Only then run the helper; it
+skips the matching nested process and obtains any other enabled backend's independent review. Mark
+the retained review status `current_codex_session` or `current_qoder_session`. Do not revise it after
+seeing the external review; resolve new information only during synthesis. If the matching reviewer
+is disabled, do not create an in-session substitute review; let the helper record `disabled`.
 
-After the helper's selective retry, if either reviewer is unavailable, times out, or fails, do not
-fabricate its advice or rerun the successful reviewer. In `direct` mode, continue with the available
-review and conservative analysis, recording each status and failure reason. If both fail, continue
-using only the primary analysis and label the result as unreviewed. In `discussion` mode, ask whether
-to retry only the failed reviewer or continue with partial or no independent review.
+After the helper's selective retry, if an enabled reviewer is unavailable, times out, or fails, do
+not fabricate its advice or rerun the successful reviewer. In `direct` mode, continue with the
+available review and conservative analysis, recording each status and failure reason. If every
+enabled reviewer fails, continue using only the primary analysis and label the result as unreviewed.
+In `discussion` mode, ask whether to retry only the failed reviewer or continue with partial or no
+independent review. A reviewer explicitly marked `disabled` is not a failure and must not trigger a
+retry question. If every reviewer is disabled, continue with primary analysis and label the plan as
+intentionally unreviewed.
 
-### 5. Synthesize both reviews and generate the plan
+### 5. Synthesize available reviews and generate the plan
 
-Compare the Codex and Qoder reviews only after both have completed. Treat agreement as a useful
-confidence signal, not proof, and resolve disagreement from the original draft and repository
-evidence rather than by majority vote. Evaluate every recommendation as follows:
+Compare all available reviews only after the helper has completed. When both are enabled, treat
+agreement as a useful confidence signal, not proof, and resolve disagreement from the original
+draft and repository evidence rather than by majority vote. Evaluate every recommendation as
+follows:
 
 1. Adopt a suggestion only when it strengthens the selected evidence-to-action chain, closes a
    correctness gap, or makes validation more deterministic.
@@ -163,15 +168,16 @@ Record how the frozen candidate changed after review. Every material correction 
 reviewer and supporting evidence; if the candidate remains unchanged, state why the reviews did not
 justify a change.
 
-Both reviewers are advisory, not authoritative. The final plan must remain a superset of the human
-draft and must still contain exactly one optimization category.
+Available reviewers are advisory, not authoritative. The final plan must remain a superset of the
+human draft and must still contain exactly one optimization category.
 
 Use `skills/gen-plan/templates/gen-plan-template.md` as the output schema. Replace every placeholder
 with concrete content. The plan must include:
 
 - the goal and the profile/research evidence that motivates it;
-- Codex and Qoder consultation status, their material findings, agreements, disagreements, and the
-  suggestions adopted, rejected, or deferred with reasons;
+- Codex and Qoder consultation status (including configured-disabled status), available material
+  findings, agreements, disagreements, and the suggestions adopted, rejected, or deferred with
+  reasons;
 - exactly one optimization category and its evidence-to-inference-to-action chain;
 - acceptance criteria in `AC-N` form, each with positive and negative tests;
 - upper and lower scope boundaries plus allowed and prohibited choices;
@@ -190,7 +196,8 @@ must not be prescribed as implementation naming.
 Before writing, verify that the plan:
 
 - does not omit or contradict the draft;
-- uses both reviews selectively and records the disposition of material suggestions and conflicts;
+- uses available reviews selectively and records the disposition of material suggestions and
+  conflicts;
 - records the frozen candidate and the evidence-based changes made after review;
 - proposes only one attributable optimization category;
 - names concrete files and validation commands;

--- a/skills/gen-plan/scripts/ask-codex.sh
+++ b/skills/gen-plan/scripts/ask-codex.sh
@@ -82,13 +82,6 @@ for ((index = 0; index < ${#context_files[@]}; index++)); do
     fi
 done
 
-# A Codex-owned episode already has Codex's analysis available in the current session. Starting a
-# second Codex process would add recursion without providing an independent backend perspective.
-if [[ "${ATREX_AGENT_CLI:-}" == "codex" ]]; then
-    echo "ASK_CODEX_SKIPPED: current agent backend is codex; use the current session's review"
-    exit 0
-fi
-
 reviewer_enabled="${ATREX_PLAN_REVIEW_CODEX_ENABLED:-}"
 reviewer_reason="${ATREX_PLAN_REVIEW_CODEX_REASON:-}"
 if [[ -z "$reviewer_enabled" ]]; then
@@ -101,8 +94,15 @@ if [[ -z "$reviewer_enabled" ]]; then
     fi
 fi
 if [[ "$reviewer_enabled" == "0" ]]; then
-    reason="${reviewer_reason:-disabled by the campaign startup probe}"
+    reason="${reviewer_reason:-disabled by campaign configuration or availability probe}"
     echo "ASK_CODEX_DISABLED: $reason"
+    exit 0
+fi
+
+# A Codex-owned episode already has Codex's analysis available in the current session. Starting a
+# second Codex process would add recursion without providing an independent backend perspective.
+if [[ "${ATREX_AGENT_CLI:-}" == "codex" ]]; then
+    echo "ASK_CODEX_SKIPPED: current agent backend is codex; use the current session's review"
     exit 0
 fi
 

--- a/skills/gen-plan/scripts/ask-qoder.sh
+++ b/skills/gen-plan/scripts/ask-qoder.sh
@@ -97,14 +97,6 @@ fi
 for ((index = 0; index < ${#context_files[@]}; index++)); do
     context_files[index]="$(to_absolute "${context_files[$index]}")"
 done
-
-# A Qoder-owned episode already has Qoder's analysis available in the current session. Starting a
-# second Qoder process would add recursion without providing an independent backend perspective.
-if [[ "${ATREX_AGENT_CLI:-}" == "qodercli" ]]; then
-    echo "ASK_QODER_SKIPPED: current agent backend is qodercli; use the current session's review"
-    exit 0
-fi
-
 reviewer_enabled="${ATREX_PLAN_REVIEW_QODER_ENABLED:-}"
 reviewer_reason="${ATREX_PLAN_REVIEW_QODER_REASON:-}"
 if [[ -z "$reviewer_enabled" ]]; then
@@ -117,8 +109,15 @@ if [[ -z "$reviewer_enabled" ]]; then
     fi
 fi
 if [[ "$reviewer_enabled" == "0" ]]; then
-    reason="${reviewer_reason:-disabled by the campaign startup probe}"
+    reason="${reviewer_reason:-disabled by campaign configuration or availability probe}"
     echo "ASK_QODER_DISABLED: $reason"
+    exit 0
+fi
+
+# A Qoder-owned episode already has Qoder's analysis available in the current session. Starting a
+# second Qoder process would add recursion without providing an independent backend perspective.
+if [[ "${ATREX_AGENT_CLI:-}" == "qodercli" ]]; then
+    echo "ASK_QODER_SKIPPED: current agent backend is qodercli; use the current session's review"
     exit 0
 fi
 

--- a/skills/gen-plan/scripts/ask-reviewers.sh
+++ b/skills/gen-plan/scripts/ask-reviewers.sh
@@ -187,7 +187,7 @@ def run_reviewer(spec, reviewer_args):
     if completed.returncode == 0 and stdout.startswith(skip_marker):
         status = f"current_{name.lower()}_session"
     elif completed.returncode == 0 and stdout.startswith(disabled_marker):
-        status = "disabled_after_startup_probe"
+        status = "disabled"
     elif completed.returncode == 0:
         status = "completed"
     else:

--- a/skills/gen-plan/templates/gen-plan-template.md
+++ b/skills/gen-plan/templates/gen-plan-template.md
@@ -21,17 +21,17 @@
 
 ### Codex Findings
 
-- Consultation status: <completed, current_codex_session, or unavailable with reason>
+- Consultation status: <completed, current_codex_session, disabled, or unavailable with reason>
 - Material findings: <concise Codex risks, gaps, direction, and validation advice>
 
 ### Qoder Findings
 
-- Consultation status: <completed, current_qoder_session, or unavailable with reason>
+- Consultation status: <completed, current_qoder_session, disabled, or unavailable with reason>
 - Material findings: <concise Qoder risks, gaps, direction, and validation advice>
 
 ### Cross-Reviewer Synthesis
 
-- Agreements: <where both reviews align and the supporting repository evidence>
+- Agreements: <where available reviews align and the supporting evidence, or not applicable>
 - Disagreements resolved: <conflict, selected disposition, and decisive evidence>
 - Candidate changes after review: <evidence-based corrections, or why no change was justified>
 - Adopted suggestions: <suggestion, source reviewer or both, and supporting evidence>

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -1786,24 +1786,6 @@ def _typed_fallback_allowed(detail: object) -> bool:
     return any(reason in text for reason in TYPED_FALLBACK_REASONS)
 
 
-def _typed_source_validation_failure(detail: object) -> bool:
-    text = str(detail).lower()
-    return "source validation failed" in text or "invalid_source" in text
-
-
-def _typed_source_validation_diagnostic(detail: object) -> str:
-    lines = [line.strip() for line in str(detail).splitlines() if line.strip()]
-    relevant = [
-        line
-        for line in lines
-        if line.startswith("blocked imports:")
-        or line.startswith("-")
-        or "source validation failed" in line.lower()
-        or "invalid_source" in line.lower()
-    ]
-    return " | ".join((relevant or lines)[:12])[:2000]
-
-
 def _finite_number(value: object) -> float | None:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return None
@@ -2635,44 +2617,6 @@ def _run_typed_gateway(
     jobs: list[dict[str, Any]] = []
     for proc in processes:
         detail = (proc.stderr or "") + (proc.stdout or "")
-        if proc.returncode and generalized and _typed_source_validation_failure(
-            detail
-        ):
-            diagnostic = _typed_source_validation_diagnostic(detail)
-            result = _mask_generalized_result(
-                workspace,
-                {
-                    "all_pass": False,
-                    "failures": [f"candidate source validation failed: {diagnostic}"],
-                    "latency_us_geomean": 0.0,
-                    "latency_us_arith_mean": 0.0,
-                    "latency_us_by_shape": {},
-                    "speedup_vs_ref_mean": None,
-                    "speedup_vs_ref_geomean": None,
-                    "performance_score": None,
-                    "performance_objective": PERFORMANCE_OBJECTIVE,
-                    "max_abs_err": 0.0,
-                    "max_rel_err": 0.0,
-                    "evaluator": "atrex-gpu-gateway/run/source-validation",
-                    "eval_id": None,
-                    "actionable_diagnostics": [
-                        {
-                            "stage": "candidate_source",
-                            "message": diagnostic,
-                        }
-                    ],
-                },
-            )
-            _record_episode_evaluation(workspace, result, gateway_kind=kind)
-            print(
-                "[sandbox] candidate source validation failed: " + diagnostic,
-                file=sys.stderr,
-            )
-            print(
-                TEST_RESULT_PREFIX
-                + json.dumps(result, ensure_ascii=False, allow_nan=False)
-            )
-            return proc.returncode
         if proc.returncode and _typed_fallback_allowed(detail):
             print(
                 f"[sandbox] gateway {kind} interface rejected this request; using dev",


### PR DESCRIPTION
## Summary

- add independent Codex and Qoder switches for V1, fast episodes, and full episodes
- default V1 and fast reviewers off while keeping full reviewers on
- discover and cache only the reviewers enabled for the active episode mode, including partial and explicitly disabled reviewer states
- make gen-plan synthesis work with both, one, or no enabled external reviewers while preserving persistent Codex and Qoder reviewer sessions
- run the primary fast-mode Agent at maximum reasoning effort
- let generalized typed source-validation rejections fall back to the dev evaluator path so production-policy review can judge dynamic loaders and dependency provenance semantically

## Validation

- python3 -m py_compile orchestrator/optimize.py orchestrator/campaign.py orchestrator/plan_reviewers.py long_horizon/campaign.py
- bash -n skills/gen-plan/scripts/ask-codex.sh
- bash -n skills/gen-plan/scripts/ask-qoder.sh
- bash -n skills/gen-plan/scripts/ask-reviewers.sh
- python3 orchestrator/optimize.py --help
- git diff --check alibaba/main...HEAD