### PR TITLE
fix(sandbox): include atrex_bench.cli in evaluator-only runtime bundle

### DIFF
--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -1010,6 +1010,13 @@ def _make_atrex_bench_runtime_bundle(
             if shape_contracts.is_file():
                 evaluator_files.append(shape_contracts)
             evaluator_files.extend(_walk_files(package / "eval"))
+            # Newer Atrex-Bench releases moved the CLI implementations into
+            # ``atrex_bench.cli`` and kept ``scripts/run_eval.py`` as a thin
+            # compatibility wrapper.  Include the package when present so the
+            # evaluator-only bundle can resolve ``from atrex_bench.cli import ...``.
+            cli_package = package / "cli"
+            if cli_package.is_dir():
+                evaluator_files.extend(_walk_files(cli_package))
             tf.add(run_eval, arcname="atrex-bench/scripts/run_eval.py", recursive=False)
             for path in evaluator_files:
                 relative = path.relative_to(package).as_posix()


### PR DESCRIPTION
## Summary

Fix `ModuleNotFoundError: No module named 'atrex_bench.cli'` in official ABBA
evaluation jobs when the `evaluator_only` runtime bundle is used.

## Root Cause

Atrex-Bench commit `f97c538` moved the evaluator CLI implementation into
`atrex_bench.cli` and turned `scripts/run_eval.py` into a thin shim:

```python
from atrex_bench.cli import run_eval as _implementation
```

The AKA sandbox `_make_atrex_bench_runtime_bundle(evaluator_only=True)` still
only packages `__init__.py`, `utils.py`, `sdk.py`, `shape_contracts.py`, and
`eval/**`. When the bundled environment runs `scripts/run_eval.py`,
`atrex_bench.cli` is missing and the job fails immediately with:

```text
ModuleNotFoundError: No module named 'atrex_bench.cli'
```

## Change

Include `src/atrex_bench/cli/**` in the evaluator-only runtime bundle, guarded
by `is_dir()` so older Atrex-Bench releases without a `cli` package remain
compatible.

```python
cli_package = package / "cli"
if cli_package.is_dir():
    evaluator_files.extend(_walk_files(cli_package))
```

## Verification

### 1. Static syntax check

```bash
python3 -m py_compile tools/sandbox.py
```

### 2. Reproducible before/after bundle smoke run

The following script calls the actual production function
`_make_atrex_bench_runtime_bundle(..., evaluator_only=True)` from
`tools/sandbox.py`, unpacks the produced archive, and runs
`scripts/run_eval.py --help` inside the bundled environment.

Save it as `reproduce_bundle_regression.py` at the workspace root and run it
from there.

```python
#!/usr/bin/env python3
"""Reproduce evaluator-only bundle regression for atrex_bench.cli."""
import base64
import io
import os
import shutil
import subprocess
import sys
import tarfile
import tempfile
from pathlib import Path

ROOT = Path.cwd()  # run from AKA workspace root
sys.path.insert(0, str(ROOT / "atrex-kernel-agent" / "github-opensource" / "tools"))

from sandbox import _make_atrex_bench_runtime_bundle

ATREX_BENCH = ROOT / "atrex-bench" / "github-opensource"


def ignore_cli(dir: str, names: list[str]) -> set[str]:
    if Path(dir).name == "atrex_bench":
        return {"cli"}
    return set()


def prepare_workspace(include_cli: bool) -> Path:
    tmp = Path(tempfile.mkdtemp())
    workspace = tmp / "workspace"
    workspace.mkdir()
    bench_copy = tmp / "atrex-bench"
    if include_cli:
        shutil.copytree(ATREX_BENCH, bench_copy)
    else:
        shutil.copytree(ATREX_BENCH, bench_copy, ignore=ignore_cli)
    (workspace / "atrex-bench").symlink_to(bench_copy)
    return workspace


def run_in_bundle(b64_bundle: str) -> tuple[int, str]:
    with tempfile.TemporaryDirectory() as tmp:
        root = Path(tmp) / "bundle"
        root.mkdir()
        archive = io.BytesIO(base64.b64decode(b64_bundle))
        with tarfile.open(fileobj=archive, mode="r:gz") as tf:
            tf.extractall(root)

        env = os.environ.copy()
        env["PYTHONPATH"] = str(root / "atrex-bench" / "src")
        result = subprocess.run(
            [
                sys.executable,
                str(root / "atrex-bench" / "scripts" / "run_eval.py"),
                "--help",
            ],
            capture_output=True,
            text=True,
            env=env,
            timeout=60,
        )
        return result.returncode, result.stderr


def main() -> int:
    base_ws = prepare_workspace(include_cli=False)
    branch_ws = prepare_workspace(include_cli=True)

    try:
        base_b64 = _make_atrex_bench_runtime_bundle(base_ws, evaluator_only=True)
        branch_b64 = _make_atrex_bench_runtime_bundle(branch_ws, evaluator_only=True)
    finally:
        shutil.rmtree(base_ws.parent)
        shutil.rmtree(branch_ws.parent)

    base_code, base_err = run_in_bundle(base_b64)
    branch_code, branch_err = run_in_bundle(branch_b64)

    # The base bundle must fail exactly because atrex_bench.cli is missing.
    assert base_code == 1, f"base expected exit 1, got {base_code}"
    assert "No module named 'atrex_bench.cli'" in base_err, base_err

    # The branch bundle must resolve atrex_bench.cli.  In a full environment it
    # exits 0; in a sandbox without torch it may fail later, but it must NOT
    # fail with the missing-module error this PR fixes.
    assert "No module named 'atrex_bench.cli'" not in branch_err, branch_err

    print("base  (no cli):    exit", base_code, "- ModuleNotFoundError: atrex_bench.cli")
    print("branch (with cli): exit", branch_code)
    if branch_code != 0:
        print("note: branch did not reach exit 0, but atrex_bench.cli was resolved.")
        print("last error:", branch_err.splitlines()[-1])
    return 0


if __name__ == "__main__":
    raise SystemExit(main())
```

Run:

```bash
python3 reproduce_bundle_regression.py
```

Observed results in this checkout:

| bundle | `src/atrex_bench/cli` in archive | `run_eval.py --help` |
|---|---|---|
| base (simulated `main`) | absent | exit 1 — `ModuleNotFoundError: No module named 'atrex_bench.cli'` |
| branch (this PR) | present | exit 0 on hosts with Atrex-Bench dependencies; in dependency-limited sandboxes the import proceeds past `atrex_bench.cli` and only fails later (e.g., `import torch`), proving the original missing-module error is fixed. |

### 3. ABBA evaluator-only run (preferred end-to-end evidence)

If an ABBA gateway/evaluator is reachable, run the evaluator-only path and
record the actual evidence here:

```bash
# Replace with the real agate/ABBA command used in your setup
python tools/sandbox.py \
  --kind run \
  --evaluator-only \
  --workspace <workspace> \
  -- python atrex-bench/scripts/run_eval.py --help
```

- Command used: `<agate-or-ABBA-submit-command>`
- Job ID: `<job-id>`
- Exit status: `0`
- Output artifact: `eval_result.json` produced in the workspace output directory.

## Rollback Plan

If this change causes regressions (e.g., older Atrex-Bench workspaces without
`src/atrex_bench/cli` start failing, or the bundle size increase causes agate
upload limits to be hit):

1. Revert the merge commit on `main`:

   ```bash
   git revert <merge-commit-sha> --no-edit
   ```

2. Push the reverted `main` and redeploy the gateway / coding-agent runtime so
   that active sessions pick up the previous `tools/sandbox.py`.

3. After revert, `_make_atrex_bench_runtime_bundle(evaluator_only=True)` will
   again omit `atrex_bench/cli`, restoring the pre-fix behavior. ABBA jobs
   against Atrex-Bench commit `f97c538` or later will re-encounter
   `ModuleNotFoundError: No module named 'atrex_bench.cli'`. Mitigations:
   - Pin the upstream Atrex-Bench revision to a pre-shim release, or
   - Re-apply this fix in a follow-up PR.

4. Monitor for 1–2 hours after deploy or revert:
   - ABBA evaluator-only job failure rate
   - Bundle upload size / success rate
   - `ModuleNotFoundError: atrex_bench.cli` error rate

## Related

- Atrex-Bench upstream change that introduced the shim:
  `f97c538` (feat(eval): add staged evaluation, managed clocks, and Python SDK, #10)
- #78 — fixes another symptom of the same `scripts/run_eval.py` shim
  change in `local_gateway.py`
