### PR TITLE
fix(local_gateway): rebind run_eval after shim self-replacement in correctness-only mode

### DIFF
--- a/tools/local_gateway.py
+++ b/tools/local_gateway.py
@@ -584,6 +584,7 @@ if spec is None or spec.loader is None:
 run_eval = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = run_eval
 spec.loader.exec_module(run_eval)
+run_eval = sys.modules.get(spec.name, run_eval)
 
 if args.shape_id is not None:
     result = run_eval.check_correctness(


### PR DESCRIPTION
## Summary

Fix `AttributeError` in local gateway's `correctness_only` evaluation mode caused by a stale module reference after the `scripts/run_eval.py` shim replaces itself in `sys.modules`.

---

## Root cause

`CORRECTNESS_ONLY_RUNNER` loads `scripts/run_eval.py` via `importlib`:

```python
spec = importlib.util.spec_from_file_location("atrex_local_run_eval", args.run_eval)
run_eval = importlib.util.module_from_spec(spec)
sys.modules[spec.name] = run_eval
spec.loader.exec_module(run_eval)
```

`scripts/run_eval.py` is a shim that, when imported as a module, replaces itself:

```python
else:
    sys.modules[__name__] = _implementation
```

This replaces `sys.modules["atrex_local_run_eval"]` with the real `atrex_bench.cli.run_eval` module, but the local `run_eval` variable still references the original empty module object. The subsequent call to `run_eval._run_eval_worker(...)` fails with:

```text
AttributeError: module 'atrex_local_run_eval' has no attribute '_run_eval_worker'
```

---

## Fix

After `exec_module`, rebind `run_eval` to the current entry in `sys.modules`:

```python
run_eval = sys.modules.get(spec.name, run_eval)
```

This ensures the local reference points to the real implementation that the shim installed.

---

## Impact

- Only affects `mode == "correctness_only"` in local gateway.
- `full` mode is unaffected because it does not use `CORRECTNESS_ONLY_RUNNER`.

---

## Test plan

- [ ] Run a local `correctness_only` evaluation and confirm it no longer crashes on `_run_eval_worker`.
- [ ] Run `full` mode evaluation to ensure no regression.
