### PR TITLE
feat(long-horizon): record GPU Wiki attribution

### DIFF
--- a/gpu-wiki/AGENTS.md
+++ b/gpu-wiki/AGENTS.md
@@ -32,6 +32,10 @@ Do not pre-compress into keywords.
 Read each record's `source`, `type`, `match.arch`, and isolated `payload`, plus
 deterministic `notes`. Evidence and bridge commentary are not served.
 
+For attribution, copy the response's top-level `query_id` and each materially
+used record's own canonical `wiki_id`; never reconstruct either value from prose
+or from the backward-compatible mapping key.
+
 When a returned record materially informs an optimization decision, preserve its
 stable mapping key in that iteration's `memory/vN.json` under
 `wiki_references.kernel_wiki` or `wiki_references.hardware_wiki`. Retrieval alone

--- a/gpu-wiki/README.md
+++ b/gpu-wiki/README.md
@@ -138,13 +138,15 @@ most one fresh repair attempt after strict local validation. `claude` is the
 default agent CLI and `qodercli` is also supported; a CLI without a verified
 no-tools protocol is rejected.
 
-The consuming agent receives only two top-level fields:
+The consuming agent receives a per-invocation attribution id plus records and notes:
 
 ```json
 {
+  "query_id": "wiki-query-0123456789abcdef0123456789abcdef",
   "records": {
     "stable.record.id": {
       "store": "gpu_wiki",
+      "wiki_id": "gpu_wiki::stable.record.id",
       "source": "kernel_wiki",
       "type": "technique-card",
       "applies_to": {},
@@ -156,10 +158,12 @@ The consuming agent receives only two top-level fields:
 }
 ```
 
-Record IDs are stable mapping keys, and every payload remains an independent JSON
-value. Evidence, retrieval metadata, rank decomposition, bridge commentary, and
-other engine-side fields are deliberately not served, so they cannot anchor AKA's
-judgement.
+Record IDs remain stable, backward-compatible mapping keys, and every payload is
+an independent JSON value. For attribution, consumers copy the top-level
+`query_id` and a record's own canonical `wiki_id` exactly rather than reconstructing
+them from mapping keys. Evidence, retrieval metadata, rank decomposition, bridge
+commentary, and other engine-side fields are deliberately not served, so they
+cannot anchor AKA's judgement.
 
 ### Direct structured queries
 

--- a/gpu-wiki/tools/query_nl.py
+++ b/gpu-wiki/tools/query_nl.py
@@ -11,12 +11,12 @@ query any store. This script owns every
 deterministic operation after that point: vocabulary normalization, staged
 widening, execution, deduplication, projection and context limits.
 
-The output intentionally has only two top-level fields: records and notes.
-Records from kernel experience and hardware facts share one id-keyed mapping,
-while each payload remains an independent JSON value under its own stable id. The
-public store is always queried; an installed sibling ``internal_gpu_wiki`` is
-queried as a second isolated store. Internal ids are namespaced so a private
-record can never overwrite a public record with the same stable id.
+The output has a per-invocation ``query_id``, plus records and notes. Records
+from kernel experience and hardware facts share one backward-compatible id-keyed
+mapping, while every value emits its canonical ``store::record`` ``wiki_id``.
+The public store is always queried; an installed sibling ``internal_gpu_wiki``
+is queried as a second isolated store. Internal mapping keys are namespaced so a
+private record can never overwrite a public record with the same stable id.
 """
 from __future__ import annotations
 
@@ -28,6 +28,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -1032,6 +1033,7 @@ def merge_store_records(
             served_id = rid if store == PUBLIC_STORE else "%s::%s" % (store, rid)
             entry = dict(raw_entry)
             entry["store"] = store
+            entry["wiki_id"] = "%s::%s" % (store, rid)
             merged[served_id] = entry
             if max_records and len(merged) >= max_records:
                 remaining = sum(1 for _, records in groups for _ in records) - len(merged)
@@ -1042,6 +1044,7 @@ def merge_store_records(
 
 
 def main(argv=None) -> int:
+    query_id = "wiki-query-%s" % uuid.uuid4().hex
     started_at = datetime.now(timezone.utc)
     started = time.perf_counter()
     bridge_ms = None
@@ -1228,7 +1231,11 @@ def main(argv=None) -> int:
             records_by_source[source] = records_by_source.get(source, 0) + 1
             store = str(entry.get("store") or "unknown")
             records_by_store[store] = records_by_store.get(store, 0) + 1
-        print(json.dumps({"records": records, "notes": notes}, ensure_ascii=False))
+        print(json.dumps({
+            "query_id": query_id,
+            "records": records,
+            "notes": notes,
+        }, ensure_ascii=False))
         status = "ok"
         return 0
     finally:
@@ -1239,6 +1246,7 @@ def main(argv=None) -> int:
             shutil.rmtree(workspace, ignore_errors=True)
         finished_at = datetime.now(timezone.utc)
         _append_metric(os.environ.get(METRICS_LOG_ENV), {
+            "query_id": query_id,
             "task_id": os.environ.get(TASK_ID_ENV),
             "pid": os.getpid(),
             "status": status,

--- a/gpu-wiki/tools/test_query_nl.py
+++ b/gpu-wiki/tools/test_query_nl.py
@@ -351,9 +351,10 @@ class FrontDoorTests(unittest.TestCase):
         self.assertEqual(code, 0, err)
         return json.loads(out)
 
-    def test_output_has_only_records_and_notes(self):
+    def test_output_emits_attribution_ids_with_records_and_notes(self):
         answer = self._answer(stub_intent())
-        self.assertEqual(set(answer), {"records", "notes"})
+        self.assertEqual(set(answer), {"query_id", "records", "notes"})
+        self.assertRegex(answer["query_id"], r"^wiki-query-[0-9a-f]{32}$")
 
     def test_records_are_id_keyed_lightweight_and_payload_is_exact(self):
         answer = self._answer(stub_intent(free_text_terms=[]), "--max-records", "3")
@@ -362,12 +363,15 @@ class FrontDoorTests(unittest.TestCase):
         paths = {e["id"]: e["path"] for e in index["records"]}
         for rid, entry in answer["records"].items():
             self.assertEqual(set(entry), {
-                "store", "source", "type", "applies_to", "match", "payload",
+                "store", "wiki_id", "source", "type", "applies_to", "match",
+                "payload",
             })
             self.assertIn(entry["store"], {
                 query_nl.PUBLIC_STORE, query_nl.INTERNAL_STORE,
             })
             self.assertNotIn("evidence", json.dumps(entry))
+            raw_id = rid.split("::", 1)[1] if "::" in rid else rid
+            self.assertEqual(entry["wiki_id"], f"{entry['store']}::{raw_id}")
             if (entry["source"] == "kernel_wiki"
                     and entry["store"] == query_nl.PUBLIC_STORE):
                 stored = json.loads((STORE / "kernel_wiki" / paths[rid]).read_text())
@@ -420,6 +424,9 @@ class FrontDoorTests(unittest.TestCase):
             row["store"] == query_nl.INTERNAL_STORE for row in records.values()))
         self.assertTrue(any(
             rid.startswith(query_nl.INTERNAL_STORE + "::") for rid in records))
+        for rid, row in records.items():
+            raw_id = rid.split("::", 1)[1] if "::" in rid else rid
+            self.assertEqual(row["wiki_id"], f"{row['store']}::{raw_id}")
         self.assertLessEqual(len(records), 6)
 
     def test_unknown_product_field_falls_back_to_complete_product_record(self):
@@ -475,7 +482,7 @@ class LauncherTests(unittest.TestCase):
             )
         self.assertEqual(code, 0, err)
         self.assertEqual(bridge.clis, ["claude"])
-        self.assertEqual(set(json.loads(out)), {"records", "notes"})
+        self.assertEqual(set(json.loads(out)), {"query_id", "records", "notes"})
         self.assertNotIn("query_bridge_agent/SKILL.md", bridge.prompts[0])
 
     def test_plain_json_result_exposes_bridge_telemetry(self):
@@ -544,8 +551,10 @@ class LauncherTests(unittest.TestCase):
                         "fused rmsnorm in triton on sm_100", "--store-root", str(STORE),
                         "--max-records", "1")
                 self.assertEqual(code, 0, err)
-                self.assertEqual(set(json.loads(out)), {"records", "notes"})
+                answer = json.loads(out)
+                self.assertEqual(set(answer), {"query_id", "records", "notes"})
                 metric = json.loads(log.read_text(encoding="utf-8"))
+                self.assertEqual(metric["query_id"], answer["query_id"])
                 self.assertEqual(metric["task_id"], "test-op")
                 self.assertEqual(metric["status"], "ok")
                 self.assertEqual(metric["record_count"], 1)

--- a/long_horizon/journal.py
+++ b/long_horizon/journal.py
@@ -11,6 +11,17 @@ from .models import TERMINAL_STATUSES
 from .protocol import atomic_write_json
 
 
+WIKI_USAGE_DISPOSITIONS = {
+    "applied",
+    "partially_applied",
+    "reference_only",
+    "rejected",
+}
+WIKI_USAGE_STATUSES = {"declared", "no_material_use", "not_queried"}
+EVALUATION_CORRECTNESS = {"pass", "fail", "unknown"}
+EVALUATION_PERFORMANCE = {"improved", "not_improved", "unknown"}
+
+
 def utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -151,6 +162,137 @@ def load(path: Path) -> dict[str, Any]:
     return value
 
 
+def normalize_wiki_usage(raw: object) -> tuple[list[dict[str, str]], list[str]]:
+    """Validate Wiki attribution without putting telemetry on the promotion path."""
+    if not isinstance(raw, list):
+        return [], ["wiki_usage must be a list"]
+    normalized: list[dict[str, str]] = []
+    errors: list[str] = []
+    for index, row in enumerate(raw):
+        label = f"wiki_usage[{index}]"
+        if not isinstance(row, dict):
+            errors.append(f"{label} must be an object")
+            continue
+        query_id = row.get("query_id")
+        wiki_id = row.get("wiki_id")
+        disposition = row.get("disposition")
+        use = row.get("use", "")
+        evidence = row.get("evidence", "")
+        if not isinstance(query_id, str) or not query_id.strip():
+            errors.append(f"{label}.query_id must be a non-empty string")
+            continue
+        if not isinstance(wiki_id, str) or not wiki_id.strip():
+            errors.append(f"{label}.wiki_id must be a non-empty string")
+            continue
+        if disposition not in WIKI_USAGE_DISPOSITIONS:
+            errors.append(
+                f"{label}.disposition must be one of "
+                + ", ".join(sorted(WIKI_USAGE_DISPOSITIONS))
+            )
+            continue
+        if not isinstance(use, str) or not isinstance(evidence, str):
+            errors.append(f"{label}.use and {label}.evidence must be strings")
+            continue
+        normalized.append({
+            "query_id": query_id.strip(),
+            "wiki_id": wiki_id.strip(),
+            "disposition": disposition,
+            "use": use.strip(),
+            "evidence": evidence.strip(),
+        })
+    return normalized, errors
+
+
+def normalize_experiment_evaluation(raw: object) -> tuple[dict[str, Any] | None, list[str]]:
+    """Normalize the bounded outcome fields used for Wiki effectiveness joins."""
+    if not isinstance(raw, dict):
+        return None, ["evaluation must be an object"]
+    correctness = raw.get("correctness")
+    performance = raw.get("performance")
+    errors: list[str] = []
+    if correctness not in EVALUATION_CORRECTNESS:
+        errors.append(
+            "evaluation.correctness must be one of "
+            + ", ".join(sorted(EVALUATION_CORRECTNESS))
+        )
+    if performance not in EVALUATION_PERFORMANCE:
+        errors.append(
+            "evaluation.performance must be one of "
+            + ", ".join(sorted(EVALUATION_PERFORMANCE))
+        )
+    latency_us = raw.get("latency_us")
+    if latency_us is not None and (
+        isinstance(latency_us, bool) or not isinstance(latency_us, (int, float))
+        or latency_us < 0
+    ):
+        errors.append("evaluation.latency_us must be a non-negative number or null")
+    kernel_hash = raw.get("kernel_hash")
+    if kernel_hash is not None and not isinstance(kernel_hash, str):
+        errors.append("evaluation.kernel_hash must be a string or null")
+    if errors:
+        return None, errors
+    return {
+        "correctness": correctness,
+        "performance": performance,
+        "latency_us": latency_us,
+        "kernel_hash": kernel_hash.strip() if isinstance(kernel_hash, str) else None,
+    }, []
+
+
+def normalize_wiki_attribution(entry: dict[str, Any]) -> None:
+    """Apply the explicit use/no-use contract while preserving legacy declarations."""
+    raw_usage_present = "wiki_usage" in entry
+    errors: list[str] = []
+    if raw_usage_present:
+        entry["wiki_usage"], usage_errors = normalize_wiki_usage(entry["wiki_usage"])
+        errors.extend(usage_errors)
+    raw_query_ids = entry.get("wiki_query_ids")
+    query_ids: list[str] = []
+    if raw_query_ids is not None:
+        if not isinstance(raw_query_ids, list) or any(
+            not isinstance(item, str) or not item.strip() for item in raw_query_ids
+        ):
+            errors.append("wiki_query_ids must be a list of non-empty strings")
+        else:
+            query_ids = list(dict.fromkeys(item.strip() for item in raw_query_ids))
+            entry["wiki_query_ids"] = query_ids
+    usage_query_ids = list(dict.fromkeys(
+        row["query_id"] for row in entry.get("wiki_usage", [])
+        if isinstance(row, dict) and row.get("query_id")
+    ))
+    status = entry.get("wiki_usage_status")
+    if status is None and entry.get("wiki_usage"):
+        # Compatibility for journals written before the explicit status contract.
+        status = "declared"
+        entry["wiki_usage_status"] = status
+        entry["wiki_usage_status_inferred"] = True
+    elif status is not None and status not in WIKI_USAGE_STATUSES:
+        errors.append(
+            "wiki_usage_status must be one of "
+            + ", ".join(sorted(WIKI_USAGE_STATUSES))
+        )
+    if status == "declared" and not entry.get("wiki_usage"):
+        errors.append("wiki_usage_status=declared requires at least one valid wiki_usage row")
+    if status == "declared":
+        if not query_ids:
+            query_ids = usage_query_ids
+            entry["wiki_query_ids"] = query_ids
+        elif not set(usage_query_ids).issubset(query_ids):
+            errors.append("wiki_query_ids must include every wiki_usage query_id")
+    if status == "no_material_use" and not query_ids:
+        errors.append("wiki_usage_status=no_material_use requires non-empty wiki_query_ids")
+    if status in {"no_material_use", "not_queried"} and entry.get("wiki_usage"):
+        errors.append(f"wiki_usage_status={status} requires an empty or omitted wiki_usage")
+    if status == "not_queried" and query_ids:
+        errors.append("wiki_usage_status=not_queried requires empty or omitted wiki_query_ids")
+    if errors:
+        existing = entry.get("wiki_usage_errors")
+        entry["wiki_usage_errors"] = [
+            *([str(item) for item in existing] if isinstance(existing, list) else []),
+            *errors,
+        ]
+
+
 def append_experiment(
     path: Path,
     experiment: dict[str, Any],
@@ -163,6 +305,11 @@ def append_experiment(
     if not isinstance(experiment, dict) or not experiment:
         raise ValueError("experiment must be a non-empty JSON object")
     entry = dict(experiment)
+    normalize_wiki_attribution(entry)
+    if "evaluation" in entry:
+        entry["evaluation"], errors = normalize_experiment_evaluation(entry["evaluation"])
+        if errors:
+            entry["evaluation_errors"] = errors
     entry.setdefault("timestamp", utc_now())
     experiments = value.setdefault("experiments", [])
     if not isinstance(experiments, list):

--- a/long_horizon/journal.py
+++ b/long_horizon/journal.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -20,6 +22,10 @@ WIKI_USAGE_DISPOSITIONS = {
 WIKI_USAGE_STATUSES = {"declared", "no_material_use", "not_queried"}
 EVALUATION_CORRECTNESS = {"pass", "fail", "unknown"}
 EVALUATION_PERFORMANCE = {"improved", "not_improved", "unknown"}
+QUERY_ID_RE = re.compile(r"wiki-query-[0-9a-f]{32}")
+WIKI_ID_RE = re.compile(
+    r"(?:gpu_wiki|internal_gpu_wiki)::[A-Za-z0-9][A-Za-z0-9._:-]*"
+)
 
 
 def utc_now() -> str:
@@ -178,11 +184,11 @@ def normalize_wiki_usage(raw: object) -> tuple[list[dict[str, str]], list[str]]:
         disposition = row.get("disposition")
         use = row.get("use", "")
         evidence = row.get("evidence", "")
-        if not isinstance(query_id, str) or not query_id.strip():
-            errors.append(f"{label}.query_id must be a non-empty string")
+        if not isinstance(query_id, str) or not QUERY_ID_RE.fullmatch(query_id.strip()):
+            errors.append(f"{label}.query_id must be an emitted Wiki query_id")
             continue
-        if not isinstance(wiki_id, str) or not wiki_id.strip():
-            errors.append(f"{label}.wiki_id must be a non-empty string")
+        if not isinstance(wiki_id, str) or not WIKI_ID_RE.fullmatch(wiki_id.strip()):
+            errors.append(f"{label}.wiki_id must be an emitted canonical store::record id")
             continue
         if disposition not in WIKI_USAGE_DISPOSITIONS:
             errors.append(
@@ -224,6 +230,7 @@ def normalize_experiment_evaluation(raw: object) -> tuple[dict[str, Any] | None,
     if latency_us is not None and (
         isinstance(latency_us, bool) or not isinstance(latency_us, (int, float))
         or latency_us < 0
+        or (isinstance(latency_us, float) and not math.isfinite(latency_us))
     ):
         errors.append("evaluation.latency_us must be a non-negative number or null")
     kernel_hash = raw.get("kernel_hash")
@@ -250,9 +257,10 @@ def normalize_wiki_attribution(entry: dict[str, Any]) -> None:
     query_ids: list[str] = []
     if raw_query_ids is not None:
         if not isinstance(raw_query_ids, list) or any(
-            not isinstance(item, str) or not item.strip() for item in raw_query_ids
+            not isinstance(item, str) or not QUERY_ID_RE.fullmatch(item.strip())
+            for item in raw_query_ids
         ):
-            errors.append("wiki_query_ids must be a list of non-empty strings")
+            errors.append("wiki_query_ids must contain only emitted Wiki query_ids")
         else:
             query_ids = list(dict.fromkeys(item.strip() for item in raw_query_ids))
             entry["wiki_query_ids"] = query_ids

--- a/long_horizon/test_journal_wiki_attribution.py
+++ b/long_horizon/test_journal_wiki_attribution.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from long_horizon import journal
+
+
+QUERY_ID = "wiki-query-0123456789abcdef0123456789abcdef"
+WIKI_ID = "gpu_wiki::nvidia.blackwell.example.strategy"
+
+
+class WikiAttributionJournalTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.path = Path(self.temporary.name) / "journal.json"
+        journal.initialize(
+            self.path,
+            episode=1,
+            base_commit="base",
+            branch="episode-1",
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def append(self, **overrides: object) -> dict[str, object]:
+        experiment: dict[str, object] = {
+            "name": "trial",
+            "wiki_usage_status": "declared",
+            "wiki_query_ids": [QUERY_ID],
+            "wiki_usage": [{
+                "query_id": QUERY_ID,
+                "wiki_id": WIKI_ID,
+                "disposition": "applied",
+                "use": "selected the launch shape",
+                "evidence": "candidate passed",
+            }],
+            "evaluation": {
+                "correctness": "pass",
+                "performance": "improved",
+                "latency_us": 12.5,
+                "kernel_hash": "abc123",
+            },
+        }
+        experiment.update(overrides)
+        value = journal.append_experiment(self.path, experiment)
+        return value["experiments"][-1]
+
+    def test_declared_usage_preserves_emitted_ids_and_outcome(self) -> None:
+        entry = self.append()
+        self.assertEqual(entry["wiki_query_ids"], [QUERY_ID])
+        self.assertEqual(entry["wiki_usage"][0]["query_id"], QUERY_ID)
+        self.assertEqual(entry["wiki_usage"][0]["wiki_id"], WIKI_ID)
+        self.assertEqual(entry["evaluation"]["latency_us"], 12.5)
+        self.assertNotIn("wiki_usage_errors", entry)
+        self.assertNotIn("evaluation_errors", entry)
+
+    def test_malformed_telemetry_is_dropped_without_blocking_append(self) -> None:
+        entry = self.append(
+            wiki_query_ids=["invented-query"],
+            wiki_usage=[{
+                "query_id": "invented-query",
+                "wiki_id": "invented-record",
+                "disposition": "applied",
+            }],
+            evaluation={
+                "correctness": "pass",
+                "performance": "improved",
+                "latency_us": float("nan"),
+                "kernel_hash": "abc123",
+            },
+        )
+        self.assertEqual(entry["wiki_usage"], [])
+        self.assertIsNone(entry["evaluation"])
+        self.assertTrue(any("emitted Wiki query_id" in error
+                            for error in entry["wiki_usage_errors"]))
+        self.assertIn(
+            "evaluation.latency_us must be a non-negative number or null",
+            entry["evaluation_errors"],
+        )
+        json.dumps(journal.load(self.path), allow_nan=False)
+
+    def test_explicit_no_use_and_not_queried_flows_are_preserved(self) -> None:
+        no_use = self.append(
+            wiki_usage_status="no_material_use",
+            wiki_query_ids=[QUERY_ID],
+            wiki_usage=[],
+        )
+        self.assertEqual(no_use["wiki_usage_status"], "no_material_use")
+        self.assertNotIn("wiki_usage_errors", no_use)
+
+        not_queried = self.append(
+            wiki_usage_status="not_queried",
+            wiki_query_ids=None,
+            wiki_usage=[],
+        )
+        self.assertEqual(not_queried["wiki_usage_status"], "not_queried")
+        self.assertNotIn("wiki_usage_errors", not_queried)
+
+    def test_nonfinite_latency_is_rejected_but_large_integer_is_valid(self) -> None:
+        for value in (float("inf"), float("-inf")):
+            with self.subTest(value=value):
+                normalized, errors = journal.normalize_experiment_evaluation({
+                    "correctness": "pass",
+                    "performance": "improved",
+                    "latency_us": value,
+                    "kernel_hash": None,
+                })
+                self.assertIsNone(normalized)
+                self.assertTrue(errors)
+
+        normalized, errors = journal.normalize_experiment_evaluation({
+            "correctness": "pass",
+            "performance": "improved",
+            "latency_us": 10**1000,
+            "kernel_hash": None,
+        })
+        self.assertEqual(errors, [])
+        self.assertEqual(normalized["latency_us"], 10**1000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orchestrator/optimize.py
+++ b/orchestrator/optimize.py
@@ -645,6 +645,9 @@ def main(argv: Optional[list[str]] = None) -> int:
         )
     sandbox_hardware = args.sandbox_hardware or args.platform
     if args.workspace:
+        # Campaign commands run from nested Git worktrees. Keeping a relative base here
+        # makes evaluator paths get resolved a second time against the campaign workspace.
+        args.workspace = str(Path(args.workspace).expanduser().resolve())
         Path(args.workspace).mkdir(parents=True, exist_ok=True)
 
     op = _resolve_op(args.op_dir, args.optimization_mode)

--- a/orchestrator/prompts/episode.md
+++ b/orchestrator/prompts/episode.md
@@ -88,10 +88,13 @@ changes the expected result. Detailed within-episode journals remain archived un
 
 ## Wiki attribution contract
 
-GPU Wiki query responses emit a stable `query_id` and canonical `store::record` ids. Whenever a returned record
+GPU Wiki query responses emit a top-level `query_id`, and every returned record emits its own
+canonical `wiki_id` in `store::record` form. Copy those fields exactly; never reconstruct either
+value from a response mapping key or from prose. Whenever a returned record
 materially influences an experiment or is explicitly evaluated and rejected, add `wiki_usage` to
-that experiment's journal append. Each row must contain the emitted `query_id`, an actually returned
-`wiki_id`, a disposition of `applied`, `partially_applied`, `reference_only`, or `rejected`, plus a
+that experiment's journal append. Each row must contain the response's emitted `query_id`, an
+actually returned record's emitted `wiki_id`, a disposition of `applied`, `partially_applied`,
+`reference_only`, or `rejected`, plus a
 short `use` and observable `evidence`. Preserve repeated use in separate experiments; do not dedupe
 across the episode. Every experiment must set `wiki_usage_status` to `declared` with non-empty usage,
 `no_material_use` when Wiki was queried without attributable use, or `not_queried` when it was not

--- a/orchestrator/prompts/episode.md
+++ b/orchestrator/prompts/episode.md
@@ -86,6 +86,21 @@ and do not repeat a rejected direction unless new evidence or a materially diffe
 changes the expected result. Detailed within-episode journals remain archived under
 `.atrex_long_horizon/episodes/` and are not part of the inherited prompt context.
 
+## Wiki attribution contract
+
+GPU Wiki query responses emit a stable `query_id` and canonical `store::record` ids. Whenever a returned record
+materially influences an experiment or is explicitly evaluated and rejected, add `wiki_usage` to
+that experiment's journal append. Each row must contain the emitted `query_id`, an actually returned
+`wiki_id`, a disposition of `applied`, `partially_applied`, `reference_only`, or `rejected`, plus a
+short `use` and observable `evidence`. Preserve repeated use in separate experiments; do not dedupe
+across the episode. Every experiment must set `wiki_usage_status` to `declared` with non-empty usage,
+`no_material_use` when Wiki was queried without attributable use, or `not_queried` when it was not
+queried. For `declared` and `no_material_use`, include `wiki_query_ids` with every Wiki query considered
+by the experiment; omit it for `not_queried`. Record `evaluation.correctness`, `evaluation.performance`, optional evaluator latency/hash,
+and an explicit decision so attribution can be joined to the experiment outcome.
+Malformed Wiki telemetry is diagnostic only: the journal drops bad rows into `wiki_usage_errors`
+without invalidating the optimization experiment or its terminal handoff.
+
 ## Engineering loop
 
 `skills/gpu-kernel-episode-loop/SKILL.md` defines the binding evidence loop for this episode:
@@ -132,8 +147,11 @@ git commit -m "v{{VERSION}}: kernel candidate"
 candidate_commit=$(git rev-parse HEAD)
 {{JOURNAL_COMMAND}} finalize --path {{JOURNAL_PATH_SHELL}} --state candidate_ready \
   --candidate-commit "$candidate_commit" \
-  --outcome-json '{"summary":"...","next_directions":["..."]}'
+  --outcome-json '{"summary":"...","next_directions":["..."],"selected_experiment_index":N}'
 ```
+
+Use the one-based journal index of the experiment selected for handoff. Its structured evaluation
+must pass correctness and its decision must be `promote` or `keep_as_best`.
 
 For `pivot` or `blocked`, finalize with that state and omit `--candidate-commit`. The journal must
 contain at least one structured experiment and a non-empty outcome summary.

--- a/orchestrator/prompts/fast_episode.md
+++ b/orchestrator/prompts/fast_episode.md
@@ -129,11 +129,21 @@ hash.
 
 Immediately after each evaluator, append one structured journal experiment for that trial. Record
 the reviewed plan, implementation, correctness, `performance_score` and latency when available,
-comparison with `best_score`, and the decision to keep or reject the trial:
+comparison with `best_score`, and the decision to keep or reject the trial. If this trial queried GPU Wiki,
+preserve the emitted `query_id` and add one `wiki_usage` row for each returned Wiki record that was
+materially used or explicitly evaluated. Use only a `wiki_id` actually returned by that query;
+classify it as `applied`, `partially_applied`, `reference_only`, or `rejected`. Every experiment must
+set `wiki_usage_status`: use `declared` with a non-empty `wiki_usage`, `no_material_use` when Wiki was
+queried but no returned knowledge materially influenced the trial, or `not_queried` when no Wiki query
+occurred. For `declared` and `no_material_use`, also set `wiki_query_ids` to every Wiki query considered
+by the trial. For `not_queried`, omit both `wiki_query_ids` and `wiki_usage`. Also record the evaluator
+outcome in structured `evaluation`; copy its kernel hash and latency
+when emitted. Wiki telemetry validation is fail-open: malformed rows
+are omitted and reported in `wiki_usage_errors`, while the experiment still records normally:
 
 ```bash
 {{JOURNAL_COMMAND}} append --path {{JOURNAL_PATH_SHELL}} \
-  --experiment-json '{"name":"fast trial N: plan -> implement -> evaluator","hypothesis":"...","change":"...","evidence":"official base-seed evaluator result or blocker","result":"...","decision":"keep_as_best | reject_and_continue | blocked"}'
+  --experiment-json '{"name":"fast trial N: plan -> implement -> evaluator","hypothesis":"...","change":"...","evidence":"official base-seed evaluator result or blocker","result":"...","evaluation":{"correctness":"pass|fail|unknown","performance":"improved|not_improved|unknown","latency_us":null,"kernel_hash":"<evaluator-kernel-hash-or-empty>"},"decision":"keep_as_best | reject_and_continue | blocked","wiki_usage_status":"declared","wiki_query_ids":["<query-id>"],"wiki_usage":[{"query_id":"<query-id>","wiki_id":"<returned-wiki-id>","disposition":"reference_only","use":"decision or code change influenced by the record","evidence":"observable evidence for this disposition"}]}'
 ```
 
 If the result passes and its `performance_score` exceeds `best_score`, update `best_commit`,
@@ -180,8 +190,11 @@ For `candidate_ready`, use the exact selected candidate commit and finalize the 
 candidate_commit=$(git rev-parse HEAD)
 {{JOURNAL_COMMAND}} finalize --path {{JOURNAL_PATH_SHELL}} --state candidate_ready \
   --candidate-commit "$candidate_commit" \
-  --outcome-json '{"summary":"...","next_directions":["..."]}'
+  --outcome-json '{"summary":"...","next_directions":["..."],"selected_experiment_index":N}'
 ```
+
+`selected_experiment_index` is the one-based journal experiment index whose evaluated kernel bytes
+were selected for handoff. It is required for `candidate_ready`; do not point it at a rejected trial.
 
 For `pivot`, finalize only after {{FAST_TRIALS}} trial experiments and
 {{FAST_TRIALS}} evaluator results. For `blocked`, finalize immediately with the completed trial

--- a/orchestrator/prompts/fast_episode.md
+++ b/orchestrator/prompts/fast_episode.md
@@ -130,8 +130,9 @@ hash.
 Immediately after each evaluator, append one structured journal experiment for that trial. Record
 the reviewed plan, implementation, correctness, `performance_score` and latency when available,
 comparison with `best_score`, and the decision to keep or reject the trial. If this trial queried GPU Wiki,
-preserve the emitted `query_id` and add one `wiki_usage` row for each returned Wiki record that was
-materially used or explicitly evaluated. Use only a `wiki_id` actually returned by that query;
+copy the response's top-level `query_id` and each used record's own emitted canonical `wiki_id`
+exactly; never reconstruct them from response mapping keys or prose. Add one `wiki_usage` row for
+each returned Wiki record that was materially used or explicitly evaluated;
 classify it as `applied`, `partially_applied`, `reference_only`, or `rejected`. Every experiment must
 set `wiki_usage_status`: use `declared` with a non-empty `wiki_usage`, `no_material_use` when Wiki was
 queried but no returned knowledge materially influenced the trial, or `not_queried` when no Wiki query
@@ -143,7 +144,7 @@ are omitted and reported in `wiki_usage_errors`, while the experiment still reco
 
 ```bash
 {{JOURNAL_COMMAND}} append --path {{JOURNAL_PATH_SHELL}} \
-  --experiment-json '{"name":"fast trial N: plan -> implement -> evaluator","hypothesis":"...","change":"...","evidence":"official base-seed evaluator result or blocker","result":"...","evaluation":{"correctness":"pass|fail|unknown","performance":"improved|not_improved|unknown","latency_us":null,"kernel_hash":"<evaluator-kernel-hash-or-empty>"},"decision":"keep_as_best | reject_and_continue | blocked","wiki_usage_status":"declared","wiki_query_ids":["<query-id>"],"wiki_usage":[{"query_id":"<query-id>","wiki_id":"<returned-wiki-id>","disposition":"reference_only","use":"decision or code change influenced by the record","evidence":"observable evidence for this disposition"}]}'
+  --experiment-json '{"name":"fast trial N: plan -> implement -> evaluator","hypothesis":"...","change":"...","evidence":"official base-seed evaluator result or blocker","result":"...","evaluation":{"correctness":"pass|fail|unknown","performance":"improved|not_improved|unknown","latency_us":null,"kernel_hash":"<evaluator-kernel-hash-or-empty>"},"decision":"keep_as_best | reject_and_continue | blocked","wiki_usage_status":"declared","wiki_query_ids":["<emitted-query-id>"],"wiki_usage":[{"query_id":"<emitted-query-id>","wiki_id":"<emitted-canonical-wiki-id>","disposition":"reference_only","use":"decision or code change influenced by the record","evidence":"observable evidence for this disposition"}]}'
 ```
 
 If the result passes and its `performance_score` exceeds `best_score`, update `best_commit`,

--- a/skills/gpu-kernel-baseline/SKILL.md
+++ b/skills/gpu-kernel-baseline/SKILL.md
@@ -44,8 +44,9 @@ referenced below as `<gpu-wiki>/`.
    request the complete product specification and relevant architecture/ISA facts, plus the framework,
    operator, shapes, dtypes, intended implementation, and uncertainties. Do not substitute another
    hardware identity or reduce the description to keywords.
-3. Results contain only `records` and `notes`. Read each id-keyed record's `store`, independent `payload`,
-   `source`, `type`, and `match.arch`; internal ids use the `internal_gpu_wiki::` namespace. Use
+3. Results contain a top-level `query_id`, `records`, and `notes`. Read each id-keyed record's own
+   canonical `wiki_id`, `store`, independent `payload`, `source`, `type`, and `match.arch`; internal
+   mapping keys use the `internal_gpu_wiki::` namespace. Copy emitted attribution ids exactly and use
    `--max-bytes` when a hard context limit is needed.
 4. Prefer records with the same framework and compute pattern. Record the stable ids and the constraints
    they established in `plans/v0_plan.md`.

--- a/skills/gpu-kernel-episode-loop/SKILL.md
+++ b/skills/gpu-kernel-episode-loop/SKILL.md
@@ -154,8 +154,9 @@ Search in this order and stop when one actionable direction is supported:
    or store gaps. Pass `--exclude <ids-already-read>` on later queries and use `--max-bytes` for a hard
    context bound. The structured `query_wiki.py` and `query_hardware.py` tools remain available when the
    exact address is already known; never drop architecture scope to manufacture a match.
-   Preserve the response's `query_id` together with the canonical `store::record` ids you use or reject so the
-   decisive experiment can declare its Wiki attribution in the native journal.
+   Copy the response's top-level `query_id` and each used record's own emitted canonical `wiki_id`
+   exactly so the decisive experiment can declare its Wiki attribution in the native journal. Never
+   reconstruct them from response mapping keys or prose.
 2. `reference-projects/` only when the local wiki is insufficient.
 3. Public primary sources only when local sources do not answer the question.
 
@@ -212,7 +213,7 @@ progress view in the incumbent workspace.
 
 ```bash
 <JOURNAL_CLI> append --path <JOURNAL_PATH> \
-  --experiment-json '{"name":"...","hypothesis":"...","change":"...","evidence":"...","result":"...","evaluation":{"correctness":"pass|fail|unknown","performance":"improved|not_improved|unknown","latency_us":null,"kernel_hash":""},"decision":"keep_as_best|promote|reject_and_continue|revert|pivot|blocked","wiki_usage_status":"declared","wiki_query_ids":["<query-id>"],"wiki_usage":[{"query_id":"<query-id>","wiki_id":"<returned-wiki-id>","disposition":"applied|partially_applied|reference_only|rejected","use":"...","evidence":"..."}]}'
+  --experiment-json '{"name":"...","hypothesis":"...","change":"...","evidence":"...","result":"...","evaluation":{"correctness":"pass|fail|unknown","performance":"improved|not_improved|unknown","latency_us":null,"kernel_hash":""},"decision":"keep_as_best|promote|reject_and_continue|revert|pivot|blocked","wiki_usage_status":"declared","wiki_query_ids":["<emitted-query-id>"],"wiki_usage":[{"query_id":"<emitted-query-id>","wiki_id":"<emitted-canonical-wiki-id>","disposition":"applied|partially_applied|reference_only|rejected","use":"...","evidence":"..."}]}'
 ```
 
 Use `declared` only with non-empty `wiki_usage`. Include `wiki_query_ids` for both `declared` and

--- a/skills/gpu-kernel-episode-loop/SKILL.md
+++ b/skills/gpu-kernel-episode-loop/SKILL.md
@@ -154,6 +154,8 @@ Search in this order and stop when one actionable direction is supported:
    or store gaps. Pass `--exclude <ids-already-read>` on later queries and use `--max-bytes` for a hard
    context bound. The structured `query_wiki.py` and `query_hardware.py` tools remain available when the
    exact address is already known; never drop architecture scope to manufacture a match.
+   Preserve the response's `query_id` together with the canonical `store::record` ids you use or reject so the
+   decisive experiment can declare its Wiki attribution in the native journal.
 2. `reference-projects/` only when the local wiki is insufficient.
 3. Public primary sources only when local sources do not answer the question.
 
@@ -210,8 +212,13 @@ progress view in the incumbent workspace.
 
 ```bash
 <JOURNAL_CLI> append --path <JOURNAL_PATH> \
-  --experiment-json '{"name":"...","hypothesis":"...","change":"...","evidence":"...","result":"...","decision":"continue|revert|pivot"}'
+  --experiment-json '{"name":"...","hypothesis":"...","change":"...","evidence":"...","result":"...","evaluation":{"correctness":"pass|fail|unknown","performance":"improved|not_improved|unknown","latency_us":null,"kernel_hash":""},"decision":"keep_as_best|promote|reject_and_continue|revert|pivot|blocked","wiki_usage_status":"declared","wiki_query_ids":["<query-id>"],"wiki_usage":[{"query_id":"<query-id>","wiki_id":"<returned-wiki-id>","disposition":"applied|partially_applied|reference_only|rejected","use":"...","evidence":"..."}]}'
 ```
+
+Use `declared` only with non-empty `wiki_usage`. Include `wiki_query_ids` for both `declared` and
+`no_material_use`; omit both arrays for `not_queried`.
+Do not invent ids and do not collapse repeated use across experiments. Invalid Wiki rows are omitted
+with `wiki_usage_errors`; this diagnostic field never blocks the experiment or handoff.
 
 ## Leaving the loop
 

--- a/tools/benchmark_wiki_attribution.py
+++ b/tools/benchmark_wiki_attribution.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Measure the incremental CPU cost of Wiki attribution normalization.
+
+The benchmark intentionally excludes journal file I/O, timestamps, and live-memory
+sync so the reported curve isolates the work added by the attribution contract.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from long_horizon import journal  # noqa: E402
+
+
+QUERY_ID = "wiki-query-0123456789abcdef0123456789abcdef"
+
+
+def experiment(status: str, rows: int) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "name": "benchmark",
+        "wiki_usage_status": status,
+        "evaluation": {
+            "correctness": "pass",
+            "performance": "improved",
+            "latency_us": 12.5,
+            "kernel_hash": "abc123",
+        },
+    }
+    if status != "not_queried":
+        value["wiki_query_ids"] = [QUERY_ID]
+    if rows:
+        value["wiki_usage"] = [{
+            "query_id": QUERY_ID,
+            "wiki_id": f"gpu_wiki::benchmark.record-{index}",
+            "disposition": "applied",
+            "use": "benchmark",
+            "evidence": "benchmark",
+        } for index in range(rows)]
+    return value
+
+
+def before_contract(template: dict[str, Any]) -> int:
+    entry = dict(template)
+    return len(entry)
+
+
+def after_contract(template: dict[str, Any]) -> int:
+    entry = dict(template)
+    journal.normalize_wiki_attribution(entry)
+    evaluation, errors = journal.normalize_experiment_evaluation(entry["evaluation"])
+    entry["evaluation"] = evaluation
+    if errors:
+        entry["evaluation_errors"] = errors
+    return len(entry) + len(entry.get("wiki_usage", []))
+
+
+def sample(function: Callable[[dict[str, Any]], int], template: dict[str, Any],
+           iterations: int) -> float:
+    checksum = 0
+    started = time.perf_counter_ns()
+    for _ in range(iterations):
+        checksum += function(template)
+    elapsed = time.perf_counter_ns() - started
+    if checksum <= 0:
+        raise RuntimeError("invalid benchmark checksum")
+    return elapsed / iterations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iterations", type=int, default=20_000)
+    parser.add_argument("--repeats", type=int, default=7)
+    args = parser.parse_args(argv)
+    if args.iterations <= 0 or args.repeats <= 0:
+        parser.error("iterations and repeats must be positive")
+
+    scenarios = [
+        ("not_queried", 0),
+        ("no_material_use", 0),
+        ("declared", 1),
+        ("declared", 4),
+        ("declared", 16),
+    ]
+    results = []
+    for status, rows in scenarios:
+        template = experiment(status, rows)
+        for function in (before_contract, after_contract):
+            sample(function, template, min(args.iterations, 1_000))
+        before = []
+        after = []
+        for _ in range(args.repeats):
+            before.append(sample(before_contract, template, args.iterations))
+            after.append(sample(after_contract, template, args.iterations))
+        overhead = [after[index] - before[index] for index in range(args.repeats)]
+        results.append({
+            "status": status,
+            "wiki_usage_rows": rows,
+            "raw_ns_per_op": {"before": before, "after": after, "overhead": overhead},
+            "median_ns_per_op": {
+                "before": statistics.median(before),
+                "after": statistics.median(after),
+                "overhead": statistics.median(overhead),
+            },
+        })
+
+    print(json.dumps({
+        "scope": "CPU normalization only; journal I/O and live-memory sync excluded",
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "iterations": args.iterations,
+        "repeats": args.repeats,
+        "results": results,
+    }, indent=2, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -190,6 +190,8 @@ TYPED_FALLBACK_REASONS = (
     "kind_not_supported",
     "invalid_source",
     "source validation failed",
+    "deps_install_failed",
+    "gateway_dependency_install_failed",
     "http 404",
     "http 413",
     "http 501",


### PR DESCRIPTION
## Problem, target, and benefit

GPU Wiki queries and optimization outcomes are currently separate data sets. A returned record cannot be joined reliably to the experiment that used or rejected it, so maintainers cannot measure adoption, no-use queries, or outcome-correlated effectiveness.

This PR targets a bounded, fail-open attribution contract:

- every `query_nl.py` invocation emits one `query_id`;
- every returned record emits its canonical `wiki_id` in `store::record` form;
- the episode copies those emitted fields into the experiment journal and records a bounded evaluator outcome;
- queried-without-material-use and not-queried are explicit rather than inferred;
- malformed telemetry is omitted with diagnostics and never blocks journal append, handoff, or promotion;
- incremental normalization stays below 50 microseconds per experiment at the tested 0–16 usage-row range.

The benefit is a deterministic offline join from request -> returned knowledge -> declared use/rejection -> correctness/performance result. This PR adds measurement infrastructure; it does not claim that Wiki advice itself improves a kernel, and it does not change retrieval ranking or promotion authority.

## Design and failure paths

```mermaid
flowchart LR
    Q[query_nl.py] -->|top-level query_id<br/>record.wiki_id| A[Episode agent]
    A -->|status + copied IDs + outcome| J[append_experiment]
    J --> N{Fail-open normalizers}
    N -->|valid declaration| V[Persist attribution + evaluation]
    N -->|queried, no material use| U[Persist query IDs + no-use status]
    N -->|not queried| Z[Persist explicit not-queried status]
    N -->|bad IDs, status, or outcome| E[Drop bad field + persist diagnostic]
    V --> O[Offline effectiveness join/profile]
    U --> O
    Z --> O
    E --> O
    E -. never gates .-> P[Handoff and promotion]
```

Interface details:

- Query response: `{query_id, records, notes}`. Backward-compatible record mapping keys remain unchanged; each record value adds canonical `wiki_id`.
- Attribution IDs are copied from the response, never reconstructed from mapping keys or prose. Query IDs must match the emitted UUID form and Wiki IDs must use a known store namespace.
- `declared` requires at least one valid usage row. `no_material_use` requires query IDs and no usage rows. `not_queried` requires neither.
- Evaluation is limited to correctness, performance, optional non-negative finite latency, and optional kernel hash.
- Validation errors are stored in `wiki_usage_errors` / `evaluation_errors`; the experiment itself still appends.

## Behavioral validation

| Flow | Input | Persisted result | Promotion impact |
|---|---|---|---|
| Normal use | emitted query ID + canonical Wiki ID + finite outcome | attribution and outcome preserved | none |
| Queried, no use | emitted query ID + `no_material_use` | query ID and explicit no-use status preserved | none |
| Not queried | `not_queried`, no IDs | explicit status preserved | none |
| Malformed | invented IDs and `NaN` / `Infinity` latency | bad rows/outcome dropped; diagnostics preserved; strict JSON remains serializable | none |

Executed on commit `058e181`:

```text
python3.12 -m unittest discover -s gpu-wiki/tools -v
126 tests OK, 8 skipped (optional local sample corpus/provenance cases)

python3.12 -m unittest long_horizon.test_journal_wiki_attribution -v
4 tests passed

python3 gpu-wiki/tools/check_kernel_wiki.py --full
9/9 gates passed; 847 records

python3 gpu-wiki/tools/check_hardware_wiki.py
6/6 gates passed; 30 records

python3.12 -m compileall -q long_horizon orchestrator tools gpu-wiki/tools
git diff --check
both passed
```

The journal tests exercise actual initialize -> append -> reload behavior, including strict `json.dumps(..., allow_nan=False)` after malformed input.

## Before/after cost curve

The committed benchmark isolates incremental CPU normalization from journal I/O, timestamp creation, and live-memory sync. “Before” performs the pre-contract experiment dictionary copy; “after” performs the same copy plus Wiki attribution and evaluation normalization. This isolates the code introduced here instead of measuring filesystem noise.

Reproduce with:

```bash
python3.12 tools/benchmark_wiki_attribution.py --iterations 20000 --repeats 7
```

Environment: Python 3.12.13, macOS arm64. Values are median nanoseconds per experiment.

| Status | Usage rows | Before | After | Incremental overhead |
|---|---:|---:|---:|---:|
| `not_queried` | 0 | 59.1 ns | 655.9 ns | 596.0 ns |
| `no_material_use` | 0 | 60.6 ns | 1,173.4 ns | 1,112.9 ns |
| `declared` | 1 | 64.0 ns | 2,073.2 ns | 2,008.6 ns |
| `declared` | 4 | 64.0 ns | 3,802.7 ns | 3,737.6 ns |
| `declared` | 16 | 63.8 ns | 10,834.2 ns | 10,772.5 ns |

<details>
<summary>Raw seven-repeat samples (ns/experiment)</summary>

```json
[
  {"status":"not_queried","rows":0,"before":[55.2417,73.76455,58.8271,59.68125,59.0875,60.0271,59.06045],"after":[640.78125,701.75,648.8125,656.9479,660.03335,655.8625,655.01665]},
  {"status":"no_material_use","rows":0,"before":[60.56875,62.24375,69.2375,60.33335,61.0479,60.4542,60.62915],"after":[1184.94165,1173.3521,1194.5771,1173.1979,1170.4625,1169.25625,1196.1646]},
  {"status":"declared","rows":1,"before":[62.55,68.90415,63.8104,64.03335,64.58125,63.83125,71.91665],"after":[2023.85,2140.0021,2074.7646,2061.325,2073.2083,2066.33335,2147.9729]},
  {"status":"declared","rows":4,"before":[63.81045,61.5979,62.5646,65.0771,63.95835,68.0396,70.9729],"after":[3742.8083,3695.9625,3811.81875,3802.7167,3776.625,4142.83335,4009.42915]},
  {"status":"declared","rows":16,"before":[66.67295,63.10625,61.6875,63.4896,66.5771,67.36875,63.8146],"after":[10876.60415,10580.5479,10834.1875,11085.51045,11164.975,10707.2625,10378.95]}
]
```

</details>

## Rollback

Revert the two PR commits. The fields are additive, so journals already written remain readable by consumers that ignore unknown keys; no data migration or store rewrite is required. Reverting the prompt restores the prior agent workflow, and the sandboxed `gpu-wiki/` exposure can be removed independently. The offline profile simply stops receiving new attribution rows. No credentials, remote writes, or promotion decisions are introduced by this change.

Supersedes #71, which GitHub made non-reopenable after its head branch was force-pushed while correcting commit identity.
