### PR TITLE
[WIP] Add staged architectural initiative checkpoints

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -130,14 +130,15 @@ runtime-detected GPU vendor.
 3. Create one private branch/worktree per canonical version. The first two optimization episodes use
    five fast `plan -> implement -> evaluator` trials per episode by default; later episodes use the
    full evidence loop. The primary Agent uses maximum reasoning effort in both modes.
-4. Validate its structured journal and `candidate_ready`, `pivot`, or `blocked` handoff, with
-   bounded same-thread recovery for Claude and Codex.
+4. Validate its structured journal and `candidate_ready`, `staged_ready`, `pivot`, or `blocked`
+   handoff, with bounded same-thread recovery for Claude and Codex.
 5. Check protected paths, the exact committed `kernel.py`, and production policy while allowing
    uncommitted intermediate artifacts to remain in the episode worktree.
 6. Select the fastest passing hash-matched result from each fast episode's five trials and compare it
    with canonical incumbent memory; compare full-mode candidates in one independent ABBA allocation.
-7. Squash-promote only a strict correctness-passing improvement; otherwise commit only canonical
-   failure/pivot/block evidence.
+7. Squash-promote only a strict correctness-passing improvement. When explicitly enabled, retain a
+   structurally valid `staged_ready` kernel outside the incumbent and bootstrap it into the next
+   full episode; otherwise commit only canonical failure/pivot/block evidence.
 8. Stop on version budget, token budget, optional stall budget, or target utilization.
 9. Recheck production policy and package the final candidate.
 
@@ -228,7 +229,7 @@ correctness and performance-parity gates.
 `Campaign.run()` in `orchestrator/campaign.py` invokes the internal Long Horizon engine. It creates
 an isolated branch and Git worktree from the incumbent for each episode. The Agent records
 structured experiments in a journal and publishes one terminal handoff: `candidate_ready`,
-`pivot`, or `blocked`.
+`staged_ready`, `pivot`, or `blocked`.
 
 A candidate must commit a `kernel.py` that still matches the worktree, preserve protected paths, and
 satisfy production policy. Other uncommitted intermediate artifacts may remain in the worktree.
@@ -238,6 +239,20 @@ must pass the exact same-allocation ABBA schedule. Accepted candidates are squas
 canonical memory; rejected and non-candidate episodes advance memory without changing the incumbent.
 Every round's numbered memory is checked against committed `HEAD` before state advances. Active
 episode state supports crash recovery.
+
+A new staged initiative becomes eligible after `--staged-after-episodes N` completed optimization
+episodes (default 40) or `--staged-after-stall S` consecutive episodes without a production
+promotion (default 8). `--max-staged-episodes M` then permits up to M consecutive full-episode
+architectural checkpoints (default 4). A staged checkpoint must be an exact `kernel.py` commit,
+continue one named initiative with monotonic stage numbers, compile, and prove a bounded material
+advance toward a stable escape hypothesis, architectural delta, final success criterion, and abort
+criterion. Compilation, parameter-only tuning, or renaming the incumbent path is not advancement.
+The checkpoint skips performance promotion verification and never changes the production incumbent.
+The next isolated worktree is created from the current incumbent and receives a supervisor-authored
+bootstrap commit containing only the staged kernel, so a later final candidate still has a clean
+cumulative `kernel.py`-only diff. Fast episodes and campaigns setting `--max-staged-episodes 0`
+reject `staged_ready`. Staging does not reset the promotion-drought counter; only a verified
+production promotion does.
 
 ## End-to-End Flow
 
@@ -313,6 +328,13 @@ the worktree's exact committed `kernel.py`, and the candidate commit, then appli
 fast comparison or incumbent/candidate ABBA gate. A rejected candidate, `pivot`, or `blocked` outcome
 advances canonical memory without changing the incumbent. Active episode state is restart-safe and
 reuses the registered worktree with its intermediate files after a supervisor restart.
+
+When staged initiatives are enabled, `staged_ready` also advances canonical memory without changing
+the incumbent, while atomically retaining the checkpoint under `.atrex_long_horizon/`. A final
+`candidate_ready` must still pass the unchanged production-policy, correctness, and strict
+performance gates; staging does not lower `--min-improvement-pct`. Supervisor state records started,
+promoted, and abandoned initiative counts so monitoring can distinguish useful architectural escape
+from checkpoint churn.
 
 For progress visibility, the supervisor creates ignored `memory/live.json` at episode start and the
 journal command refreshes it after every decisive experiment. This live view is explicitly

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -277,6 +277,12 @@ Rerunning the same command keeps the interrupted worktree and resumes V1 from th
 --sandbox-timeout S              Remote command timeout, at most 600 seconds
 --workspace DIR                  Campaign parent directory (default: current directory)
 --max-stall N                    Stop after N unpromoted episodes (0 = disabled)
+--max-staged-episodes N          Allow N consecutive full-episode architectural checkpoints
+                                 without production promotion (default: 4; 0 disables)
+--staged-after-episodes N        Completed optimization episodes before a new staged initiative
+                                 may start (default: 40; first eligible episode is 41)
+--staged-after-stall N           Consecutive unpromoted episodes before an architectural escape
+                                 initiative may start (default: 8; 0 disables this trigger)
 --convert-after N                Triton stalls before mandatory Gluon conversion (default: 3)
 --handoff-resumes N              Same-thread incomplete-handoff recovery turns (default: 2)
 --verify-repeats N               Full-mode ABBA repeat pairs (default: 2)
@@ -294,6 +300,16 @@ handoff or its coding-agent process exits. `memory/live.json` exposes progress d
 episode, while canonical `memory/vN.json` is written only after the episode reaches a terminal state.
 The supervisor validates that this numbered record is both parseable and committed at `HEAD` before
 it advances campaign state, including failed, pivoted, blocked, and interrupted rounds.
+
+After 40 completed optimization episodes or 8 consecutive unpromoted episodes, rewrites that need
+several temporarily neutral or slower prerequisites may publish `staged_ready` (up to four
+consecutive checkpoints by default). Each stage must compile and prove a material architectural
+advance toward a stable escape hypothesis with explicit final-success and abort criteria; compile-only
+refactors and parameter sweeps are rejected. The supervisor keeps the production incumbent unchanged,
+restores that exact `kernel.py` only into the next isolated episode, and does not reset the promotion
+drought. `--staged-after-episodes`, `--staged-after-stall`, and `--max-staged-episodes` override these
+defaults; the final `candidate_ready` still requires the normal correctness, policy, and strict
+improvement gates.
 
 ### Direct sandbox and profiling
 
@@ -319,4 +335,5 @@ Each optimization workspace records the full optimization trail:
 - `plans/`: evidence-based optimization plans
 - `profiles/`: profiler artifacts and extracted bottleneck evidence
 - `.atrex_long_horizon/`: restart state, journals, handoffs, telemetry, and archived attempts
+- `.atrex_long_horizon/staged_checkpoint/`: ignored continuation snapshot for an active staged initiative
 - `submission.json`: SOL-ExecBench submission output for SOL campaigns

--- a/long_horizon/README.md
+++ b/long_horizon/README.md
@@ -5,20 +5,31 @@ This package implements the native optimization engine used by
 
 Each canonical optimization version is explored in an isolated Git branch and worktree. A coding
 agent may run multiple related profile/research/edit/validate cycles, preserve private checkpoint
-commits, and finally publish one structured handoff: `candidate_ready`, `pivot`, or `blocked`.
+commits, and finally publish one structured handoff: `candidate_ready`, `staged_ready`, `pivot`, or
+`blocked`.
 
 The supervisor validates the journal and candidate commit, checks production policy, and evaluates
 incumbent and candidate in an exact same-allocation ABBA schedule. A strict correctness-passing
 improvement is squash-promoted to the incumbent; every other outcome records canonical
 `memory/vN.json` evidence without changing the incumbent kernel.
 
+After 40 completed optimization episodes or 8 consecutive episodes without a promotion by default,
+full episodes may start an architectural escape initiative and persist up to four stages under
+`.atrex_long_horizon/staged_checkpoint/`. Each checkpoint must compile and prove a bounded material
+advance toward one stable, falsifiable escape contract; compilation alone is not progress. The
+supervisor restores that exact kernel into the next isolated worktree while leaving the incumbent
+untouched. `--staged-after-episodes`, `--staged-after-stall`, and `--max-staged-episodes` configure or
+disable the flow. Only a real production promotion resets the promotion drought. Staged checkpoints
+never bypass the normal final policy, correctness, or strict performance gates.
+
 An episode candidate commit contains only `kernel.py`. Plans, profiles, planner discussions,
 journals, and handoffs stay uncommitted and are copied into the episode archive before the isolated
 worktree is removed.
 
 Runtime state lives under `.atrex_long_horizon/` in generated campaign workspaces. Public options
-such as `--handoff-resumes`, `--verify-repeats`, `--verify-run-timeout`, and
-`--min-improvement-pct` are parsed directly by `orchestrator/optimize.py`.
+such as `--handoff-resumes`, `--staged-after-episodes`, `--staged-after-stall`,
+`--max-staged-episodes`, `--verify-repeats`, `--verify-run-timeout`, and `--min-improvement-pct` are
+parsed directly by `orchestrator/optimize.py`.
 
 Each active episode also exposes ignored `memory/live.json`. It is initialized immediately and
 atomically refreshed after every journal append, but it never participates in version selection or

--- a/long_horizon/campaign.py
+++ b/long_horizon/campaign.py
@@ -62,6 +62,7 @@ FAST_POLICY_REVIEW_REQUEST_PATH = Path(
 )
 FAST_REASONING_EFFORT = "max"
 FULL_REASONING_EFFORT = "max"
+STAGED_STALLED_RETRY_THRESHOLD = 3
 
 
 def _render(template: str, values: dict[str, object]) -> str:
@@ -457,6 +458,28 @@ class LongHorizonCampaign:
     ) -> bool:
         return bool(self._staged_trigger(state, fast_mode=fast_mode))
 
+    @staticmethod
+    def _staged_blocked_retries(
+        state: SupervisorState,
+        staged_checkpoint: dict[str, Any] | None,
+    ) -> int:
+        """Count blocked landing attempts since the current stage was created."""
+        if not staged_checkpoint:
+            return 0
+        initiative_id = str(staged_checkpoint.get("initiative_id", "")).strip()
+        source_episode = staged_checkpoint.get("source_episode", 0)
+        if not initiative_id or not isinstance(source_episode, int):
+            return 0
+        return sum(
+            1
+            for attempt in state.attempts
+            if attempt.get("status") == "blocked"
+            and not attempt.get("violation")
+            and attempt.get("initiative_id") == initiative_id
+            and isinstance(attempt.get("episode"), int)
+            and int(attempt["episode"]) > source_episode
+        )
+
     def _staged_rewrite_directive(
         self,
         *,
@@ -465,6 +488,7 @@ class LongHorizonCampaign:
         completed_episodes: int,
         promotion_drought: int,
         staged_trigger: str,
+        staged_blocked_retries: int,
         fast_mode: bool,
     ) -> str:
         if self.max_staged_episodes <= 0:
@@ -510,7 +534,7 @@ class LongHorizonCampaign:
                 "produce a final candidate, pivot, or report a real blocker."
             )
         if staged_checkpoint:
-            return (
+            directive = (
                 "This worktree was bootstrapped from a non-production staged checkpoint for "
                 f"initiative `{staged_checkpoint.get('initiative_id')}`, stage "
                 f"{staged_checkpoint.get('stage')}. Continue its declared next stage: "
@@ -524,6 +548,22 @@ class LongHorizonCampaign:
                 "checkpoint if a coherent enabling stage is complete but the full initiative is "
                 "not yet promotion-ready."
             )
+            if staged_blocked_retries >= STAGED_STALLED_RETRY_THRESHOLD:
+                directive += (
+                    f" This checkpoint has already consumed {staged_blocked_retries} valid "
+                    "blocked continuation episodes since its last stage advancement, so treat "
+                    "the evidence plan as stalled. Do not replay the same measurement budget "
+                    "unchanged. Before another expensive campaign, pre-register a materially "
+                    "different, variance-aware sequential stopping rule using same-allocation "
+                    "paired evidence and explicit success and abort bounds; keep the final "
+                    "production correctness, policy, and performance gates unchanged. If no new "
+                    "falsifiable evidence plan or architectural advancement can resolve the "
+                    "final criterion, pivot so another initiative can explore the search space. "
+                    "A genuine external blocker may still finish as `blocked` and preserve the "
+                    "checkpoint, but unchanged bytes or another identical retry must not be "
+                    "reported as stage advancement."
+                )
+            return directive
         if staged_trigger == "promotion_drought":
             return (
                 f"This campaign has gone {promotion_drought} consecutive episodes without a "
@@ -709,6 +749,7 @@ class LongHorizonCampaign:
         completed_episodes: int = 0,
         promotion_drought: int = 0,
         staged_trigger: str = "",
+        staged_blocked_retries: int = 0,
     ) -> str:
         directives = main_adapter.episode_directives(self.base_campaign, version)
         fast_trial_count = fast_trials or self.fast_trials
@@ -771,6 +812,7 @@ class LongHorizonCampaign:
                     completed_episodes=completed_episodes,
                     promotion_drought=promotion_drought,
                     staged_trigger=staged_trigger,
+                    staged_blocked_retries=staged_blocked_retries,
                     fast_mode=fast_mode,
                 ),
             },
@@ -2276,6 +2318,19 @@ class LongHorizonCampaign:
                         + ", ".join(unexpected)
                     )
             self._restore_staged_checkpoint(store, worktree, active)
+            staged_checkpoint = (
+                active.get("staged_checkpoint")
+                if isinstance(active.get("staged_checkpoint"), dict)
+                else None
+            )
+            staged_blocked_retries = self._staged_blocked_retries(
+                state, staged_checkpoint
+            )
+            active["staged_blocked_retries"] = staged_blocked_retries
+            active["staged_stall_review"] = (
+                staged_blocked_retries >= STAGED_STALLED_RETRY_THRESHOLD
+            )
+            store.save_active(active)
             fast_trial_count = self._active_fast_trials(
                 active, fast_mode=fast_mode
             )
@@ -2310,14 +2365,11 @@ class LongHorizonCampaign:
                 fast_trials=fast_trial_count,
                 resumed=resumed,
                 staged_allowed=staged_allowed,
-                staged_checkpoint=(
-                    active.get("staged_checkpoint")
-                    if isinstance(active.get("staged_checkpoint"), dict)
-                    else None
-                ),
+                staged_checkpoint=staged_checkpoint,
                 completed_episodes=state.episodes,
                 promotion_drought=state.consecutive_without_promotion,
                 staged_trigger=str(active.get("staged_trigger", "")),
+                staged_blocked_retries=staged_blocked_retries,
             )
             store.write_brief(episode, prompt)
             telemetry_environment = {

--- a/long_horizon/campaign.py
+++ b/long_horizon/campaign.py
@@ -392,12 +392,21 @@ class LongHorizonCampaign:
     verifier: GatewayABBAValidator | None = None
     session_runner: LongSessionRunner | None = None
     worktree_root: Path | None = None
+    max_staged_episodes: int = 4
+    staged_after_episodes: int = 40
+    staged_after_stall: int = 8
 
     def __post_init__(self) -> None:
         if self.fast_episodes < 0:
             raise ValueError("fast_episodes must be non-negative")
         if self.fast_trials < 1:
             raise ValueError("fast_trials must be positive")
+        if self.max_staged_episodes < 0:
+            raise ValueError("max_staged_episodes must be non-negative")
+        if self.staged_after_episodes < 0:
+            raise ValueError("staged_after_episodes must be non-negative")
+        if self.staged_after_stall < 0:
+            raise ValueError("staged_after_stall must be non-negative")
 
     @property
     def workspace(self) -> Path:
@@ -424,6 +433,140 @@ class LongHorizonCampaign:
     @staticmethod
     def _episode_reasoning_effort(*, fast_mode: bool) -> str:
         return FAST_REASONING_EFFORT if fast_mode else FULL_REASONING_EFFORT
+
+    def _staged_trigger(
+        self, state: SupervisorState, *, fast_mode: bool
+    ) -> str:
+        if self.max_staged_episodes <= 0 or fast_mode:
+            return ""
+        if state.consecutive_staged >= self.max_staged_episodes:
+            return ""
+        if state.consecutive_staged > 0:
+            return "continuation"
+        if (
+            self.staged_after_stall > 0
+            and state.consecutive_without_promotion >= self.staged_after_stall
+        ):
+            return "promotion_drought"
+        if state.episodes >= self.staged_after_episodes:
+            return "episode_count"
+        return ""
+
+    def _staged_allowed(
+        self, state: SupervisorState, *, fast_mode: bool
+    ) -> bool:
+        return bool(self._staged_trigger(state, fast_mode=fast_mode))
+
+    def _staged_rewrite_directive(
+        self,
+        *,
+        staged_allowed: bool,
+        staged_checkpoint: dict[str, Any] | None,
+        completed_episodes: int,
+        promotion_drought: int,
+        staged_trigger: str,
+        fast_mode: bool,
+    ) -> str:
+        if self.max_staged_episodes <= 0:
+            return (
+                "Staged architectural rewrites are disabled for this campaign. Do not use "
+                "`staged_ready`; finish with `candidate_ready`, `pivot`, or `blocked`."
+            )
+        if (
+            staged_checkpoint is None
+            and completed_episodes < self.staged_after_episodes
+            and not (
+                self.staged_after_stall > 0
+                and promotion_drought >= self.staged_after_stall
+            )
+        ):
+            stall_clause = (
+                f" or {self.staged_after_stall} consecutive episodes without promotion"
+                if self.staged_after_stall > 0
+                else ""
+            )
+            return (
+                "Staged architectural rewrites activate after "
+                f"{self.staged_after_episodes} completed optimization episodes"
+                f"{stall_clause}. This campaign has completed {completed_episodes} "
+                f"episodes with a promotion drought of {promotion_drought}; do not use "
+                "`staged_ready` yet."
+            )
+        if fast_mode:
+            return (
+                "Staged architectural rewrites are unavailable in fast episodes. Do not use "
+                "`staged_ready` in this episode."
+            )
+        if not staged_allowed:
+            if staged_checkpoint is None:
+                return (
+                    "This episode's terminal contract was frozen before staged eligibility was "
+                    "latched. Do not use `staged_ready` in this in-flight episode; the next new "
+                    "full episode will reevaluate the architectural escape trigger."
+                )
+            return (
+                f"The {self.max_staged_episodes}-checkpoint initiative budget was reached. "
+                "Do not use `staged_ready`; "
+                "produce a final candidate, pivot, or report a real blocker."
+            )
+        if staged_checkpoint:
+            return (
+                "This worktree was bootstrapped from a non-production staged checkpoint for "
+                f"initiative `{staged_checkpoint.get('initiative_id')}`, stage "
+                f"{staged_checkpoint.get('stage')}. Continue its declared next stage: "
+                f"{staged_checkpoint.get('next_stage')}. Its escape hypothesis is "
+                f"{staged_checkpoint.get('escape_hypothesis')}; its architectural delta is "
+                f"{staged_checkpoint.get('architectural_delta')}. Keep the declared final success "
+                f"criterion ({staged_checkpoint.get('final_success_criterion')}) and abort "
+                f"criterion ({staged_checkpoint.get('abort_criterion')}) stable. If the abort "
+                "criterion is met, pivot instead of preserving the checkpoint. You may publish "
+                "another `staged_ready` "
+                "checkpoint if a coherent enabling stage is complete but the full initiative is "
+                "not yet promotion-ready."
+            )
+        if staged_trigger == "promotion_drought":
+            return (
+                f"This campaign has gone {promotion_drought} consecutive episodes without a "
+                "production promotion, so this is an architectural escape episode. Start from a "
+                "bottleneck that local tuning of the incumbent cannot remove, cite the exhausted "
+                "local directions, and implement a materially different dataflow, layout, "
+                "pipeline, synchronization, or communication design. Use `candidate_ready` if "
+                "the structural candidate is already mature; otherwise use `staged_ready` only "
+                "for a coherent first enabling stage. Do not spend this escape opportunity on "
+                "another parameter-only tweak."
+            )
+        return (
+            "This full episode may start a multi-episode architectural initiative. Use "
+            "`staged_ready` only for a coherent, committed enabling stage that is intentionally "
+            "not promotion-ready; identify the initiative, stage number, concrete next stage, "
+            "escape hypothesis, architectural delta, final success criterion, and abort criterion."
+        )
+
+    def _restore_staged_checkpoint(
+        self,
+        store: CampaignStore,
+        worktree: EpisodeWorktree,
+        active: dict[str, Any],
+    ) -> None:
+        if isinstance(active.get("staged_checkpoint"), dict):
+            return
+        snapshot = store.load_staged_checkpoint()
+        if snapshot is None:
+            return
+        metadata, kernel = snapshot
+        current_kernel = (worktree.path / "kernel.py").read_bytes()
+        if git_head(worktree.path) != worktree.base_commit and current_kernel != kernel:
+            raise RuntimeError(
+                "cannot restore staged checkpoint over divergent episode work"
+            )
+        development_base_commit = worktree.bootstrap_staged_kernel(
+            kernel,
+            initiative_id=str(metadata["initiative_id"]),
+            stage=int(metadata["stage"]),
+        )
+        active["staged_checkpoint"] = metadata
+        active["development_base_commit"] = development_base_commit
+        store.save_active(active)
 
     def _expected_shape_ids(self) -> set[str] | None:
         private_reference_dir = self.base_campaign.private_reference_dir
@@ -561,6 +704,11 @@ class LongHorizonCampaign:
         fast_mode: bool,
         fast_trials: int | None = None,
         resumed: bool = False,
+        staged_allowed: bool = False,
+        staged_checkpoint: dict[str, Any] | None = None,
+        completed_episodes: int = 0,
+        promotion_drought: int = 0,
+        staged_trigger: str = "",
     ) -> str:
         directives = main_adapter.episode_directives(self.base_campaign, version)
         fast_trial_count = fast_trials or self.fast_trials
@@ -584,6 +732,7 @@ class LongHorizonCampaign:
                 "PLATFORM": self.base_campaign.platform,
                 "FRAMEWORK": self.base_campaign.framework,
                 "BASE_COMMIT": worktree.base_commit,
+                "DEVELOPMENT_BASE_COMMIT": git_head(worktree.path),
                 "EPISODE_BRANCH": worktree.branch,
                 "JOURNAL_PATH": journal_path,
                 "JOURNAL_PATH_SHELL": json.dumps(str(journal_path)),
@@ -615,6 +764,14 @@ class LongHorizonCampaign:
                     "the incumbent latency."
                     if conversion_pending
                     else "No mandatory framework conversion is currently latched."
+                ),
+                "STAGED_REWRITE_DIRECTIVE": self._staged_rewrite_directive(
+                    staged_allowed=staged_allowed,
+                    staged_checkpoint=staged_checkpoint,
+                    completed_episodes=completed_episodes,
+                    promotion_drought=promotion_drought,
+                    staged_trigger=staged_trigger,
+                    fast_mode=fast_mode,
                 ),
             },
         )
@@ -733,9 +890,13 @@ class LongHorizonCampaign:
         *,
         fast_mode: bool = False,
         fast_trials: int | None = None,
+        staged_allowed: bool = False,
     ) -> str:
         candidate = (
             handoff.candidate_commit if handoff.status == "candidate_ready" else ""
+        )
+        checkpoint = (
+            handoff.checkpoint_commit if handoff.status == "staged_ready" else ""
         )
         diagnosis = validate_terminal(
             journal_path,
@@ -744,9 +905,12 @@ class LongHorizonCampaign:
             branch=worktree.branch,
             state=handoff.status,
             candidate_commit=candidate,
+            checkpoint_commit=checkpoint,
         )
         if diagnosis:
             return diagnosis
+        if handoff.status == "staged_ready" and not staged_allowed:
+            return "staged_ready is not enabled for this episode"
         if fast_mode and handoff.status != "blocked":
             required_fast_trials = fast_trials or self.fast_trials
             try:
@@ -766,22 +930,25 @@ class LongHorizonCampaign:
                     f"fast episode requires {required_fast_trials} evaluator results; "
                     f"found {evaluation_count}"
                 )
-        if handoff.status != "candidate_ready":
+        if handoff.status not in {"candidate_ready", "staged_ready"}:
             return ""
-        violation, _ = worktree.validate_candidate(candidate)
+        terminal_commit = candidate or checkpoint
+        violation, _ = worktree.validate_candidate(terminal_commit)
         if violation:
             return violation
         try:
             journal = load_journal(journal_path)
             finalized_at = _iso_timestamp(str(journal["finalized_at"]))
             committed_at = float(
-                git_text(worktree.path, "show", "-s", "--format=%ct", candidate)
+                git_text(
+                    worktree.path, "show", "-s", "--format=%ct", terminal_commit
+                )
             )
         except (KeyError, ValueError, OSError, json.JSONDecodeError) as exc:
             return f"cannot validate terminal journal ordering: {exc}"
         if finalized_at <= committed_at:
             return (
-                "candidate journal must be finalized after the exact candidate commit"
+                "terminal journal must be finalized after the exact handoff commit"
             )
         return ""
 
@@ -950,6 +1117,7 @@ class LongHorizonCampaign:
         violation: str,
         journal: dict[str, Any],
         candidate_commit: str,
+        checkpoint_commit: str = "",
         verification: VerificationResult | None = None,
         episode_workspace: Path | None = None,
         fast_mode: bool = False,
@@ -1146,6 +1314,10 @@ class LongHorizonCampaign:
             "long_horizon": {
                 "status": status,
                 "candidate_commit": candidate_commit or None,
+                "checkpoint_commit": checkpoint_commit or None,
+                "initiative_id": outcome.get("initiative_id"),
+                "stage": outcome.get("stage"),
+                "next_stage": outcome.get("next_stage"),
                 "mode": "fast" if fast_mode else "full",
                 "fast_trials": fast_trial_count if fast_mode else None,
             },
@@ -1164,11 +1336,49 @@ class LongHorizonCampaign:
         verifier: GatewayABBAValidator,
     ) -> tuple[str, list[str], VerificationResult | None, bool]:
         """Apply the authoritative candidate gates to one terminal handoff."""
-        if handoff.status != "candidate_ready":
+        if handoff.status not in {"candidate_ready", "staged_ready"}:
             return "", [], None, False
 
+        terminal_commit = (
+            handoff.candidate_commit
+            if handoff.status == "candidate_ready"
+            else handoff.checkpoint_commit
+        )
+        violation, paths = worktree.validate_candidate(terminal_commit)
+        if handoff.status == "staged_ready":
+            try:
+                journal = load_journal(worktree.path / RUNTIME_DIR / "journal.json")
+                outcome = journal["outcome"]
+                initiative_id = str(outcome["initiative_id"])
+                stage = int(outcome["stage"])
+            except (KeyError, TypeError, ValueError, OSError, json.JSONDecodeError):
+                return "staged_ready journal metadata is invalid", paths, None, False
+            prior = active.get("staged_checkpoint")
+            if isinstance(prior, dict):
+                if initiative_id != str(prior.get("initiative_id", "")):
+                    violation = "staged_ready must continue the active initiative_id"
+                elif stage != int(prior.get("stage", 0)) + 1:
+                    violation = "staged_ready stage must increment the active stage by one"
+                else:
+                    for field in (
+                        "escape_hypothesis",
+                        "architectural_delta",
+                        "final_success_criterion",
+                        "abort_criterion",
+                    ):
+                        if str(outcome.get(field, "")).strip() != str(
+                            prior.get(field, "")
+                        ).strip():
+                            violation = (
+                                "staged_ready continuation must preserve the active "
+                                f"{field}"
+                            )
+                            break
+            elif stage != 1:
+                violation = "a new staged initiative must begin at stage 1"
+            return violation, paths, None, False
+
         candidate_commit = handoff.candidate_commit
-        violation, paths = worktree.validate_candidate(candidate_commit)
         if (
             not violation
             and conversion_pending
@@ -1245,6 +1455,7 @@ class LongHorizonCampaign:
         fast_mode: bool,
         status: str,
         candidate_commit: str,
+        checkpoint_commit: str = "",
         violation: str,
         paths: list[str],
         verification: VerificationResult | None,
@@ -1278,6 +1489,11 @@ class LongHorizonCampaign:
             if isinstance(journal.get("outcome"), dict)
             else {}
         )
+        prior_staged = (
+            active.get("staged_checkpoint")
+            if isinstance(active.get("staged_checkpoint"), dict)
+            else {}
+        )
         attempt = {
             "episode": episode,
             "version": memory_version,
@@ -1290,6 +1506,7 @@ class LongHorizonCampaign:
             "episode_branch": worktree.branch,
             "episode_head": git_head(worktree.path),
             "candidate_commit": candidate_commit or None,
+            "checkpoint_commit": checkpoint_commit or None,
             "changed_paths": paths,
             "session_id": session_id or None,
             "resume_count": max(0, int(resume_count)),
@@ -1300,6 +1517,11 @@ class LongHorizonCampaign:
             "next_directions": outcome.get("next_directions")
             if isinstance(outcome, dict)
             else None,
+            "initiative_id": outcome.get("initiative_id")
+            or prior_staged.get("initiative_id"),
+            "initiative_stage": outcome.get("stage")
+            or prior_staged.get("stage"),
+            "staged_trigger": active.get("staged_trigger") or None,
             "verification": verification.as_dict() if verification else None,
         }
         if recovered_after_supervisor_interruption:
@@ -1363,12 +1585,39 @@ class LongHorizonCampaign:
             )
             attempt["promotion_commit"] = promotion_commit
             state.accepted += 1
+            if prior_staged:
+                state.staged_initiatives_promoted += 1
             state.consecutive_without_promotion = 0
+            state.consecutive_staged = 0
+            store.clear_staged_checkpoint()
             main_adapter.save_stall(self.workspace, 0)
             active["phase"] = "promoted"
             active["promotion_commit"] = promotion_commit
             store.save_active(active)
         else:
+            valid_staged = status == "staged_ready" and not violation
+            if valid_staged:
+                active["phase"] = "staging"
+                store.save_active(active)
+                staged_metadata = store.save_staged_checkpoint(
+                    {
+                        "initiative_id": str(outcome["initiative_id"]),
+                        "stage": int(outcome["stage"]),
+                        "next_stage": str(outcome["next_stage"]),
+                        "escape_hypothesis": str(outcome["escape_hypothesis"]),
+                        "architectural_delta": str(outcome["architectural_delta"]),
+                        "final_success_criterion": str(
+                            outcome["final_success_criterion"]
+                        ),
+                        "abort_criterion": str(outcome["abort_criterion"]),
+                        "checkpoint_commit": checkpoint_commit,
+                        "source_episode": episode,
+                        "source_base_commit": base_commit,
+                    },
+                    (worktree.path / "kernel.py").read_bytes(),
+                )
+                attempt["staged_checkpoint"] = staged_metadata
+                active["staged_checkpoint"] = staged_metadata
             active["phase"] = "recording"
             active["terminal_status"] = status
             store.save_active(active)
@@ -1378,6 +1627,7 @@ class LongHorizonCampaign:
                 violation=violation,
                 journal=journal,
                 candidate_commit=candidate_commit,
+                checkpoint_commit=checkpoint_commit,
                 verification=verification,
                 episode_workspace=worktree.path,
                 fast_mode=fast_mode,
@@ -1392,17 +1642,31 @@ class LongHorizonCampaign:
                 memory_record=memory,
             )
             attempt["outcome_commit"] = outcome_commit
-            state.consecutive_without_promotion += 1
-            main_adapter.save_stall(
-                self.workspace, state.consecutive_without_promotion
-            )
+            if valid_staged:
+                state.staged += 1
+                state.consecutive_staged += 1
+                if not prior_staged:
+                    state.staged_initiatives_started += 1
+                state.consecutive_without_promotion += 1
+                main_adapter.save_stall(
+                    self.workspace, state.consecutive_without_promotion
+                )
+            else:
+                state.consecutive_without_promotion += 1
+                main_adapter.save_stall(
+                    self.workspace, state.consecutive_without_promotion
+                )
             if status == "pivot" and not violation:
                 state.pivoted += 1
+                if prior_staged:
+                    state.staged_initiatives_abandoned += 1
+                state.consecutive_staged = 0
+                store.clear_staged_checkpoint()
             elif status == "blocked" and not violation:
                 state.blocked += 1
             elif status == "invalid_handoff":
                 state.protocol_failures += 1
-            else:
+            elif not valid_staged:
                 state.rejected += 1
         self._require_canonical_memory(memory_version)
         try:
@@ -1477,6 +1741,12 @@ class LongHorizonCampaign:
             handoff,
             fast_mode=fast_mode,
             fast_trials=fast_trials,
+            staged_allowed=bool(
+                active.get(
+                    "staged_allowed",
+                    self._staged_allowed(state, fast_mode=fast_mode),
+                )
+            ),
         )
         if diagnosis:
             print(
@@ -1513,6 +1783,7 @@ class LongHorizonCampaign:
             fast_mode=fast_mode,
             status=handoff.status,
             candidate_commit=handoff.candidate_commit,
+            checkpoint_commit=handoff.checkpoint_commit,
             violation=violation,
             paths=paths,
             verification=verification,
@@ -1563,6 +1834,7 @@ class LongHorizonCampaign:
                 "preparing",
                 "exploring",
                 "verifying",
+                "staging",
                 "promoting",
                 "recording",
             }
@@ -1662,6 +1934,11 @@ class LongHorizonCampaign:
                 terminal_status = "interrupted"
             self._require_canonical_memory(memory_version)
             if not already_recorded:
+                recovered_prior_staged = (
+                    active.get("staged_checkpoint")
+                    if isinstance(active.get("staged_checkpoint"), dict)
+                    else {}
+                )
                 state.episodes = max(state.episodes, episode)
                 recovered_attempt: dict[str, Any] = {
                     "episode": episode,
@@ -1676,13 +1953,47 @@ class LongHorizonCampaign:
                 }
                 if promoted:
                     state.accepted += 1
+                    if recovered_prior_staged:
+                        state.staged_initiatives_promoted += 1
                     state.consecutive_without_promotion = 0
+                    state.consecutive_staged = 0
+                    store.clear_staged_checkpoint()
                     recovered_attempt["promotion_commit"] = git_head(self.workspace)
                 else:
-                    state.consecutive_without_promotion += 1
                     recovered_attempt["outcome_commit"] = git_head(self.workspace)
+                    if terminal_status == "staged_ready":
+                        snapshot = store.load_staged_checkpoint()
+                        if snapshot is None:
+                            raise RuntimeError(
+                                "recorded staged episode has no persisted checkpoint"
+                            )
+                        staged_metadata, _staged_kernel = snapshot
+                        recovered_attempt["checkpoint_commit"] = (
+                            staged_metadata.get("checkpoint_commit")
+                        )
+                        recovered_attempt["staged_checkpoint"] = staged_metadata
+                        recovered_attempt["initiative_id"] = staged_metadata.get(
+                            "initiative_id"
+                        )
+                        recovered_attempt["initiative_stage"] = staged_metadata.get(
+                            "stage"
+                        )
+                        state.staged += 1
+                        state.consecutive_staged += 1
+                        if (
+                            int(staged_metadata.get("stage", 0)) == 1
+                            and int(staged_metadata.get("source_episode", 0)) == episode
+                        ):
+                            state.staged_initiatives_started += 1
+                        state.consecutive_without_promotion += 1
+                    else:
+                        state.consecutive_without_promotion += 1
                     if terminal_status == "pivot":
                         state.pivoted += 1
+                        if recovered_prior_staged:
+                            state.staged_initiatives_abandoned += 1
+                        state.consecutive_staged = 0
+                        store.clear_staged_checkpoint()
                     elif terminal_status == "blocked":
                         state.blocked += 1
                         recovered_attempt["blocked_retry_scheduled"] = True
@@ -1691,6 +2002,8 @@ class LongHorizonCampaign:
                         recovered_attempt["violation"] = "supervisor process interrupted"
                     elif terminal_status == "invalid_handoff":
                         state.protocol_failures += 1
+                    elif terminal_status == "staged_ready":
+                        pass
                     else:
                         state.rejected += 1
                 state.attempts.append(recovered_attempt)
@@ -1811,11 +2124,21 @@ class LongHorizonCampaign:
         store.save_state(state)
         store.clear_active()
         return None
-
     def run(self) -> str:
         main_adapter.prepare_campaign(self.base_campaign)
         store = CampaignStore(self.workspace)
         state = store.load_state()
+        staged_snapshot = store.load_staged_checkpoint()
+        if staged_snapshot is not None and self.max_staged_episodes <= 0:
+            raise RuntimeError(
+                "a staged architectural checkpoint exists; resume with "
+                "--max-staged-episodes greater than zero"
+            )
+        if staged_snapshot is not None:
+            staged_metadata, _staged_kernel = staged_snapshot
+            state.consecutive_staged = max(
+                state.consecutive_staged, int(staged_metadata["stage"])
+            )
         if state.episodes == 0 and state.consecutive_without_promotion == 0:
             state.consecutive_without_promotion = main_adapter.restored_stall(
                 self.workspace
@@ -1897,6 +2220,18 @@ class LongHorizonCampaign:
                 active.setdefault(
                     "fast_trials", self.fast_trials if fast_mode else None
                 )
+                computed_staged_trigger = self._staged_trigger(
+                    state, fast_mode=fast_mode
+                )
+                active.setdefault(
+                    "staged_allowed", bool(computed_staged_trigger)
+                )
+                active.setdefault(
+                    "staged_trigger",
+                    computed_staged_trigger
+                    if bool(active.get("staged_allowed"))
+                    else "",
+                )
                 if active.get("resumed_from_phase") == "preparing":
                     main_adapter.link_episode_runtime(
                         self.base_campaign, worktree.path
@@ -1916,6 +2251,12 @@ class LongHorizonCampaign:
                     "mode": "fast" if fast_mode else "full",
                     "fast_trials": self.fast_trials if fast_mode else None,
                     "phase": "preparing",
+                    "staged_allowed": self._staged_allowed(
+                        state, fast_mode=fast_mode
+                    ),
+                    "staged_trigger": self._staged_trigger(
+                        state, fast_mode=fast_mode
+                    ),
                 }
                 store.save_active(active)
                 worktree.materialize(self.workspace)
@@ -1934,8 +2275,15 @@ class LongHorizonCampaign:
                         "runtime linking dirtied the episode boundary: "
                         + ", ".join(unexpected)
                     )
+            self._restore_staged_checkpoint(store, worktree, active)
             fast_trial_count = self._active_fast_trials(
                 active, fast_mode=fast_mode
+            )
+            staged_allowed = bool(
+                active.get(
+                    "staged_allowed",
+                    self._staged_allowed(state, fast_mode=fast_mode),
+                )
             )
             runtime = worktree.path / RUNTIME_DIR
             journal_path = runtime / "journal.json"
@@ -1947,6 +2295,7 @@ class LongHorizonCampaign:
                     memory_version=memory_version,
                     base_commit=base_commit,
                     branch=worktree.branch,
+                    development_base_commit=git_head(worktree.path),
                     live_path=store.live_memory_path,
                 )
             prompt = self._prompt(
@@ -1960,6 +2309,15 @@ class LongHorizonCampaign:
                 fast_mode=fast_mode,
                 fast_trials=fast_trial_count,
                 resumed=resumed,
+                staged_allowed=staged_allowed,
+                staged_checkpoint=(
+                    active.get("staged_checkpoint")
+                    if isinstance(active.get("staged_checkpoint"), dict)
+                    else None
+                ),
+                completed_episodes=state.episodes,
+                promotion_drought=state.consecutive_without_promotion,
+                staged_trigger=str(active.get("staged_trigger", "")),
             )
             store.write_brief(episode, prompt)
             telemetry_environment = {
@@ -2007,6 +2365,7 @@ class LongHorizonCampaign:
                         handoff,
                         fast_mode=fast_mode,
                         fast_trials=fast_trial_count,
+                        staged_allowed=staged_allowed,
                     ),
                     reasoning_effort=self._episode_reasoning_effort(
                         fast_mode=fast_mode
@@ -2033,6 +2392,7 @@ class LongHorizonCampaign:
             status = handoff.status if handoff else "invalid_handoff"
             violation = ""
             candidate_commit = handoff.candidate_commit if handoff else ""
+            checkpoint_commit = handoff.checkpoint_commit if handoff else ""
             paths: list[str] = []
             verification: VerificationResult | None = None
             accepted = False
@@ -2043,7 +2403,7 @@ class LongHorizonCampaign:
                     result.completion_diagnosis
                     or "session produced no valid terminal handoff"
                 )
-            elif status == "candidate_ready":
+            elif status in {"candidate_ready", "staged_ready"}:
                 violation, paths, verification, accepted = (
                     self._assess_terminal_handoff(
                         store,
@@ -2066,6 +2426,7 @@ class LongHorizonCampaign:
                 fast_mode=fast_mode,
                 status=status,
                 candidate_commit=candidate_commit,
+                checkpoint_commit=checkpoint_commit,
                 violation=violation,
                 paths=paths,
                 verification=verification,
@@ -2093,6 +2454,7 @@ class LongHorizonCampaign:
             if (
                 self.max_stall
                 and state.consecutive_without_promotion >= self.max_stall
+                and store.load_staged_checkpoint() is None
                 and not main_adapter.conversion_required(
                     self.base_campaign,
                     state.consecutive_without_promotion,
@@ -2104,7 +2466,11 @@ class LongHorizonCampaign:
 
         print(
             f"[long-horizon] STOP {reason}; episodes={state.episodes} accepted={state.accepted} "
-            f"rejected={state.rejected} pivoted={state.pivoted} blocked={state.blocked} "
+            f"staged={state.staged} rejected={state.rejected} pivoted={state.pivoted} "
+            f"blocked={state.blocked} staged_initiatives_started="
+            f"{state.staged_initiatives_started} staged_initiatives_promoted="
+            f"{state.staged_initiatives_promoted} staged_initiatives_abandoned="
+            f"{state.staged_initiatives_abandoned} "
             f"protocol_failures={state.protocol_failures} tokens={state.tokens}",
             flush=True,
         )

--- a/long_horizon/git_episode.py
+++ b/long_horizon/git_episode.py
@@ -153,6 +153,42 @@ class EpisodeWorktree:
         )
         CampaignStore.ensure_excluded(self.path)
 
+    def bootstrap_staged_kernel(
+        self, kernel: bytes, *, initiative_id: str, stage: int
+    ) -> str:
+        """Restore a non-promoted initiative checkpoint onto the new episode branch."""
+        path = self.path / "kernel.py"
+        if path.read_bytes() == kernel:
+            return git_head(self.path)
+        path.write_bytes(kernel)
+        subprocess.run(
+            ["git", "add", "--", "kernel.py"],
+            cwd=str(self.path),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=atrex-long-horizon",
+                "-c",
+                "user.email=atrex-long-horizon@local",
+                "commit",
+                "--only",
+                "-m",
+                f"resume staged initiative {initiative_id} stage {stage}",
+                "--",
+                "kernel.py",
+            ],
+            cwd=str(self.path),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return git_head(self.path)
+
     @classmethod
     def create(
         cls,

--- a/long_horizon/journal.py
+++ b/long_horizon/journal.py
@@ -93,7 +93,9 @@ def sync_live_memory(
         "latest_experiment": experiments[-1] if experiments else None,
         "outcome": value.get("outcome"),
         "candidate_commit": value.get("candidate_commit"),
+        "checkpoint_commit": value.get("checkpoint_commit"),
         "base_commit": value.get("base_commit"),
+        "development_base_commit": value.get("development_base_commit"),
         "episode_branch": value.get("episode_branch"),
         "created_at": value.get("created_at"),
         "updated_at": utc_now(),
@@ -141,6 +143,7 @@ def initialize(
     episode: int,
     base_commit: str,
     branch: str,
+    development_base_commit: str = "",
     memory_version: int | None = None,
     live_path: Path | None = None,
 ) -> dict[str, Any]:
@@ -149,6 +152,7 @@ def initialize(
         "episode": episode,
         "memory_version": memory_version,
         "base_commit": base_commit,
+        "development_base_commit": development_base_commit or base_commit,
         "episode_branch": branch,
         "state": "in_progress",
         "experiments": [],
@@ -334,11 +338,14 @@ def finalize(
     state: str,
     outcome: dict[str, Any],
     candidate_commit: str = "",
+    checkpoint_commit: str = "",
     live_path: Path | None = None,
 ) -> dict[str, Any]:
     value = load(path)
     if state not in TERMINAL_STATUSES:
-        raise ValueError("state must be candidate_ready, pivot, or blocked")
+        raise ValueError(
+            "state must be candidate_ready, staged_ready, pivot, or blocked"
+        )
     if value.get("state") not in {"in_progress", state}:
         raise ValueError(f"cannot change finalized state to {state}")
     if not isinstance(outcome, dict) or not str(outcome.get("summary", "")).strip():
@@ -351,9 +358,43 @@ def finalize(
         raise ValueError("a terminal journal requires at least one experiment")
     if state == "candidate_ready" and not candidate_commit.strip():
         raise ValueError("candidate_ready requires candidate_commit")
+    if state == "staged_ready":
+        if not checkpoint_commit.strip():
+            raise ValueError("staged_ready requires checkpoint_commit")
+        initiative_id = outcome.get("initiative_id")
+        stage = outcome.get("stage")
+        next_stage = outcome.get("next_stage")
+        if not isinstance(initiative_id, str) or not initiative_id.strip():
+            raise ValueError("staged_ready requires outcome.initiative_id")
+        if isinstance(stage, bool) or not isinstance(stage, int) or stage < 1:
+            raise ValueError("staged_ready requires a positive integer outcome.stage")
+        if not isinstance(next_stage, str) or not next_stage.strip():
+            raise ValueError("staged_ready requires outcome.next_stage")
+        for field in (
+            "escape_hypothesis",
+            "architectural_delta",
+            "final_success_criterion",
+            "abort_criterion",
+        ):
+            if not isinstance(outcome.get(field), str) or not outcome[field].strip():
+                raise ValueError(f"staged_ready requires outcome.{field}")
+        stage_gate = outcome.get("stage_gate")
+        if not isinstance(stage_gate, dict):
+            raise ValueError("staged_ready requires outcome.stage_gate")
+        if stage_gate.get("compile") != "pass":
+            raise ValueError("staged_ready requires outcome.stage_gate.compile=pass")
+        if stage_gate.get("advancement") != "pass":
+            raise ValueError(
+                "staged_ready requires outcome.stage_gate.advancement=pass"
+            )
+        if not str(stage_gate.get("scope", "")).strip():
+            raise ValueError("staged_ready requires outcome.stage_gate.scope")
+        if not str(stage_gate.get("evidence", "")).strip():
+            raise ValueError("staged_ready requires outcome.stage_gate.evidence")
     value["state"] = state
     value["outcome"] = outcome
     value["candidate_commit"] = candidate_commit.strip() or None
+    value["checkpoint_commit"] = checkpoint_commit.strip() or None
     value["finalized_at"] = utc_now()
     atomic_write_json(path, value)
     _sync_live_best_effort(path, value, live_path)
@@ -368,6 +409,7 @@ def validate_terminal(
     branch: str,
     state: str,
     candidate_commit: str = "",
+    checkpoint_commit: str = "",
 ) -> str:
     try:
         value = load(path)
@@ -392,6 +434,37 @@ def validate_terminal(
         return "episode journal is not finalized"
     if state == "candidate_ready" and value.get("candidate_commit") != candidate_commit:
         return "episode journal candidate_commit does not match handoff"
+    if state == "staged_ready":
+        if value.get("checkpoint_commit") != checkpoint_commit:
+            return "episode journal checkpoint_commit does not match handoff"
+        initiative_id = outcome.get("initiative_id")
+        stage = outcome.get("stage")
+        next_stage = outcome.get("next_stage")
+        if not isinstance(initiative_id, str) or not initiative_id.strip():
+            return "staged_ready outcome has no initiative_id"
+        if isinstance(stage, bool) or not isinstance(stage, int) or stage < 1:
+            return "staged_ready outcome stage is invalid"
+        if not isinstance(next_stage, str) or not next_stage.strip():
+            return "staged_ready outcome has no next_stage"
+        for field in (
+            "escape_hypothesis",
+            "architectural_delta",
+            "final_success_criterion",
+            "abort_criterion",
+        ):
+            if not isinstance(outcome.get(field), str) or not outcome[field].strip():
+                return f"staged_ready outcome has no {field}"
+        stage_gate = outcome.get("stage_gate")
+        if not isinstance(stage_gate, dict):
+            return "staged_ready outcome has no stage_gate"
+        if stage_gate.get("compile") != "pass":
+            return "staged_ready stage_gate compile did not pass"
+        if stage_gate.get("advancement") != "pass":
+            return "staged_ready stage_gate advancement did not pass"
+        if not str(stage_gate.get("scope", "")).strip():
+            return "staged_ready stage_gate scope is empty"
+        if not str(stage_gate.get("evidence", "")).strip():
+            return "staged_ready stage_gate evidence is empty"
     return ""
 
 
@@ -418,6 +491,7 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--state", choices=sorted(TERMINAL_STATUSES), required=True)
     finish.add_argument("--outcome-json", required=True)
     finish.add_argument("--candidate-commit", default="")
+    finish.add_argument("--checkpoint-commit", default="")
     args = parser.parse_args(argv)
     try:
         if args.command == "append":
@@ -432,6 +506,7 @@ def main(argv: list[str] | None = None) -> int:
                 state=args.state,
                 outcome=_json_object(args.outcome_json, "--outcome-json"),
                 candidate_commit=args.candidate_commit,
+                checkpoint_commit=args.checkpoint_commit,
                 live_path=Path(args.live_path) if args.live_path else None,
             )
     except (OSError, ValueError, json.JSONDecodeError) as exc:

--- a/long_horizon/models.py
+++ b/long_horizon/models.py
@@ -10,7 +10,9 @@ from orchestrator.agent_runtime.model import (
 )
 
 
-TERMINAL_STATUSES = frozenset({"candidate_ready", "pivot", "blocked"})
+TERMINAL_STATUSES = frozenset(
+    {"candidate_ready", "staged_ready", "pivot", "blocked"}
+)
 
 
 @dataclass(frozen=True)
@@ -18,6 +20,7 @@ class EpisodeHandoff:
     status: str
     candidate_commit: str = ""
     last_trial_commit: str = ""
+    checkpoint_commit: str = ""
 
     def as_dict(self) -> dict[str, str]:
         return {key: value for key, value in asdict(self).items() if value}
@@ -101,6 +104,11 @@ class SupervisorState:
     tokens: int = 0
     consecutive_without_promotion: int = 0
     attempts: list[dict[str, Any]] = field(default_factory=list)
+    staged: int = 0
+    consecutive_staged: int = 0
+    staged_initiatives_started: int = 0
+    staged_initiatives_promoted: int = 0
+    staged_initiatives_abandoned: int = 0
 
     @classmethod
     def from_dict(cls, value: object) -> "SupervisorState":

--- a/long_horizon/protocol.py
+++ b/long_horizon/protocol.py
@@ -26,12 +26,22 @@ def normalize_handoff(value: object) -> EpisodeHandoff | None:
     if status not in TERMINAL_STATUSES:
         return None
     candidate = value.get("candidate_commit", "")
-    if status == "candidate_ready" and (not isinstance(candidate, str) or not candidate.strip()):
+    if status == "candidate_ready" and (
+        not isinstance(candidate, str) or not candidate.strip()
+    ):
+        return None
+    checkpoint = value.get("checkpoint_commit", "")
+    if status == "staged_ready" and (
+        not isinstance(checkpoint, str) or not checkpoint.strip()
+    ):
         return None
     trial = value.get("last_trial_commit", "")
     return EpisodeHandoff(
         status=str(status),
         candidate_commit=candidate.strip() if isinstance(candidate, str) else "",
+        checkpoint_commit=(
+            checkpoint.strip() if isinstance(checkpoint, str) else ""
+        ),
         last_trial_commit=trial.strip() if isinstance(trial, str) else "",
     )
 
@@ -59,7 +69,15 @@ def handoff_diagnosis(path: Path) -> str:
     if not isinstance(value, dict):
         return "handoff must be a JSON object"
     if value.get("status") not in TERMINAL_STATUSES:
-        return "handoff status must be candidate_ready, pivot, or blocked"
-    if value.get("status") == "candidate_ready" and not str(value.get("candidate_commit", "")).strip():
+        return (
+            "handoff status must be candidate_ready, staged_ready, pivot, or blocked"
+        )
+    if value.get("status") == "candidate_ready" and not str(
+        value.get("candidate_commit", "")
+    ).strip():
         return "candidate_ready requires candidate_commit"
+    if value.get("status") == "staged_ready" and not str(
+        value.get("checkpoint_commit", "")
+    ).strip():
+        return "staged_ready requires checkpoint_commit"
     return "handoff schema is valid but its episode completion contract is not satisfied"

--- a/long_horizon/store.py
+++ b/long_horizon/store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import subprocess
 from pathlib import Path
@@ -65,6 +67,78 @@ class CampaignStore:
     def live_memory_path(self) -> Path:
         """Uncommitted, best-effort progress for the currently active episode."""
         return self.workspace / LIVE_MEMORY_FILE
+
+    @property
+    def staged_checkpoint_dir(self) -> Path:
+        return self.root / "staged_checkpoint"
+
+    @property
+    def staged_checkpoint_path(self) -> Path:
+        return self.staged_checkpoint_dir / "checkpoint.json"
+
+    def load_staged_checkpoint(self) -> tuple[dict[str, Any], bytes] | None:
+        if not self.staged_checkpoint_path.is_file():
+            return None
+        try:
+            metadata = json.loads(
+                self.staged_checkpoint_path.read_text(encoding="utf-8")
+            )
+            kernel = base64.b64decode(metadata["kernel_b64"], validate=True)
+        except (
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+            KeyError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            raise RuntimeError(f"staged checkpoint cannot be read: {exc}") from exc
+        if not isinstance(metadata, dict) or metadata.get("schema_version") != 2:
+            raise RuntimeError("staged checkpoint metadata is invalid")
+        initiative_id = metadata.get("initiative_id")
+        stage = metadata.get("stage")
+        next_stage = metadata.get("next_stage")
+        if not isinstance(initiative_id, str) or not initiative_id.strip():
+            raise RuntimeError("staged checkpoint initiative_id is invalid")
+        if isinstance(stage, bool) or not isinstance(stage, int) or stage < 1:
+            raise RuntimeError("staged checkpoint stage is invalid")
+        if not isinstance(next_stage, str) or not next_stage.strip():
+            raise RuntimeError("staged checkpoint next_stage is invalid")
+        for field in (
+            "escape_hypothesis",
+            "architectural_delta",
+            "final_success_criterion",
+            "abort_criterion",
+        ):
+            if not isinstance(metadata.get(field), str) or not metadata[field].strip():
+                raise RuntimeError(f"staged checkpoint {field} is invalid")
+        digest = hashlib.sha256(kernel).hexdigest()
+        if metadata.get("kernel_sha256") != digest:
+            raise RuntimeError("staged checkpoint kernel digest does not match metadata")
+        public_metadata = {
+            key: item for key, item in metadata.items() if key != "kernel_b64"
+        }
+        return public_metadata, kernel
+
+    def save_staged_checkpoint(
+        self, metadata: dict[str, Any], kernel: bytes
+    ) -> dict[str, Any]:
+        value = {
+            **metadata,
+            "schema_version": 2,
+            "kernel_sha256": hashlib.sha256(kernel).hexdigest(),
+            "kernel_b64": base64.b64encode(kernel).decode("ascii"),
+        }
+        self.staged_checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(self.staged_checkpoint_path, value)
+        return {key: item for key, item in value.items() if key != "kernel_b64"}
+
+    def clear_staged_checkpoint(self) -> None:
+        self.staged_checkpoint_path.unlink(missing_ok=True)
+        try:
+            self.staged_checkpoint_dir.rmdir()
+        except OSError:
+            pass
 
     def episode_dir(self, episode: int) -> Path:
         path = self.root / "episodes" / f"e{episode:04d}"

--- a/long_horizon/test_staged_checkpoint.py
+++ b/long_horizon/test_staged_checkpoint.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from long_horizon import journal
+from long_horizon.campaign import LongHorizonCampaign
+from long_horizon.git_episode import EpisodeWorktree, git_head
+from long_horizon.models import SupervisorState
+from long_horizon.protocol import normalize_handoff
+from long_horizon.store import CampaignStore
+
+
+class StagedActivationTest(unittest.TestCase):
+    def test_defaults_activate_after_forty_completed_episodes(self) -> None:
+        engine = LongHorizonCampaign(base_campaign=object())  # type: ignore[arg-type]
+        self.assertEqual(engine.max_staged_episodes, 4)
+        self.assertEqual(engine.staged_after_episodes, 40)
+        self.assertEqual(engine.staged_after_stall, 8)
+        self.assertFalse(
+            engine._staged_allowed(SupervisorState(episodes=39), fast_mode=False)
+        )
+        self.assertTrue(
+            engine._staged_allowed(SupervisorState(episodes=40), fast_mode=False)
+        )
+        self.assertFalse(
+            engine._staged_allowed(SupervisorState(episodes=40), fast_mode=True)
+        )
+
+    def test_promotion_drought_starts_architectural_escape_early(self) -> None:
+        engine = LongHorizonCampaign(base_campaign=object())  # type: ignore[arg-type]
+        almost_stalled = SupervisorState(
+            episodes=20,
+            consecutive_without_promotion=7,
+        )
+        stalled = SupervisorState(
+            episodes=20,
+            consecutive_without_promotion=8,
+        )
+        self.assertEqual(engine._staged_trigger(almost_stalled, fast_mode=False), "")
+        self.assertEqual(
+            engine._staged_trigger(stalled, fast_mode=False),
+            "promotion_drought",
+        )
+        self.assertEqual(
+            engine._staged_trigger(
+                SupervisorState(
+                    episodes=92,
+                    consecutive_without_promotion=78,
+                ),
+                fast_mode=False,
+            ),
+            "promotion_drought",
+        )
+
+    def test_active_initiative_continues_until_fourth_checkpoint(self) -> None:
+        engine = LongHorizonCampaign(base_campaign=object())  # type: ignore[arg-type]
+        self.assertTrue(
+            engine._staged_allowed(
+                SupervisorState(episodes=12, consecutive_staged=1),
+                fast_mode=False,
+            )
+        )
+        self.assertFalse(
+            engine._staged_allowed(
+                SupervisorState(episodes=54, consecutive_staged=4),
+                fast_mode=False,
+            )
+        )
+
+
+class StagedJournalTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.path = Path(self.temporary.name) / "journal.json"
+        journal.initialize(
+            self.path,
+            episode=3,
+            base_commit="base",
+            branch="episode-3",
+        )
+        journal.append_experiment(
+            self.path,
+            {
+                "name": "bring up async loader",
+                "evaluation": {
+                    "correctness": "unknown",
+                    "performance": "not_improved",
+                    "latency_us": None,
+                    "kernel_hash": "checkpoint",
+                },
+                "wiki_usage_status": "not_queried",
+            },
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    @staticmethod
+    def outcome() -> dict[str, object]:
+        return {
+            "summary": "async loader compiles and preserves its tile invariant",
+            "next_directions": ["overlap producer and consumer warps"],
+            "initiative_id": "warp-specialized-nvfp4",
+            "stage": 1,
+            "next_stage": "add producer-consumer overlap",
+            "escape_hypothesis": "serial tile movement caps tensor-core issue rate",
+            "architectural_delta": "dedicated producer and consumer warps",
+            "final_success_criterion": "pass correctness and beat the incumbent",
+            "abort_criterion": "producer overlap cannot hide measured load latency",
+            "stage_gate": {
+                "compile": "pass",
+                "advancement": "pass",
+                "scope": "one tile reaches shared memory",
+                "evidence": "official sandbox compile log job-123",
+            },
+        }
+
+    def test_staged_ready_round_trip(self) -> None:
+        value = journal.finalize(
+            self.path,
+            state="staged_ready",
+            outcome=self.outcome(),
+            checkpoint_commit="abc123",
+        )
+        self.assertEqual(value["checkpoint_commit"], "abc123")
+        handoff = normalize_handoff(
+            {"status": "staged_ready", "checkpoint_commit": "abc123"}
+        )
+        self.assertIsNotNone(handoff)
+        assert handoff is not None
+        self.assertEqual(handoff.checkpoint_commit, "abc123")
+        self.assertEqual(
+            journal.validate_terminal(
+                self.path,
+                expected_episode=3,
+                base_commit="base",
+                branch="episode-3",
+                state="staged_ready",
+                checkpoint_commit="abc123",
+            ),
+            "",
+        )
+
+    def test_staged_ready_requires_compile_gate(self) -> None:
+        outcome = self.outcome()
+        outcome["stage_gate"] = {
+            "compile": "fail",
+            "advancement": "pass",
+            "scope": "loader",
+            "evidence": "compiler error",
+        }
+        with self.assertRaisesRegex(ValueError, "compile=pass"):
+            journal.finalize(
+                self.path,
+                state="staged_ready",
+                outcome=outcome,
+                checkpoint_commit="abc123",
+            )
+
+    def test_staged_ready_requires_architectural_advancement(self) -> None:
+        outcome = self.outcome()
+        outcome["stage_gate"] = {
+            "compile": "pass",
+            "advancement": "fail",
+            "scope": "loader",
+            "evidence": "only the incumbent schedule compiled",
+        }
+        with self.assertRaisesRegex(ValueError, "advancement=pass"):
+            journal.finalize(
+                self.path,
+                state="staged_ready",
+                outcome=outcome,
+                checkpoint_commit="abc123",
+            )
+
+
+class StagedCheckpointStoreTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.workspace = self.root / "workspace"
+        self.workspace.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=self.workspace, check=True)
+        (self.workspace / "kernel.py").write_text("VALUE = 0\n", encoding="utf-8")
+        subprocess.run(["git", "add", "kernel.py"], cwd=self.workspace, check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "-qm",
+                "base",
+            ],
+            cwd=self.workspace,
+            check=True,
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_snapshot_bootstraps_next_episode_without_changing_incumbent(self) -> None:
+        store = CampaignStore(self.workspace)
+        base = git_head(self.workspace)
+        kernel = b"VALUE = 1\n"
+        saved = store.save_staged_checkpoint(
+            {
+                "initiative_id": "async-pipeline",
+                "stage": 1,
+                "next_stage": "add consumer warp",
+                "escape_hypothesis": "serialized movement limits utilization",
+                "architectural_delta": "split producer and consumer warps",
+                "final_success_criterion": "beat incumbent after full overlap",
+                "abort_criterion": "official profile shows no load-bound region",
+                "checkpoint_commit": "source-checkpoint",
+                "source_episode": 1,
+            },
+            kernel,
+        )
+        self.assertNotIn("kernel_b64", saved)
+        loaded = store.load_staged_checkpoint()
+        self.assertIsNotNone(loaded)
+        assert loaded is not None
+        metadata, restored_kernel = loaded
+        self.assertEqual(restored_kernel, kernel)
+        self.assertEqual(metadata["initiative_id"], "async-pipeline")
+        self.assertEqual(metadata["schema_version"], 2)
+
+        worktree = EpisodeWorktree.create(
+            self.workspace,
+            episode=2,
+            base_commit=base,
+            root=self.root / "episode-worktrees",
+        )
+        try:
+            checkpoint = worktree.bootstrap_staged_kernel(
+                restored_kernel,
+                initiative_id=str(metadata["initiative_id"]),
+                stage=int(metadata["stage"]),
+            )
+            violation, paths = worktree.validate_candidate(checkpoint)
+            self.assertEqual(violation, "")
+            self.assertEqual(paths, ["kernel.py"])
+            self.assertEqual((worktree.path / "kernel.py").read_bytes(), kernel)
+            self.assertEqual(
+                (self.workspace / "kernel.py").read_text(encoding="utf-8"),
+                "VALUE = 0\n",
+            )
+            self.assertEqual(git_head(self.workspace), base)
+        finally:
+            worktree.remove(self.workspace)
+
+        store.clear_staged_checkpoint()
+        self.assertIsNone(store.load_staged_checkpoint())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orchestrator/agent_runtime/process.py
+++ b/orchestrator/agent_runtime/process.py
@@ -365,25 +365,92 @@ def signal_process_groups(process_groups: set[int], sig: signal.Signals) -> None
 
 def terminate_process_group(process_group: int) -> None:
     """Stop descendants that outlive the guarded coding-session process."""
-    signal_process_groups({process_group}, signal.SIGTERM)
+    terminate_process_groups({process_group})
+
+
+def terminate_process_groups(process_groups: set[int]) -> None:
+    """Stop all process groups observed inside one guarded coding session."""
+    remaining = set(process_groups)
+    signal_process_groups(remaining, signal.SIGTERM)
     deadline = time.monotonic() + PROCESS_GROUP_SHUTDOWN_SECONDS
-    while time.monotonic() < deadline:
-        try:
-            os.killpg(process_group, 0)
-        except ProcessLookupError:
+    while remaining and time.monotonic() < deadline:
+        for process_group in tuple(remaining):
+            try:
+                os.killpg(process_group, 0)
+            except ProcessLookupError:
+                remaining.discard(process_group)
+            except PermissionError:
+                remaining.discard(process_group)
+        if not remaining:
             return
-        except PermissionError:
-            break
         time.sleep(0.05)
-    signal_process_groups({process_group}, signal.SIGKILL)
+    signal_process_groups(remaining, signal.SIGKILL)
+
+
+def process_groups_in_directory_tree(root: Path) -> set[int]:
+    """Find detached helpers whose current directory is the guarded worktree."""
+    root = root.resolve()
+    pids: set[int] = set()
+    proc_root = Path("/proc")
+    if proc_root.is_dir():
+        for entry in proc_root.iterdir():
+            if not entry.name.isdigit():
+                continue
+            try:
+                current = (entry / "cwd").resolve(strict=True)
+            except (FileNotFoundError, PermissionError, ProcessLookupError):
+                continue
+            if current == root or root in current.parents:
+                pids.add(int(entry.name))
+    else:
+        try:
+            output = subprocess.run(
+                ["lsof", "-a", "-d", "cwd", "-Fpn"],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout
+        except OSError:
+            return set()
+        pid: int | None = None
+        for line in output.splitlines():
+            if line.startswith("p"):
+                try:
+                    pid = int(line[1:])
+                except ValueError:
+                    pid = None
+            elif pid is not None and line.startswith("n"):
+                current = Path(line[1:]).resolve()
+                if current == root or root in current.parents:
+                    pids.add(pid)
+
+    caller_group = os.getpgrp()
+    process_groups: set[int] = set()
+    for pid in pids:
+        try:
+            process_group = os.getpgid(pid)
+        except ProcessLookupError:
+            continue
+        if process_group != caller_group:
+            process_groups.add(process_group)
+    return process_groups
 
 
 def dependency_guard(
-    proc: subprocess.Popen[str], stop: threading.Event, violations: list[str]
+    proc: subprocess.Popen[str],
+    stop: threading.Event,
+    violations: list[str],
+    cwd: Path,
 ) -> None:
     """Kill a coding session as soon as it starts a forbidden dependency job."""
     while not stop.wait(DEPENDENCY_GUARD_POLL_SECONDS):
         if proc.poll() is not None:
+            # Detached helpers can keep stdout/stderr inherited from the coding
+            # CLI open after that direct process exits. Reap every group seen
+            # while the process tree was live so communicate() can reach EOF.
+            terminate_process_groups(
+                {proc.pid} | process_groups_in_directory_tree(cwd)
+            )
             return
         for pid, argv in descendant_process_commands(proc.pid):
             reason = dependency_process_violation(argv)
@@ -426,7 +493,12 @@ def run_bounded(
     dependency_violations: list[str] = []
     guard = threading.Thread(
         target=dependency_guard,
-        args=(proc, guard_stop, dependency_violations),
+        args=(
+            proc,
+            guard_stop,
+            dependency_violations,
+            cwd,
+        ),
         name=f"dependency-guard-{proc.pid}",
         daemon=True,
     )
@@ -451,7 +523,9 @@ def run_bounded(
     finally:
         guard_stop.set()
         guard.join(timeout=1)
-        terminate_process_group(session_process_group)
+        terminate_process_groups(
+            {session_process_group} | process_groups_in_directory_tree(cwd)
+        )
     returncode = proc.returncode
     if dependency_violations:
         policy_message = (

--- a/orchestrator/agent_runtime/process.py
+++ b/orchestrator/agent_runtime/process.py
@@ -13,6 +13,7 @@ from typing import Protocol
 
 
 DEPENDENCY_GUARD_POLL_SECONDS = 0.25
+PROCESS_GROUP_SHUTDOWN_SECONDS = 1.0
 DEFAULT_PROTECTED_GATEWAY_SCREEN = "atrex-local-gateway"
 DEFAULT_PROTECTED_GATEWAY_STATE_NAME = "atrex-local-gateway"
 
@@ -362,6 +363,21 @@ def signal_process_groups(process_groups: set[int], sig: signal.Signals) -> None
             pass
 
 
+def terminate_process_group(process_group: int) -> None:
+    """Stop descendants that outlive the guarded coding-session process."""
+    signal_process_groups({process_group}, signal.SIGTERM)
+    deadline = time.monotonic() + PROCESS_GROUP_SHUTDOWN_SECONDS
+    while time.monotonic() < deadline:
+        try:
+            os.killpg(process_group, 0)
+        except ProcessLookupError:
+            return
+        except PermissionError:
+            break
+        time.sleep(0.05)
+    signal_process_groups({process_group}, signal.SIGKILL)
+
+
 def dependency_guard(
     proc: subprocess.Popen[str], stop: threading.Event, violations: list[str]
 ) -> None:
@@ -402,6 +418,10 @@ def run_bounded(
         start_new_session=True,
         env=env,
     )
+    # start_new_session makes this stable even after the direct CLI process exits.
+    # Retaining it lets us reap background evaluator/profile commands before their
+    # episode worktree is archived or removed.
+    session_process_group = proc.pid
     guard_stop = threading.Event()
     dependency_violations: list[str] = []
     guard = threading.Thread(
@@ -431,6 +451,7 @@ def run_bounded(
     finally:
         guard_stop.set()
         guard.join(timeout=1)
+        terminate_process_group(session_process_group)
     returncode = proc.returncode
     if dependency_violations:
         policy_message = (

--- a/orchestrator/campaign.py
+++ b/orchestrator/campaign.py
@@ -190,6 +190,9 @@ class Campaign:
     fast_episode_ask_qoder: bool = False
     full_episode_ask_codex: bool = True
     full_episode_ask_qoder: bool = True
+    max_staged_episodes: int = 4  # full-episode non-production checkpoints
+    staged_after_episodes: int = 40  # completed optimization episodes before staging
+    staged_after_stall: int = 8  # unpromoted episodes before architectural escape
     tokens_spent: int = field(default=0, init=False)
     _production_review_cache: dict[str, tuple[tuple[str, ...], dict[str, object]]] = (
         field(default_factory=dict, init=False, repr=False, compare=False)
@@ -2885,6 +2888,9 @@ class Campaign:
             token_budget=self.token_budget,
             handoff_resumes=self.handoff_resumes,
             max_stall=self.max_stall,
+            max_staged_episodes=self.max_staged_episodes,
+            staged_after_episodes=self.staged_after_episodes,
+            staged_after_stall=self.staged_after_stall,
             verifier=verifier,
             session_runner=LongSessionRunner(agent_cli=self.agent_cli),
         )

--- a/orchestrator/optimize.py
+++ b/orchestrator/optimize.py
@@ -571,6 +571,35 @@ def main(argv: Optional[list[str]] = None) -> int:
         help="Optional: stop after N consecutive unpromoted episodes (0 = disabled).",
     )
     ap.add_argument(
+        "--max-staged-episodes",
+        type=int,
+        default=4,
+        help=(
+            "Allow up to N consecutive full-episode staged architectural checkpoints "
+            "that carry kernel.py forward without production promotion (default: 4; "
+            "0 disables)."
+        ),
+    )
+    ap.add_argument(
+        "--staged-after-episodes",
+        type=int,
+        default=40,
+        help=(
+            "Allow a new staged architectural initiative only after N completed "
+            "optimization episodes (default: 40; first eligible episode is 41)."
+        ),
+    )
+    ap.add_argument(
+        "--staged-after-stall",
+        type=int,
+        default=8,
+        help=(
+            "Allow a new staged architectural initiative after N consecutive episodes "
+            "without production promotion, even before --staged-after-episodes "
+            "(default: 8; 0 disables the drought trigger)."
+        ),
+    )
+    ap.add_argument(
         "--convert-after",
         type=int,
         default=DEFAULT_CONVERT_AFTER,
@@ -608,6 +637,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         )
     if args.convert_after < 0:
         ap.error("--convert-after must be non-negative")
+    if args.max_staged_episodes < 0:
+        ap.error("--max-staged-episodes must be non-negative")
+    if args.staged_after_episodes < 0:
+        ap.error("--staged-after-episodes must be non-negative")
+    if args.staged_after_stall < 0:
+        ap.error("--staged-after-stall must be non-negative")
     if args.fast_episodes < 0:
         ap.error("--fast-episodes must be non-negative")
     if args.fast_trials <= 0:
@@ -746,6 +781,9 @@ def main(argv: Optional[list[str]] = None) -> int:
         target_util=args.target_util,
         setup_timeout=args.setup_timeout,
         max_stall=args.max_stall,
+        max_staged_episodes=args.max_staged_episodes,
+        staged_after_episodes=args.staged_after_episodes,
+        staged_after_stall=args.staged_after_stall,
         framework_baseline=args.framework_baseline,
         framework_baseline_timeout=args.framework_baseline_timeout,
         handoff_resumes=args.handoff_resumes,

--- a/orchestrator/prompts/episode.md
+++ b/orchestrator/prompts/episode.md
@@ -14,7 +14,8 @@ final squash promotion. You own only this episode branch and its structured evid
 - Canonical version produced by the supervisor: `v{{VERSION}}`
 - Platform: `{{PLATFORM}}`
 - Framework: `{{FRAMEWORK}}`
-- Incumbent commit: `{{BASE_COMMIT}}`
+- Production incumbent commit: `{{BASE_COMMIT}}`
+- Episode starting commit: `{{DEVELOPMENT_BASE_COMMIT}}`
 - Episode branch: `{{EPISODE_BRANCH}}`
 - Journal: `{{JOURNAL_PATH}}`
 - Handoff: `{{HANDOFF_PATH}}`
@@ -86,6 +87,23 @@ and do not repeat a rejected direction unless new evidence or a materially diffe
 changes the expected result. Detailed within-episode journals remain archived under
 `.atrex_long_horizon/episodes/` and are not part of the inherited prompt context.
 
+## Multi-episode architectural initiative
+
+{{STAGED_REWRITE_DIRECTIVE}}
+
+A staged checkpoint is an engineering continuation point, never a production candidate. It may be
+neutral or slower than the incumbent because it establishes a prerequisite such as a new data
+layout, pipeline, loader, or synchronization model. It must still be a coherent `kernel.py` state
+that compiles through the official sandbox and proves one stage-specific architectural advancement.
+An initiative must state the incumbent limitation it is escaping, the material architectural delta,
+the measurable final success criterion, and the evidence that would abort the initiative. These four
+parts remain stable across continuation stages; if the hypothesis is falsified, pivot instead of
+preserving a checkpoint. A compile-only refactor, parameter sweep, or renamed incumbent path is not
+an architectural advancement. Do not weaken final correctness, policy, or performance requirements
+to preserve a stage.
+The supervisor keeps the production incumbent unchanged and restores the staged kernel only into the
+next isolated episode worktree.
+
 ## Wiki attribution contract
 
 GPU Wiki query responses emit a top-level `query_id`, and every returned record emits its own
@@ -137,8 +155,11 @@ Reach exactly one evidence-backed terminal state:
 1. `candidate_ready`: a mature candidate is committed, the worktree `kernel.py` matches that exact
    commit, protected files are unchanged, and development correctness/performance supports
    independent verification. Uncommitted intermediate artifacts may remain in the worktree.
-2. `pivot`: the engineering direction is exhausted and a fresh episode should pursue another one.
-3. `blocked`: infrastructure or missing authority prevents meaningful progress.
+2. `staged_ready`: an enabled architectural initiative completed one coherent prerequisite stage,
+   the checkpoint compiles and satisfies its declared stage gate, but the initiative is not yet
+   eligible for production verification. A temporary performance regression is allowed here.
+3. `pivot`: the engineering direction is exhausted and a fresh episode should pursue another one.
+4. `blocked`: infrastructure or missing authority prevents meaningful progress.
 
 For `candidate_ready`, append the final evidence, commit only `kernel.py`, then finalize the journal.
 The candidate commit must be the episode `HEAD`, and its complete diff from the incumbent must name
@@ -156,16 +177,35 @@ candidate_commit=$(git rev-parse HEAD)
 Use the one-based journal index of the experiment selected for handoff. Its structured evaluation
 must pass correctness and its decision must be `promote` or `keep_as_best`.
 
-For `pivot` or `blocked`, finalize with that state and omit `--candidate-commit`. The journal must
-contain at least one structured experiment and a non-empty outcome summary.
+For an enabled `staged_ready`, append the stage evidence, commit only `kernel.py`, and finalize after
+that exact commit. A new initiative starts at stage 1; continuation stages keep the same
+`initiative_id` and increment `stage` by exactly one. The escape contract fields must remain exact
+across continuation stages. `stage_gate.compile` and `stage_gate.advancement` must both be `pass`;
+`scope` states the bounded functional or structural invariant proven by this stage, and `evidence`
+identifies the official sandbox result. Merely compiling unchanged or locally retuned architecture
+does not satisfy `advancement`.
+
+```bash
+git add -- kernel.py
+git commit -m "v{{VERSION}}: staged architectural checkpoint"
+checkpoint_commit=$(git rev-parse HEAD)
+{{JOURNAL_COMMAND}} finalize --path {{JOURNAL_PATH_SHELL}} --state staged_ready \
+  --checkpoint-commit "$checkpoint_commit" \
+  --outcome-json '{"summary":"...","next_directions":["..."],"initiative_id":"...","stage":1,"next_stage":"...","escape_hypothesis":"incumbent limitation that local tuning cannot remove","architectural_delta":"materially different dataflow/layout/pipeline/synchronization/communication design","final_success_criterion":"measurable final correctness and performance gate","abort_criterion":"evidence that falsifies the initiative","stage_gate":{"compile":"pass","advancement":"pass","scope":"bounded invariant proven by this stage","evidence":"official sandbox result"}}'
+```
+
+For `pivot` or `blocked`, finalize with that state and omit both commit arguments. The journal must
+contain at least one structured experiment and a non-empty outcome summary. A valid `pivot` abandons
+the active staged initiative; a `blocked` handoff preserves its last accepted checkpoint.
 
 Only after finalizing, atomically publish the control handoff by writing complete JSON to
 `{{HANDOFF_PATH}}.tmp` and renaming it to `{{HANDOFF_PATH}}`:
 
 ```json
 {
-  "status": "candidate_ready | pivot | blocked",
+  "status": "candidate_ready | staged_ready | pivot | blocked",
   "candidate_commit": "required only for candidate_ready",
+  "checkpoint_commit": "required only for staged_ready",
   "last_trial_commit": "optional checkpoint for pivot or blocked"
 }
 ```

--- a/skills/gpu-kernel-episode-loop/SKILL.md
+++ b/skills/gpu-kernel-episode-loop/SKILL.md
@@ -184,13 +184,21 @@ backend-native plan generator `<PLAN_GENERATOR>`.
 
 The episode may contain multiple related experiments, but they must advance one coherent engineering
 direction. Checkpoint useful intermediate states so failed sub-steps can be reverted without losing
-the whole direction.
+the whole direction. When the episode prompt explicitly enables multi-episode architectural
+initiatives, a coherent prerequisite state may be handed off as `staged_ready`: it must compile and
+prove a declared stage-specific architectural advancement, even though it may be neutral or
+temporarily slower. The initiative must name the incumbent limitation it escapes, the material
+architectural delta, a measurable final success criterion, and a falsifiable abort criterion. Keep
+that escape contract stable across continuation stages. A compile-only refactor, parameter sweep, or
+renamed incumbent path is not an advancement. This is a continuation checkpoint, not a production
+candidate.
 
 ### 5. Implement and repair
 
 Modify only candidate source/metadata files allowed by policy. Compile and probe through the sandbox.
 On compile or correctness failure, diagnose and repair while the direction remains viable. Do not
-publish an intermediate checkpoint as a candidate.
+publish an intermediate checkpoint as `candidate_ready`; use `staged_ready` only when the episode
+prompt enables it and the bounded stage gate is complete.
 
 Land one optimization category per edit — vectorized load, swizzle, double buffering, tiling change,
 and so on — and attribute each edit as `evidence -> inference -> action`. Do not mix unrelated
@@ -237,5 +245,6 @@ with `wiki_usage_errors`; this diagnostic field never blocks the experiment or h
 ## Leaving the loop
 
 Leave the loop as soon as one coherent candidate passes the full development correctness check and
-has credible performance evidence, or as soon as the direction is exhausted or blocked. Then follow
+has credible performance evidence, when an enabled architectural initiative has completed a valid
+stage but requires another episode, or as soon as the direction is exhausted or blocked. Then follow
 the episode prompt's terminal contract for finalizing the journal and publishing the handoff.

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -144,6 +144,7 @@ MAX_GATEWAY_JOB_TIMEOUT = 10_800
 MAX_DEV_JOB_TIMEOUT = 600
 MAX_HTTP_REQUEST_TIMEOUT = 600
 AGATE_WAIT_SLICE_SECONDS = 300
+AGATE_WAIT_PROCESS_GRACE_SECONDS = 30
 RUNTIME_CHUNK_BYTES = 20 * 1024
 # Small inline workspace bundles stay below Linux MAX_ARG_STRLEN; larger
 # bundles use agate's OSS attachment transport.
@@ -229,6 +230,9 @@ def _safe_relative(value: str) -> str:
 
 def _find_agate() -> str | None:
     """Find agate beside the active Python before consulting the shell PATH."""
+    configured = os.environ.get("ATREX_AGATE_EXECUTABLE")
+    if configured:
+        return configured
     adjacent = Path(sys.executable).resolve().parent / "agate"
     if adjacent.is_file() and os.access(adjacent, os.X_OK):
         return str(adjacent)
@@ -1711,21 +1715,31 @@ def _resume_interrupted_agate_wait(
     deadline = time.monotonic() + remaining
     resumed = initial
     while (remaining := int(deadline - time.monotonic())) > 0:
-        resumed = subprocess.run(
-            [
-                *get_command,
-                "--http-timeout",
-                str(MAX_HTTP_REQUEST_TIMEOUT),
-                "--wait-timeout",
-                str(min(AGATE_WAIT_SLICE_SECONDS, remaining)),
-                "--job-timeout",
-                str(command_timeout),
-                "--wait",
-                job_id,
-            ],
-            capture_output=True,
-            text=True,
-        )
+        wait_slice = min(AGATE_WAIT_SLICE_SECONDS, remaining)
+        poll_command = [
+            *get_command,
+            "--http-timeout",
+            str(MAX_HTTP_REQUEST_TIMEOUT),
+            "--wait-timeout",
+            str(wait_slice),
+            "--job-timeout",
+            str(command_timeout),
+            "--wait",
+            job_id,
+        ]
+        try:
+            resumed = subprocess.run(
+                poll_command,
+                capture_output=True,
+                text=True,
+                timeout=min(remaining, wait_slice + AGATE_WAIT_PROCESS_GRACE_SECONDS),
+            )
+        except subprocess.TimeoutExpired:
+            stderr_parts.append(
+                f"[sandbox] agate get exceeded its {wait_slice}s wait slice; "
+                f"retrying job_id={job_id}"
+            )
+            continue
         if resumed.stderr:
             stderr_parts.append(resumed.stderr.rstrip())
         job = _job_response(resumed.stdout or "")


### PR DESCRIPTION
## Summary
- add isolated, persisted staged initiative checkpoints with strict stage gates and production-incumbent isolation
- trigger architectural escape episodes after episode-count or promotion-drought thresholds
- preserve staged continuity across blocked episodes and track initiative outcomes
- reap direct and detached episode process groups without affecting unrelated processes
- escalate a checkpoint evidence plan after three blocked continuation attempts, requiring variance-aware paired validation without weakening production gates

## Validation
- `python3.10 -m unittest long_horizon.test_staged_checkpoint long_horizon.test_journal_wiki_attribution`
- detached-helper cleanup and unrelated-process isolation regressions
- `python3.10 -m py_compile long_horizon/campaign.py`