### PR TITLE
Fix nested FP4 metadata detection

### DIFF
--- a/reference/atrex_bench_test_kernel.py
+++ b/reference/atrex_bench_test_kernel.py
@@ -55,16 +55,16 @@ def _is_fp4_dtype(value: object) -> bool:
 
 
 def _metadata_has_fp4_dtype(metadata: object) -> bool:
-    if not isinstance(metadata, dict):
-        return False
-    if any(_is_fp4_dtype(metadata.get(field)) for field in ("dtype", "dtype_compute")):
-        return True
-    shapes = metadata.get("shapes")
-    return isinstance(shapes, dict) and any(
-        isinstance(shape, dict)
-        and any(_is_fp4_dtype(shape.get(field)) for field in ("dtype", "dtype_compute"))
-        for shape in shapes.values()
-    )
+    if isinstance(metadata, dict):
+        if any(
+            _is_fp4_dtype(metadata.get(field))
+            for field in ("dtype", "dtype_compute")
+        ):
+            return True
+        return any(_metadata_has_fp4_dtype(value) for value in metadata.values())
+    if isinstance(metadata, list):
+        return any(_metadata_has_fp4_dtype(value) for value in metadata)
+    return False
 
 
 def _fp4_correctness_max_rel_l2(workspace: Path) -> float | None:

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -561,17 +561,17 @@ def _is_fp4_dtype(value: object) -> bool:
     return "fp4" in normalized or "float4" in normalized
 
 
-def _metadata_has_fp4_dtype(metadata: dict[str, Any] | None) -> bool:
-    if metadata is None:
-        return False
-    if any(_is_fp4_dtype(metadata.get(field)) for field in ("dtype", "dtype_compute")):
-        return True
-    shapes = metadata.get("shapes")
-    return isinstance(shapes, dict) and any(
-        isinstance(shape, dict)
-        and any(_is_fp4_dtype(shape.get(field)) for field in ("dtype", "dtype_compute"))
-        for shape in shapes.values()
-    )
+def _metadata_has_fp4_dtype(metadata: object) -> bool:
+    if isinstance(metadata, dict):
+        if any(
+            _is_fp4_dtype(metadata.get(field))
+            for field in ("dtype", "dtype_compute")
+        ):
+            return True
+        return any(_metadata_has_fp4_dtype(value) for value in metadata.values())
+    if isinstance(metadata, list):
+        return any(_metadata_has_fp4_dtype(value) for value in metadata)
+    return False
 
 
 def _fp4_correctness_max_rel_l2(


### PR DESCRIPTION
## Summary

- recursively detect FP4 dtypes in nested fusion metadata
- keep detection scoped to `dtype` and `dtype_compute` fields
- apply the same behavior to the benchmark adapter and sandbox request path

## Validation

- verified that hybrid metadata with a nested `nvfp4` component enables relative-L2 validation
- verified that unrelated FP4 description text does not trigger the gate