### PR TITLE
Support distributed evaluator GPU requests

### DIFF
--- a/tools/local_gateway.py
+++ b/tools/local_gateway.py
@@ -357,6 +357,11 @@ def _validate_target(payload: dict[str, Any]) -> None:
     targets = spec.get("target_hardware") if isinstance(spec, dict) else None
     if not isinstance(targets, list) or not targets or not all(isinstance(v, str) for v in targets):
         raise ValueError("spec.target_hardware must be a non-empty string array")
+    num_gpus = spec.get("num_gpus", 1)
+    if isinstance(num_gpus, bool) or not isinstance(num_gpus, int) or num_gpus < 1:
+        raise ValueError("spec.num_gpus must be a positive integer")
+    if num_gpus > 1:
+        raise ValueError("localhost scheduler does not support spec.num_gpus greater than 1")
 
 
 def _validate_timeout(value: Any, field: str) -> int:

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -556,7 +556,7 @@ def _command_input_paths(
 def _command_executable_index(
     command: list[str], *, typed_launcher: bool = False
 ) -> int | None:
-    """Skip supported shell assignments and an optional env wrapper."""
+    """Skip supported shell assignments, env, and execution wrappers."""
     def assignment_end(start: int, *, shell_prefix: bool = False) -> int | None:
         while start < len(command):
             name, separator, _ = command[start].partition("=")
@@ -612,6 +612,86 @@ def _command_executable_index(
         index = assignment_end(index)
         if index is None:
             return None
+    while index < len(command):
+        wrapper = Path(command[index]).name
+        if wrapper not in {"command", "exec", "nice", "time"}:
+            break
+        if typed_launcher:
+            return None
+        index += 1
+
+        if wrapper == "command":
+            while index < len(command):
+                option = command[index]
+                if option == "--":
+                    index += 1
+                    break
+                if option == "-p":
+                    index += 1
+                    continue
+                if option.startswith("-"):
+                    return None
+                break
+        elif wrapper == "exec":
+            while index < len(command):
+                option = command[index]
+                if option == "--":
+                    index += 1
+                    break
+                if option == "-a":
+                    if index + 1 >= len(command):
+                        return None
+                    index += 2
+                    continue
+                if re.fullmatch(r"-[cl]+", option):
+                    index += 1
+                    continue
+                if option.startswith("-"):
+                    return None
+                break
+        elif wrapper == "nice":
+            while index < len(command):
+                option = command[index]
+                if option == "--":
+                    index += 1
+                    break
+                if option in {"-n", "--adjustment"}:
+                    if index + 1 >= len(command):
+                        return None
+                    index += 2
+                    continue
+                if (
+                    re.fullmatch(r"-(?:n)?\d+", option)
+                    or option.startswith("--adjustment=")
+                ):
+                    index += 1
+                    continue
+                if option.startswith("-"):
+                    return None
+                break
+        else:
+            while index < len(command):
+                option = command[index]
+                if option == "--":
+                    index += 1
+                    break
+                if option in {"-f", "--format", "-o", "--output"}:
+                    if index + 1 >= len(command):
+                        return None
+                    index += 2
+                    continue
+                if (
+                    re.fullmatch(r"-[fo].+", option)
+                    or option.startswith("--format=")
+                    or option.startswith("--output=")
+                    or re.fullmatch(r"-[apqv]+", option)
+                    or option in {"--append", "--portability", "--quiet", "--verbose"}
+                ):
+                    index += 1
+                    continue
+                if option.startswith("-"):
+                    return None
+                break
     return index if index < len(command) else None
 
 
@@ -688,7 +768,8 @@ def _shell_command_operand(
     command: list[str], executable_index: int
 ) -> tuple[str, int] | None:
     """Locate a shell script or the command string consumed by ``-c``."""
-    if Path(command[executable_index]).name not in {"bash", "sh"}:
+    shell = Path(command[executable_index]).name
+    if shell not in {"bash", "sh"}:
         return None
     index = executable_index + 1
     while index < len(command):
@@ -696,9 +777,46 @@ def _shell_command_operand(
         if option == "--":
             index += 1
             break
-        if re.fullmatch(r"-[abefhiklmpruvxBCHPc]+", option):
-            if "c" in option[1:]:
-                return ("command", index + 1) if index + 1 < len(command) else None
+        if shell == "bash" and option in {"--init-file", "--rcfile"}:
+            if index + 1 >= len(command):
+                return None
+            index += 2
+            continue
+        if shell == "bash" and (
+            option.startswith("--init-file=") or option.startswith("--rcfile=")
+        ):
+            index += 1
+            continue
+        if shell == "bash" and option in {
+            "--debug",
+            "--debugger",
+            "--login",
+            "--noediting",
+            "--noprofile",
+            "--norc",
+            "--posix",
+            "--protected",
+            "--restricted",
+            "--verbose",
+        }:
+            index += 1
+            continue
+        if shell == "bash" and option in {
+            "--dump-po-strings",
+            "--dump-strings",
+            "--help",
+            "--version",
+            "--wordexp",
+        }:
+            return None
+        if re.fullmatch(r"-[abefhiklmpruvxBCHP]*c", option):
+            return ("command", index + 1) if index + 1 < len(command) else None
+        if re.fullmatch(r"-[abefhiklmpruvxBCHP]*[oO]", option):
+            if index + 1 >= len(command):
+                return None
+            index += 2
+            continue
+        if re.fullmatch(r"-[abefhiklmpruvxBCHP]+", option):
             index += 1
             continue
         if option.startswith("-"):

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -543,7 +543,7 @@ def _is_test_kernel_command(parts: list[str]) -> bool:
     command = _command_parts(parts)
     return (
         len(command) >= 2
-        and Path(command[0]).name in {"python", "python3", "python3.10", "python3.12"}
+        and re.fullmatch(r"python(?:3(?:\.\d+)*)?", Path(command[0]).name) is not None
         and Path(command[1]).name == "test_kernel.py"
     )
 
@@ -2971,6 +2971,7 @@ def _main(argv: list[str] | None = None) -> int:
         raise SystemExit(f"sandbox: workspace not found: {workspace}")
 
     gateway_kind = _requested_gateway_kind(args.kind, args.command)
+    evaluator_command = _is_test_kernel_command(args.command)
     profile_command = _is_profile_command(args.command)
     if profile_command:
         try:
@@ -2979,13 +2980,14 @@ def _main(argv: list[str] | None = None) -> int:
             raise SystemExit(f"sandbox: {exc}") from exc
     typed_limitation: str | None = None
     num_gpus = 1
-    if gateway_kind in TYPED_KINDS:
+    if gateway_kind in TYPED_KINDS or evaluator_command:
         try:
             num_gpus = _workspace_num_gpus(workspace)
         except ValueError as exc:
             raise SystemExit(
                 f"sandbox: invalid distributed evaluator contract: {exc}"
             ) from exc
+    if gateway_kind in TYPED_KINDS:
         if (
             gateway_kind == "profile"
             and args.profile_level == "deep"
@@ -3025,7 +3027,6 @@ def _main(argv: list[str] | None = None) -> int:
         )
         gateway_kind = "dev"
 
-    evaluator_command = _is_test_kernel_command(args.command)
     if evaluator_command:
         selected = set(_evaluation_input_paths(workspace, args.command))
         try:

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -547,8 +547,25 @@ def _test_kernel_script_index(
     if not command:
         return None
 
-    index = 0
-    if command[index] in {"env", "/usr/bin/env"}:
+    def assignment_end(start: int, *, shell_prefix: bool = False) -> int | None:
+        while start < len(command):
+            name, separator, _ = command[start].partition("=")
+            if not separator or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name) is None:
+                break
+            if shell_prefix and shlex.quote(command[start]) != command[start]:
+                break
+            if typed_launcher and name not in {
+                "PYTHONDONTWRITEBYTECODE",
+                "PYTHONUNBUFFERED",
+            }:
+                return None
+            start += 1
+        return start
+
+    index = assignment_end(0, shell_prefix=True)
+    if index is None:
+        return None
+    if index < len(command) and command[index] in {"env", "/usr/bin/env"}:
         index += 1
         while index < len(command):
             option = command[index]
@@ -582,16 +599,9 @@ def _test_kernel_script_index(
             if option.startswith("-"):
                 return None
             break
-        while index < len(command):
-            name, separator, _ = command[index].partition("=")
-            if not separator or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name) is None:
-                break
-            if typed_launcher and name not in {
-                "PYTHONDONTWRITEBYTECODE",
-                "PYTHONUNBUFFERED",
-            }:
-                return None
-            index += 1
+        index = assignment_end(index)
+        if index is None:
+            return None
 
     if (
         index >= len(command)
@@ -3124,6 +3134,11 @@ def _main(argv: list[str] | None = None) -> int:
             if typed_result is not None:
                 return typed_result
             typed_limitation = f"gateway {gateway_kind} route unavailable or rejected the source contract"
+        if gateway_kind == "profile" and num_gpus > 1:
+            raise SystemExit(
+                "sandbox: distributed profile cannot fall back to dev "
+                f"({typed_limitation}); the dev route does not launch ranks"
+            )
         print(
             f"[sandbox] {gateway_kind} interface unsupported ({typed_limitation}); using dev",
             file=sys.stderr,

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -596,6 +596,45 @@ def _json_object(path: Path, *, required: bool = False) -> dict[str, Any] | None
     return value
 
 
+def _distributed_evaluation_world_size(metadata: object) -> int:
+    """Return the GPU count declared by a single-node evaluator contract."""
+    if not isinstance(metadata, dict):
+        return 1
+    benchmark_contract = metadata.get("benchmark_contract")
+    if not isinstance(benchmark_contract, dict):
+        return 1
+    evaluation = benchmark_contract.get("distributed_evaluation")
+    if evaluation is None:
+        return 1
+    if not isinstance(evaluation, dict):
+        raise ValueError("benchmark_contract.distributed_evaluation must be an object")
+    if evaluation.get("launcher") != "torchrun":
+        raise ValueError(
+            "benchmark_contract.distributed_evaluation.launcher must be 'torchrun'"
+        )
+    if evaluation.get("backend") != "nccl":
+        raise ValueError(
+            "benchmark_contract.distributed_evaluation.backend must be 'nccl'"
+        )
+    world_size = evaluation.get("world_size")
+    if isinstance(world_size, bool) or not isinstance(world_size, int):
+        raise ValueError(
+            "benchmark_contract.distributed_evaluation.world_size must be an integer"
+        )
+    if world_size != 2:
+        raise ValueError(
+            "benchmark_contract.distributed_evaluation.world_size must be 2"
+        )
+    return world_size
+
+
+def _workspace_num_gpus(workspace: Path) -> int:
+    metadata = _json_object(
+        _evaluator_input_path(workspace, "metadata.json", required=False)
+    )
+    return _distributed_evaluation_world_size(metadata)
+
+
 def _is_fp4_dtype(value: object) -> bool:
     if not isinstance(value, str):
         return False
@@ -925,12 +964,16 @@ def _typed_request(
                     value["num_shapes"] = len(requested_shape_ids)
             reference[field] = value
 
+    spec: dict[str, Any] = {
+        "languages": [str(value) for value in languages],
+        "target_hardware": [hardware],
+    }
+    num_gpus = _distributed_evaluation_world_size(reference.get("metadata"))
+    if num_gpus > 1:
+        spec["num_gpus"] = num_gpus
     request: dict[str, Any] = {
         "name": f"{workspace.name}_{kind}",
-        "spec": {
-            "languages": [str(value) for value in languages],
-            "target_hardware": [hardware],
-        },
+        "spec": spec,
         "candidate": (workspace / "kernel.py").read_text(encoding="utf-8"),
         "reference": reference,
         "options": {
@@ -1527,19 +1570,23 @@ def _run_direct_gateway(
     env_items: list[str],
     files: dict[str, Path],
     command: str,
+    num_gpus: int = 1,
 ) -> subprocess.CompletedProcess[str]:
     """Use the public dev-job HTTP API when the optional agate CLI is absent."""
     try:
         env_vars = _parse_env_items(env_items)
     except ValueError as exc:
         raise SystemExit(f"sandbox: {exc}") from exc
+    spec: dict[str, Any] = {"target_hardware": [hardware]}
+    if num_gpus > 1:
+        spec["num_gpus"] = num_gpus
     return _run_direct_job(
         url=url,
         kind="dev",
         timeout=timeout,
         queue_wait_grace=queue_wait_grace,
         payload={
-            "spec": {"target_hardware": [hardware]},
+            "spec": spec,
             "command": command,
             "timeout_s": timeout,
             "env_vars": env_vars,
@@ -1891,9 +1938,11 @@ def _typed_agate_command(
     # --reference-dir at the private source while keeping the candidate in the
     # public workspace.  The private directory is never copied into the workspace.
     reference_dir = reference_dir or _private_reference_dir(workspace) or workspace
+    command += ["--gpu", args.hardware]
+    num_gpus = request.get("spec", {}).get("num_gpus", 1)
+    if num_gpus > 1:
+        command += ["--num-gpus", str(num_gpus)]
     command += [
-        "--gpu",
-        args.hardware,
         "--candidate",
         str(workspace / "kernel.py"),
         "--reference-dir",
@@ -2679,6 +2728,7 @@ def _run_typed_gateway(
                     "gateway_profile": args.gateway_profile,
                     "workspace": str(workspace),
                     "kind": kind,
+                    "num_gpus": request.get("spec", {}).get("num_gpus", 1),
                     "fallback_kind": "dev",
                     "candidate_bytes": len(request["candidate"].encode("utf-8")),
                     "shape_count": (
@@ -2919,6 +2969,10 @@ def _main(argv: list[str] | None = None) -> int:
         )
     if not workspace.is_dir():
         raise SystemExit(f"sandbox: workspace not found: {workspace}")
+    try:
+        num_gpus = _workspace_num_gpus(workspace)
+    except ValueError as exc:
+        raise SystemExit(f"sandbox: invalid distributed evaluator contract: {exc}") from exc
 
     gateway_kind = _requested_gateway_kind(args.kind, args.command)
     profile_command = _is_profile_command(args.command)
@@ -3072,6 +3126,7 @@ def _main(argv: list[str] | None = None) -> int:
                     "gateway_profile": args.gateway_profile,
                     "workspace": str(workspace),
                     "kind": "dev",
+                    "num_gpus": num_gpus,
                     "requested_kind": args.kind,
                     "typed_fallback_reason": typed_limitation,
                     "files": file_count,
@@ -3149,9 +3204,10 @@ def _main(argv: list[str] | None = None) -> int:
             agate += ["--url", args.url]
         elif args.gateway_profile:
             agate += ["--profile", args.gateway_profile]
+        agate += ["--gpu", args.hardware]
+        if num_gpus > 1:
+            agate += ["--num-gpus", str(num_gpus)]
         agate += [
-            "--gpu",
-            args.hardware,
             "--dev-timeout",
             str(args.timeout),
             "--http-timeout",
@@ -3234,6 +3290,7 @@ def _main(argv: list[str] | None = None) -> int:
                     env_items=gateway_environment,
                     files=direct_files,
                     command="bash __atrex_runner.sh",
+                    num_gpus=num_gpus,
                 )
             except (OSError, RuntimeError, TimeoutError) as exc:
                 raise SystemExit(

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -205,6 +205,7 @@ TYPED_FALLBACK_REASONS = (
 AGENT_PROBLEM_FILENAME = "agent_problem.json"
 MODE_STATE_FILENAME = ".orchestrator_mode.json"
 PRIVATE_REFERENCE_ENV = "ATREX_PRIVATE_REFERENCE_DIR"
+PRIVATE_EVALUATOR_FILENAMES = ("shapes.json", "metadata.json", "roofline.json")
 PRIVATE_PROFILE_CASE_FILENAME = ".atrex_private_profile_case.json"
 EPISODE_EVALUATIONS_PATH = ".atrex_long_horizon/evaluations.jsonl"
 PROFILE_ENVIRONMENT_KEYS = (
@@ -288,6 +289,7 @@ def _make_input_bundle(
     workspace: Path,
     max_file_bytes: int,
     input_paths: Iterable[str] = (),
+    injected_inputs: dict[str, Path] | None = None,
     injected_payloads: dict[str, bytes] | None = None,
 ) -> tuple[str, int, list[str]]:
     """Return a base64 tarball containing only explicitly selected inputs."""
@@ -341,6 +343,10 @@ def _make_input_bundle(
         count += 1
 
     with tarfile.open(fileobj=archive, mode="w:gz") as tf:
+        # Evaluator-only inputs are added before the public workspace tree so a candidate-created
+        # file with the same name cannot shadow the orchestrator-owned private test set.
+        for arcname, path in (injected_inputs or {}).items():
+            add_file(tf, path, arcname)
         for arcname, payload in (injected_payloads or {}).items():
             add_payload(tf, payload, arcname)
         add_tree(tf, workspace)
@@ -1091,6 +1097,20 @@ def _evaluator_input_path(workspace: Path, filename: str, *, required: bool) -> 
     if required and not path.is_file():
         raise ValueError(f"required evaluator input is missing: {filename}")
     return path
+
+
+def _private_evaluator_inputs(workspace: Path) -> dict[str, Path]:
+    private_dir = _private_reference_dir(workspace)
+    if private_dir is None:
+        return {}
+    inputs: dict[str, Path] = {}
+    for filename in PRIVATE_EVALUATOR_FILENAMES:
+        path = private_dir / filename
+        if filename in {"shapes.json", "metadata.json"} and not path.is_file():
+            raise ValueError(f"required private evaluator input is missing: {filename}")
+        if path.is_file():
+            inputs[filename] = path
+    return inputs
 
 
 def _sort_shape_id(shape_id: str) -> tuple[int, object]:
@@ -3405,16 +3425,6 @@ def _main(argv: list[str] | None = None) -> int:
         typed_fallback_kind = gateway_kind
         gateway_kind = "dev"
 
-    if (
-        gateway_kind == "dev"
-        and evaluator_command
-        and _is_generalized_workspace(workspace)
-    ):
-        limitation = f" ({typed_limitation})" if typed_limitation else ""
-        raise SystemExit(
-            "sandbox: generalized evaluator commands require the typed run route"
-            f"{limitation}; private evaluator inputs are never injected into dev commands"
-        )
     if gateway_kind == "dev" and profile_request and num_gpus > 1:
         limitation = f" ({typed_limitation})" if typed_limitation else ""
         raise SystemExit(
@@ -3446,6 +3456,9 @@ def _main(argv: list[str] | None = None) -> int:
         except ValueError as exc:
             raise SystemExit(f"sandbox: {exc}") from exc
     try:
+        injected_inputs = (
+            _private_evaluator_inputs(workspace) if evaluator_command else {}
+        )
         injected_payloads: dict[str, bytes] = {}
         if profile_command and _is_generalized_workspace(workspace):
             profile_case = _private_profile_case(workspace, args.env)
@@ -3457,6 +3470,7 @@ def _main(argv: list[str] | None = None) -> int:
             workspace,
             args.max_input_file_mb * 1024 * 1024,
             selected_inputs,
+            injected_inputs,
             injected_payloads,
         )
     except (OSError, UnicodeDecodeError, ValueError) as exc:

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -430,8 +430,22 @@ def _expand_workspace_input(workspace: Path, value: str) -> set[str]:
     raise ValueError(f"sandbox input does not exist: {value!r}")
 
 
+def _parsed_command_parts(parts: list[str]) -> tuple[list[str], bool]:
+    """Return command words and whether a single shell string stayed opaque."""
+    command = parts[1:] if parts and parts[0] == "--" else list(parts)
+    if len(command) != 1:
+        return command, False
+    try:
+        parsed = shlex.split(command[0])
+    except ValueError:
+        return command, True
+    if shlex.join(parsed) == command[0]:
+        return parsed, False
+    return command, True
+
+
 def _command_parts(parts: list[str]) -> list[str]:
-    return parts[1:] if parts and parts[0] == "--" else list(parts)
+    return _parsed_command_parts(parts)[0]
 
 
 def _python_inline_imports(parts: list[str]) -> set[str]:
@@ -539,14 +553,10 @@ def _command_input_paths(
     return frozenset(selected)
 
 
-def _test_kernel_script_index(
-    parts: list[str], *, typed_launcher: bool = False
+def _command_executable_index(
+    command: list[str], *, typed_launcher: bool = False
 ) -> int | None:
-    """Locate the evaluator; optionally require a prefix typed run may omit."""
-    command = _command_parts(parts)
-    if not command:
-        return None
-
+    """Skip supported shell assignments and an optional env wrapper."""
     def assignment_end(start: int, *, shell_prefix: bool = False) -> int | None:
         while start < len(command):
             name, separator, _ = command[start].partition("=")
@@ -602,9 +612,20 @@ def _test_kernel_script_index(
         index = assignment_end(index)
         if index is None:
             return None
+    return index if index < len(command) else None
+
+
+def _python_script_index(
+    parts: list[str], script_name: str, *, typed_launcher: bool = False
+) -> int | None:
+    """Locate a Python script; optionally require a prefix typed run may omit."""
+    command, opaque = _parsed_command_parts(parts)
+    if opaque:
+        return None
+    index = _command_executable_index(command, typed_launcher=typed_launcher)
 
     if (
-        index >= len(command)
+        index is None
         or re.fullmatch(r"python(?:3(?:\.\d+)*)?", Path(command[index]).name) is None
     ):
         return None
@@ -646,9 +667,17 @@ def _test_kernel_script_index(
             return None
         break
 
-    if index < len(command) and Path(command[index]).name == "test_kernel.py":
+    if index < len(command) and Path(command[index]).name == script_name:
         return index
     return None
+
+
+def _test_kernel_script_index(
+    parts: list[str], *, typed_launcher: bool = False
+) -> int | None:
+    return _python_script_index(
+        parts, "test_kernel.py", typed_launcher=typed_launcher
+    )
 
 
 def _is_test_kernel_command(parts: list[str]) -> bool:
@@ -657,11 +686,55 @@ def _is_test_kernel_command(parts: list[str]) -> bool:
 
 def _is_profile_command(parts: list[str]) -> bool:
     """Return whether argv invokes one of the repository profiler wrappers."""
-    return any(
-        Path(token).name
-        in {"profile_nvidia.sh", "profile_kernel.sh", "profile_driver.py"}
-        for token in _command_parts(parts)
+    command, opaque = _parsed_command_parts(parts)
+    if opaque:
+        return False
+    if _python_script_index(command, "profile_driver.py") is not None:
+        return True
+    index = _command_executable_index(command)
+    if index is None:
+        return False
+    wrappers = {"profile_nvidia.sh", "profile_kernel.sh"}
+    executable = Path(command[index]).name
+    return executable == "profile_driver.py" or executable in wrappers or (
+        executable in {"bash", "sh"}
+        and index + 1 < len(command)
+        and Path(command[index + 1]).name in wrappers
     )
+
+
+def _is_opaque_target_command(parts: list[str]) -> bool:
+    """Reject shell strings that hide an evaluator or profiler invocation."""
+    command, opaque = _parsed_command_parts(parts)
+    if len(command) != 1 or not opaque:
+        return False
+    lexer = shlex.shlex(command[0], posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    parsed: list[str] = []
+    try:
+        while (token := lexer.get_token()) is not None:
+            parsed.append(token)
+    except ValueError:
+        pass
+    if not parsed:
+        return False
+    name, separator, _ = parsed[0].partition("=")
+    if separator and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+        if re.match(rf"^\s*{re.escape(name)}=", command[0]) is None:
+            return False
+        for index, token in enumerate(parsed):
+            assignment, separator, _ = token.partition("=")
+            if not separator or re.fullmatch(
+                r"[A-Za-z_][A-Za-z0-9_]*", assignment
+            ) is None:
+                break
+            parsed[index] = f"{assignment}=x"
+    elif any(character.isspace() for character in parsed[0]):
+        return False
+    return (
+        len(parsed) >= 2 and _is_test_kernel_command(parsed)
+    ) or _is_profile_command(parsed)
 
 
 def _option_value(parts: list[str], name: str, default: Any = None) -> Any:
@@ -3082,18 +3155,25 @@ def _main(argv: list[str] | None = None) -> int:
         )
     if not workspace.is_dir():
         raise SystemExit(f"sandbox: workspace not found: {workspace}")
+    if _is_opaque_target_command(args.command):
+        raise SystemExit(
+            "sandbox: evaluator and profile commands cannot be passed as opaque "
+            "shell strings; pass the command as separate arguments after --"
+        )
 
     gateway_kind = _requested_gateway_kind(args.kind, args.command)
     evaluator_command = _is_test_kernel_command(args.command)
     profile_command = _is_profile_command(args.command)
+    profile_request = gateway_kind == "profile" or profile_command
     if profile_command:
         try:
             args.env = _with_inherited_profile_environment(args.env)
         except ValueError as exc:
             raise SystemExit(f"sandbox: {exc}") from exc
     typed_limitation: str | None = None
+    typed_fallback_kind: str | None = None
     num_gpus = 1
-    if gateway_kind in TYPED_KINDS or evaluator_command:
+    if gateway_kind in TYPED_KINDS or evaluator_command or profile_request:
         try:
             num_gpus = _workspace_num_gpus(workspace)
         except ValueError as exc:
@@ -3134,16 +3214,21 @@ def _main(argv: list[str] | None = None) -> int:
             if typed_result is not None:
                 return typed_result
             typed_limitation = f"gateway {gateway_kind} route unavailable or rejected the source contract"
-        if gateway_kind == "profile" and num_gpus > 1:
-            raise SystemExit(
-                "sandbox: distributed profile cannot fall back to dev "
-                f"({typed_limitation}); the dev route does not launch ranks"
-            )
+        typed_fallback_kind = gateway_kind
+        gateway_kind = "dev"
+
+    if gateway_kind == "dev" and profile_request and num_gpus > 1:
+        limitation = f" ({typed_limitation})" if typed_limitation else ""
+        raise SystemExit(
+            "sandbox: distributed profile commands require the typed profile route"
+            f"{limitation}; "
+            "the dev route does not launch ranks"
+        )
+    if typed_fallback_kind is not None:
         print(
-            f"[sandbox] {gateway_kind} interface unsupported ({typed_limitation}); using dev",
+            f"[sandbox] {typed_fallback_kind} interface unsupported ({typed_limitation}); using dev",
             file=sys.stderr,
         )
-        gateway_kind = "dev"
 
     if evaluator_command:
         selected = set(_evaluation_input_paths(workspace, args.command))

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -539,13 +539,110 @@ def _command_input_paths(
     return frozenset(selected)
 
 
-def _is_test_kernel_command(parts: list[str]) -> bool:
+def _test_kernel_script_index(
+    parts: list[str], *, typed_launcher: bool = False
+) -> int | None:
+    """Locate the evaluator; optionally require a prefix typed run may omit."""
     command = _command_parts(parts)
-    return (
-        len(command) >= 2
-        and re.fullmatch(r"python(?:3(?:\.\d+)*)?", Path(command[0]).name) is not None
-        and Path(command[1]).name == "test_kernel.py"
-    )
+    if not command:
+        return None
+
+    index = 0
+    if command[index] in {"env", "/usr/bin/env"}:
+        index += 1
+        while index < len(command):
+            option = command[index]
+            if option == "--":
+                index += 1
+                break
+            if option == "-" or option == "--ignore-environment" or option == "--debug":
+                if typed_launcher:
+                    return None
+                index += 1
+                continue
+            if re.fullmatch(r"-[iv]+", option):
+                if typed_launcher:
+                    return None
+                index += 1
+                continue
+            if option in {"-u", "--unset"}:
+                if index + 1 >= len(command):
+                    return None
+                if typed_launcher:
+                    return None
+                index += 2
+                continue
+            if (option.startswith("-u") and len(option) > 2) or (
+                option.startswith("--unset=") and len(option) > len("--unset=")
+            ):
+                if typed_launcher:
+                    return None
+                index += 1
+                continue
+            if option.startswith("-"):
+                return None
+            break
+        while index < len(command):
+            name, separator, _ = command[index].partition("=")
+            if not separator or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name) is None:
+                break
+            if typed_launcher and name not in {
+                "PYTHONDONTWRITEBYTECODE",
+                "PYTHONUNBUFFERED",
+            }:
+                return None
+            index += 1
+
+    if (
+        index >= len(command)
+        or re.fullmatch(r"python(?:3(?:\.\d+)*)?", Path(command[index]).name) is None
+    ):
+        return None
+    index += 1
+    while index < len(command):
+        option = command[index]
+        if option == "--":
+            index += 1
+            break
+        if re.fullmatch(r"-[bBdEiIOPqRsSuvx]+", option):
+            if typed_launcher and re.fullmatch(r"-[Bu]+", option) is None:
+                return None
+            index += 1
+            continue
+        if option in {"-W", "-X"}:
+            if index + 1 >= len(command):
+                return None
+            if typed_launcher:
+                return None
+            index += 2
+            continue
+        if len(option) > 2 and option.startswith(("-W", "-X")):
+            if typed_launcher:
+                return None
+            index += 1
+            continue
+        if option == "--check-hash-based-pycs":
+            if index + 1 >= len(command) or command[index + 1] not in {
+                "always",
+                "default",
+                "never",
+            }:
+                return None
+            if typed_launcher:
+                return None
+            index += 2
+            continue
+        if option.startswith("-"):
+            return None
+        break
+
+    if index < len(command) and Path(command[index]).name == "test_kernel.py":
+        return index
+    return None
+
+
+def _is_test_kernel_command(parts: list[str]) -> bool:
+    return _test_kernel_script_index(parts) is not None
 
 
 def _is_profile_command(parts: list[str]) -> bool:
@@ -770,6 +867,12 @@ def _typed_workspace_limitation(
         _evaluator_input_path(workspace, "shapes.json", required=True)
     except ValueError as exc:
         return str(exc)
+    if (
+        kind == "run"
+        and _is_test_kernel_command(command)
+        and _test_kernel_script_index(command, typed_launcher=True) is None
+    ):
+        return "evaluator launcher semantics require the dev route"
     if kind == "profile" and _is_generalized_workspace(workspace):
         return "generalized tasks inject one private real shape through the dev profile route"
     if (workspace / "workload.jsonl").is_file():

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -205,7 +205,6 @@ TYPED_FALLBACK_REASONS = (
 AGENT_PROBLEM_FILENAME = "agent_problem.json"
 MODE_STATE_FILENAME = ".orchestrator_mode.json"
 PRIVATE_REFERENCE_ENV = "ATREX_PRIVATE_REFERENCE_DIR"
-PRIVATE_EVALUATOR_FILENAMES = ("shapes.json", "metadata.json", "roofline.json")
 PRIVATE_PROFILE_CASE_FILENAME = ".atrex_private_profile_case.json"
 EPISODE_EVALUATIONS_PATH = ".atrex_long_horizon/evaluations.jsonl"
 PROFILE_ENVIRONMENT_KEYS = (
@@ -289,7 +288,6 @@ def _make_input_bundle(
     workspace: Path,
     max_file_bytes: int,
     input_paths: Iterable[str] = (),
-    injected_inputs: dict[str, Path] | None = None,
     injected_payloads: dict[str, bytes] | None = None,
 ) -> tuple[str, int, list[str]]:
     """Return a base64 tarball containing only explicitly selected inputs."""
@@ -343,10 +341,6 @@ def _make_input_bundle(
         count += 1
 
     with tarfile.open(fileobj=archive, mode="w:gz") as tf:
-        # Evaluator-only inputs are added before the public workspace tree so a candidate-created
-        # file with the same name cannot shadow the orchestrator-owned private test set.
-        for arcname, path in (injected_inputs or {}).items():
-            add_file(tf, path, arcname)
         for arcname, payload in (injected_payloads or {}).items():
             add_payload(tf, payload, arcname)
         add_tree(tf, workspace)
@@ -553,6 +547,14 @@ def _command_input_paths(
     return frozenset(selected)
 
 
+def _standard_command_name(value: str, names: set[str]) -> str | None:
+    """Return a command name only for PATH lookup or a conventional system path."""
+    name = Path(value).name
+    if name in names and value in {name, f"/bin/{name}", f"/usr/bin/{name}"}:
+        return name
+    return None
+
+
 def _command_executable_index(
     command: list[str], *, typed_launcher: bool = False
 ) -> int | None:
@@ -592,15 +594,16 @@ def _command_executable_index(
                     return None
                 index += 1
                 continue
-            if option in {"-u", "--unset"}:
+            if option in {"-C", "--chdir", "-u", "--unset"}:
                 if index + 1 >= len(command):
                     return None
                 if typed_launcher:
                     return None
                 index += 2
                 continue
-            if (option.startswith("-u") and len(option) > 2) or (
-                option.startswith("--unset=") and len(option) > len("--unset=")
+            if (option.startswith(("-C", "-u")) and len(option) > 2) or (
+                option.startswith(("--chdir=", "--unset="))
+                and option.partition("=")[2]
             ):
                 if typed_launcher:
                     return None
@@ -613,8 +616,12 @@ def _command_executable_index(
         if index is None:
             return None
     while index < len(command):
-        wrapper = Path(command[index]).name
-        if wrapper not in {"command", "exec", "nice", "time"}:
+        launcher = command[index]
+        wrapper = _standard_command_name(
+            launcher,
+            {"command", "exec", "nice", "nohup", "stdbuf", "time", "timeout"},
+        )
+        if wrapper is None:
             break
         if typed_launcher:
             return None
@@ -669,7 +676,7 @@ def _command_executable_index(
                 if option.startswith("-"):
                     return None
                 break
-        else:
+        elif wrapper == "time":
             while index < len(command):
                 option = command[index]
                 if option == "--":
@@ -692,6 +699,59 @@ def _command_executable_index(
                 if option.startswith("-"):
                     return None
                 break
+        elif wrapper == "timeout":
+            while index < len(command):
+                option = command[index]
+                if option == "--":
+                    index += 1
+                    break
+                if option in {"-k", "--kill-after", "-s", "--signal"}:
+                    if index + 1 >= len(command):
+                        return None
+                    index += 2
+                    continue
+                if (
+                    re.fullmatch(r"-[ks].+", option)
+                    or option.startswith(("--kill-after=", "--signal="))
+                    or option in {"--foreground", "--preserve-status", "--verbose"}
+                ):
+                    index += 1
+                    continue
+                if option.startswith("-"):
+                    return None
+                break
+            if index >= len(command):
+                return None
+            index += 1
+        elif wrapper == "stdbuf":
+            while index < len(command):
+                option = command[index]
+                if option == "--":
+                    index += 1
+                    break
+                if option in {"-e", "--error", "-i", "--input", "-o", "--output"}:
+                    if index + 1 >= len(command):
+                        return None
+                    index += 2
+                    continue
+                if re.fullmatch(r"-[eio].+", option) or option.startswith(
+                    ("--error=", "--input=", "--output=")
+                ):
+                    index += 1
+                    continue
+                if option.startswith("-"):
+                    return None
+                break
+        else:
+            if index < len(command) and command[index] == "--":
+                index += 1
+            elif index < len(command) and command[index].startswith("-"):
+                return None
+    if index < len(command) and command[index] in {"env", "/usr/bin/env"}:
+        nested = _command_executable_index(
+            command[index:], typed_launcher=typed_launcher
+        )
+        return index + nested if nested is not None else None
     return index if index < len(command) else None
 
 
@@ -768,8 +828,8 @@ def _shell_command_operand(
     command: list[str], executable_index: int
 ) -> tuple[str, int] | None:
     """Locate a shell script or the command string consumed by ``-c``."""
-    shell = Path(command[executable_index]).name
-    if shell not in {"bash", "sh"}:
+    shell = _standard_command_name(command[executable_index], {"bash", "sh"})
+    if shell is None:
         return None
     index = executable_index + 1
     while index < len(command):
@@ -835,108 +895,48 @@ def _is_profile_command(parts: list[str]) -> bool:
     index = _command_executable_index(command)
     if index is None:
         return False
-    wrappers = {"profile_nvidia.sh", "profile_kernel.sh"}
-    executable = Path(command[index]).name
-    if executable == "profile_driver.py" or executable in wrappers:
+    frontend = _standard_command_name(command[index], {"ncu", "nsys", "rocprofv3"})
+    if frontend is not None and (
+        frontend != "nsys"
+        or (index + 1 < len(command) and command[index + 1] == "profile")
+    ):
+        for nested_index in range(index + 1, len(command)):
+            if (
+                _python_script_index(
+                    command[nested_index:], "profile_driver.py"
+                )
+                is not None
+            ):
+                return True
+    wrappers = {"tools/profile_nvidia.sh", "tools/profile_kernel.sh"}
+    executable = PurePosixPath(command[index]).as_posix()
+    if Path(executable).name == "profile_driver.py" or executable in wrappers:
         return True
     operand = _shell_command_operand(command, index)
     return bool(
         operand
         and operand[0] == "script"
-        and Path(command[operand[1]]).name in wrappers
+        and PurePosixPath(command[operand[1]]).as_posix() in wrappers
     )
 
 
-def _shell_text_tokens(command: str) -> list[str]:
-    """Tokenize one simple shell command for rejection-only inspection."""
-    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
-    lexer.whitespace_split = True
-    lexer.commenters = ""
-    parsed: list[str] = []
-    try:
-        while (token := lexer.get_token()) is not None:
-            parsed.append(token)
-    except ValueError:
-        pass
-    if not parsed:
-        return []
-    name, separator, _ = parsed[0].partition("=")
-    if separator and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
-        if re.match(rf"^\s*{re.escape(name)}=", command) is None:
-            return []
-        for index, token in enumerate(parsed):
-            assignment, separator, _ = token.partition("=")
-            if not separator or re.fullmatch(
-                r"[A-Za-z_][A-Za-z0-9_]*", assignment
-            ) is None:
-                break
-            parsed[index] = f"{assignment}=x"
-    elif any(character.isspace() for character in parsed[0]):
-        return []
-    return parsed
+def _mentions_evaluator_target(value: str) -> bool:
+    """Find target names in shell text without pretending to parse shell grammar."""
+    unquoted = value.translate(str.maketrans("", "", "\\'\""))
+    return re.search(
+        r"(?<![A-Za-z0-9_.-])"
+        r"(?:test_kernel\.py|profile_driver\.py|profile_nvidia\.sh|profile_kernel\.sh)"
+        r"(?![A-Za-z0-9_.-])",
+        unquoted,
+    ) is not None
 
 
-def _shell_command_segments(command: str) -> list[str]:
-    """Split on unquoted shell control operators without executing the command."""
-    segments: list[str] = []
-    start = 0
-    quote: str | None = None
-    escaped = False
-    for index, character in enumerate(command):
-        if escaped:
-            escaped = False
-            continue
-        if character == "\\" and quote != "'":
-            escaped = True
-            continue
-        if quote is not None:
-            if character == quote:
-                quote = None
-            continue
-        if character in {"'", '"'}:
-            quote = character
-            continue
-        if character in "&|;()<>\n{}":
-            segment = command[start:index].strip()
-            if segment:
-                segments.append(segment)
-            start = index + 1
-    segment = command[start:].strip()
-    if segment:
-        segments.append(segment)
-    return segments
-
-
-def _nested_shell_command(command: list[str]) -> str | None:
-    executable_index = _command_executable_index(command)
-    if executable_index is None:
-        return None
-    operand = _shell_command_operand(command, executable_index)
-    if operand and operand[0] == "command":
-        return command[operand[1]]
-    return None
-
-
-def _shell_text_has_target(command: str) -> bool:
-    for segment in _shell_command_segments(command):
-        parsed = _shell_text_tokens(segment)
-        if not parsed:
-            continue
-        if _is_test_kernel_command(parsed) or _is_profile_command(parsed):
-            return True
-        nested = _nested_shell_command(parsed)
-        if nested is not None and _shell_text_has_target(nested):
-            return True
-    return False
-
-
-def _is_opaque_target_command(parts: list[str]) -> bool:
-    """Reject evaluator or profiler invocations hidden inside shell syntax."""
-    command, opaque = _parsed_command_parts(parts)
-    if opaque:
-        return len(command) == 1 and _shell_text_has_target(command[0])
-    nested = _nested_shell_command(command)
-    return nested is not None and _shell_text_has_target(nested)
+def _is_unsafe_target_command(parts: list[str]) -> bool:
+    """Reject target-bearing commands outside the supported launcher grammar."""
+    command, _ = _parsed_command_parts(parts)
+    if _is_test_kernel_command(command) or _is_profile_command(command):
+        return False
+    return any(_mentions_evaluator_target(token) for token in command)
 
 
 def _option_value(parts: list[str], name: str, default: Any = None) -> Any:
@@ -1091,20 +1091,6 @@ def _evaluator_input_path(workspace: Path, filename: str, *, required: bool) -> 
     if required and not path.is_file():
         raise ValueError(f"required evaluator input is missing: {filename}")
     return path
-
-
-def _private_evaluator_inputs(workspace: Path) -> dict[str, Path]:
-    private_dir = _private_reference_dir(workspace)
-    if private_dir is None:
-        return {}
-    inputs: dict[str, Path] = {}
-    for filename in PRIVATE_EVALUATOR_FILENAMES:
-        path = private_dir / filename
-        if filename in {"shapes.json", "metadata.json"} and not path.is_file():
-            raise ValueError(f"required private evaluator input is missing: {filename}")
-        if path.is_file():
-            inputs[filename] = path
-    return inputs
 
 
 def _sort_shape_id(shape_id: str) -> tuple[int, object]:
@@ -3357,10 +3343,10 @@ def _main(argv: list[str] | None = None) -> int:
         )
     if not workspace.is_dir():
         raise SystemExit(f"sandbox: workspace not found: {workspace}")
-    if _is_opaque_target_command(args.command):
+    if _is_unsafe_target_command(args.command):
         raise SystemExit(
-            "sandbox: evaluator and profile commands cannot be passed as opaque "
-            "shell strings; pass the command as separate arguments after --"
+            "sandbox: evaluator and profile targets must use a supported launcher "
+            "with separate arguments after --"
         )
 
     gateway_kind = _requested_gateway_kind(args.kind, args.command)
@@ -3419,6 +3405,16 @@ def _main(argv: list[str] | None = None) -> int:
         typed_fallback_kind = gateway_kind
         gateway_kind = "dev"
 
+    if (
+        gateway_kind == "dev"
+        and evaluator_command
+        and _is_generalized_workspace(workspace)
+    ):
+        limitation = f" ({typed_limitation})" if typed_limitation else ""
+        raise SystemExit(
+            "sandbox: generalized evaluator commands require the typed run route"
+            f"{limitation}; private evaluator inputs are never injected into dev commands"
+        )
     if gateway_kind == "dev" and profile_request and num_gpus > 1:
         limitation = f" ({typed_limitation})" if typed_limitation else ""
         raise SystemExit(
@@ -3450,9 +3446,6 @@ def _main(argv: list[str] | None = None) -> int:
         except ValueError as exc:
             raise SystemExit(f"sandbox: {exc}") from exc
     try:
-        injected_inputs = (
-            _private_evaluator_inputs(workspace) if evaluator_command else {}
-        )
         injected_payloads: dict[str, bytes] = {}
         if profile_command and _is_generalized_workspace(workspace):
             profile_case = _private_profile_case(workspace, args.env)
@@ -3464,7 +3457,6 @@ def _main(argv: list[str] | None = None) -> int:
             workspace,
             args.max_input_file_mb * 1024 * 1024,
             selected_inputs,
-            injected_inputs,
             injected_payloads,
         )
     except (OSError, UnicodeDecodeError, ValueError) as exc:

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -2969,10 +2969,6 @@ def _main(argv: list[str] | None = None) -> int:
         )
     if not workspace.is_dir():
         raise SystemExit(f"sandbox: workspace not found: {workspace}")
-    try:
-        num_gpus = _workspace_num_gpus(workspace)
-    except ValueError as exc:
-        raise SystemExit(f"sandbox: invalid distributed evaluator contract: {exc}") from exc
 
     gateway_kind = _requested_gateway_kind(args.kind, args.command)
     profile_command = _is_profile_command(args.command)
@@ -2982,7 +2978,14 @@ def _main(argv: list[str] | None = None) -> int:
         except ValueError as exc:
             raise SystemExit(f"sandbox: {exc}") from exc
     typed_limitation: str | None = None
+    num_gpus = 1
     if gateway_kind in TYPED_KINDS:
+        try:
+            num_gpus = _workspace_num_gpus(workspace)
+        except ValueError as exc:
+            raise SystemExit(
+                f"sandbox: invalid distributed evaluator contract: {exc}"
+            ) from exc
         if (
             gateway_kind == "profile"
             and args.profile_level == "deep"

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -684,6 +684,29 @@ def _is_test_kernel_command(parts: list[str]) -> bool:
     return _test_kernel_script_index(parts) is not None
 
 
+def _shell_command_operand(
+    command: list[str], executable_index: int
+) -> tuple[str, int] | None:
+    """Locate a shell script or the command string consumed by ``-c``."""
+    if Path(command[executable_index]).name not in {"bash", "sh"}:
+        return None
+    index = executable_index + 1
+    while index < len(command):
+        option = command[index]
+        if option == "--":
+            index += 1
+            break
+        if re.fullmatch(r"-[abefhiklmpruvxBCHPc]+", option):
+            if "c" in option[1:]:
+                return ("command", index + 1) if index + 1 < len(command) else None
+            index += 1
+            continue
+        if option.startswith("-"):
+            return None
+        break
+    return ("script", index) if index < len(command) else None
+
+
 def _is_profile_command(parts: list[str]) -> bool:
     """Return whether argv invokes one of the repository profiler wrappers."""
     command, opaque = _parsed_command_parts(parts)
@@ -696,19 +719,19 @@ def _is_profile_command(parts: list[str]) -> bool:
         return False
     wrappers = {"profile_nvidia.sh", "profile_kernel.sh"}
     executable = Path(command[index]).name
-    return executable == "profile_driver.py" or executable in wrappers or (
-        executable in {"bash", "sh"}
-        and index + 1 < len(command)
-        and Path(command[index + 1]).name in wrappers
+    if executable == "profile_driver.py" or executable in wrappers:
+        return True
+    operand = _shell_command_operand(command, index)
+    return bool(
+        operand
+        and operand[0] == "script"
+        and Path(command[operand[1]]).name in wrappers
     )
 
 
-def _is_opaque_target_command(parts: list[str]) -> bool:
-    """Reject shell strings that hide an evaluator or profiler invocation."""
-    command, opaque = _parsed_command_parts(parts)
-    if len(command) != 1 or not opaque:
-        return False
-    lexer = shlex.shlex(command[0], posix=True, punctuation_chars=True)
+def _shell_text_tokens(command: str) -> list[str]:
+    """Tokenize one simple shell command for rejection-only inspection."""
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
     lexer.whitespace_split = True
     lexer.commenters = ""
     parsed: list[str] = []
@@ -718,11 +741,11 @@ def _is_opaque_target_command(parts: list[str]) -> bool:
     except ValueError:
         pass
     if not parsed:
-        return False
+        return []
     name, separator, _ = parsed[0].partition("=")
     if separator and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
-        if re.match(rf"^\s*{re.escape(name)}=", command[0]) is None:
-            return False
+        if re.match(rf"^\s*{re.escape(name)}=", command) is None:
+            return []
         for index, token in enumerate(parsed):
             assignment, separator, _ = token.partition("=")
             if not separator or re.fullmatch(
@@ -731,10 +754,71 @@ def _is_opaque_target_command(parts: list[str]) -> bool:
                 break
             parsed[index] = f"{assignment}=x"
     elif any(character.isspace() for character in parsed[0]):
-        return False
-    return (
-        len(parsed) >= 2 and _is_test_kernel_command(parsed)
-    ) or _is_profile_command(parsed)
+        return []
+    return parsed
+
+
+def _shell_command_segments(command: str) -> list[str]:
+    """Split on unquoted shell control operators without executing the command."""
+    segments: list[str] = []
+    start = 0
+    quote: str | None = None
+    escaped = False
+    for index, character in enumerate(command):
+        if escaped:
+            escaped = False
+            continue
+        if character == "\\" and quote != "'":
+            escaped = True
+            continue
+        if quote is not None:
+            if character == quote:
+                quote = None
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            continue
+        if character in "&|;()<>\n{}":
+            segment = command[start:index].strip()
+            if segment:
+                segments.append(segment)
+            start = index + 1
+    segment = command[start:].strip()
+    if segment:
+        segments.append(segment)
+    return segments
+
+
+def _nested_shell_command(command: list[str]) -> str | None:
+    executable_index = _command_executable_index(command)
+    if executable_index is None:
+        return None
+    operand = _shell_command_operand(command, executable_index)
+    if operand and operand[0] == "command":
+        return command[operand[1]]
+    return None
+
+
+def _shell_text_has_target(command: str) -> bool:
+    for segment in _shell_command_segments(command):
+        parsed = _shell_text_tokens(segment)
+        if not parsed:
+            continue
+        if _is_test_kernel_command(parsed) or _is_profile_command(parsed):
+            return True
+        nested = _nested_shell_command(parsed)
+        if nested is not None and _shell_text_has_target(nested):
+            return True
+    return False
+
+
+def _is_opaque_target_command(parts: list[str]) -> bool:
+    """Reject evaluator or profiler invocations hidden inside shell syntax."""
+    command, opaque = _parsed_command_parts(parts)
+    if opaque:
+        return len(command) == 1 and _shell_text_has_target(command[0])
+    nested = _nested_shell_command(command)
+    return nested is not None and _shell_text_has_target(nested)
 
 
 def _option_value(parts: list[str], name: str, default: Any = None) -> Any:


### PR DESCRIPTION
## Summary

- derive the requested GPU count from `benchmark_contract.distributed_evaluation`
- propagate `num_gpus` through typed eval/profile, agate dev fallback, and direct-gateway requests
- validate the supported single-node contract as `torchrun` + `nccl` + `world_size=2`
- preserve the existing one-GPU request shape when no distributed contract is present

## Validation

- `git diff --check`
- `python3 -m py_compile tools/sandbox.py`
- `python3 -m compileall -q tools long_horizon orchestrator`
- focused positive/negative smoke coverage for distributed evaluator metadata parsing

No additional GPU evaluation job was submitted.